### PR TITLE
Start the service in one process

### DIFF
--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -86,10 +86,3 @@ func TestLoadStorageConfiguration(t *testing.T) {
 		t.Fatal("Improper DB data source name", storageCfg.DataSource)
 	}
 }
-
-func TestStartServiceNoCommand(t *testing.T) {
-	code := main.StartService(false, false, false)
-	if code != main.ExitStatusNoCommand {
-		t.Fatal("Improper status code", code)
-	}
-}


### PR DESCRIPTION
# Description

Start the whole service (consumer and REST API server) in one process, not needed to use -consumer or -server.

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps
Use `make test` as usual.