### PR TITLE
created tests for storage using sqlite in memory as a way to mock db

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/spf13/viper v1.6.2
+	github.com/stretchr/testify v1.3.0
 )

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -39,6 +39,7 @@ type Timestamp string
 
 // Storage represents an interface to any relational database based on SQL language
 type Storage interface {
+	Init() error
 	Close() error
 	ListOfOrgs() ([]OrgID, error)
 	ListOfClustersForOrg(orgID OrgID) ([]ClusterName, error)
@@ -63,6 +64,20 @@ func New(configuration Configuration) (Storage, error) {
 	}
 
 	return Impl{connection, configuration}, nil
+}
+
+// Init method is doing initialization like creating tables in underlying database
+func (storage Impl) Init() error {
+	_, err := storage.connection.Exec(`
+		create table report (
+			org_id      integer not null,
+			cluster     varchar not null unique,
+			report      varchar not null,
+			reported_at datetime,
+			PRIMARY KEY(org_id, cluster)
+		);
+	`)
+	return err
 }
 
 // Close method closes the connection to database. Needs to be called at the end of application lifecycle.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -47,8 +47,8 @@ func TestMockDBStorageReadReport(t *testing.T) {
 	defer mockStorage.Close()
 
 	const testOrgID = storage.OrgID(1)
-	const testClusterName = storage.ClusterName("cluster name")
-	const testClusterReport = storage.ClusterReport("cluster report")
+	const testClusterName = storage.ClusterName("84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc")
+	const testClusterReport = storage.ClusterReport("{}")
 
 	err = mockStorage.WriteReportForCluster(testOrgID, testClusterName, testClusterReport)
 	if err != nil {
@@ -71,12 +71,12 @@ func TestMockDBStorageListOfOrgs(t *testing.T) {
 	}
 	defer mockStorage.Close()
 
-	err = mockStorage.WriteReportForCluster(1, "cluster 1", "report 1")
+	err = mockStorage.WriteReportForCluster(1, "1deb586c-fb85-4db4-ae5b-139cdbdf77ae", "{}")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = mockStorage.WriteReportForCluster(3, "cluster 2", "report 2")
+	err = mockStorage.WriteReportForCluster(3, "a1bf5b15-5229-4042-9825-c69dc36b57f5", "{}")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,16 +96,16 @@ func TestMockDBStorageListOfClustersForOrg(t *testing.T) {
 	}
 	defer mockStorage.Close()
 
-	err = mockStorage.WriteReportForCluster(1, "cluster 1", "report 1")
+	err = mockStorage.WriteReportForCluster(1, "eabb4fbf-edfa-45d0-9352-fb05332fdb82", "{}")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mockStorage.WriteReportForCluster(1, "cluster 2", "report 1")
+	err = mockStorage.WriteReportForCluster(1, "edf5f242-0c12-4307-8c9f-29dcd289d045", "{}")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// also pushing cluster for different org
-	err = mockStorage.WriteReportForCluster(5, "cluster 3", "report 1")
+	err = mockStorage.WriteReportForCluster(5, "4016d01b-62a1-4b49-a36e-c1c5a3d02750", "{}")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,12 +115,15 @@ func TestMockDBStorageListOfClustersForOrg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, []storage.ClusterName{"cluster 1", "cluster 2"}, result)
+	assert.Equal(t, []storage.ClusterName{
+		"eabb4fbf-edfa-45d0-9352-fb05332fdb82",
+		"edf5f242-0c12-4307-8c9f-29dcd289d045",
+	}, result)
 
 	result, err = mockStorage.ListOfClustersForOrg(5)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, []storage.ClusterName{"cluster 3"}, result)
+	assert.Equal(t, []storage.ClusterName{"4016d01b-62a1-4b49-a36e-c1c5a3d02750"}, result)
 }


### PR DESCRIPTION
# Description

Created tests for storage using sqlite in memory as a way to mock db

Fixes #18 

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

`make test` or `go test ./... -run "TestMockDBStorage.*"`

## Notes

https://github.com/DATA-DOG/go-sqlmock doesn't fit very well because it requires us to call methods like `ExpectQuery("SELECT something FROM somewhere .*")` for each request our storage methods are doing and I think that unit tests should not be aware of internal implementation of the storage. 

## Questions

1. Should the `cluster` field be unique? Because now if we are pushing two rows `orgID: 1, cluster: "cluster name"` and `orgID: 2, cluster: "cluster name"`  (with the same cluster field) we will end up having only second row in database