### PR TITLE
Add OpenAPI 3.0 specification

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,99 @@
+openapi: 3.0.0
+
+info:
+  title: Insights Results Aggregator
+  description: Aggregation service for the results of running Insights rules.
+  version: 0.1.0
+
+servers:
+  - url: http://127.0.0.1:8080/api/v1
+    description: Local instance of the insights results aggregation service.
+
+paths:
+  /organization:
+    get:
+      summary: Returns a list of available organization IDs.
+      description: List of organizations for which at least one Insights report is available via the API.
+      responses:
+        "200":
+          description: A JSON array of organization IDs.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  organizations:
+                    type: array
+                    items:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                  status:
+                    type: string
+                    example: "ok"
+
+  /cluster/{orgId}:
+    get:
+      summary: Returns a list of clusters associated with the specified organization ID.
+      parameters:
+        - name: orgId
+          in: path
+          required: true
+          description: ID of the requested organization.
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        "200":
+          description: A JSON array of clusters that belong to the specified organization.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  clusters:
+                    type: array
+                    items:
+                      type: string
+                      minLength: 36
+                      maxLength: 36
+                      format: uuid
+                  status:
+                    type: string
+                    example: "ok"
+
+  /report/{orgId}/{clusterId}:
+    get:
+      summary: Returns the latest report for the given organization and cluster.
+      description: The report is specified by the organization ID and the cluster ID. The latest report available for the given combination will be returned.
+      parameters:
+        - name: orgId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+        - name: clusterId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 36
+            maxLength: 36
+            format: uuid
+      responses:
+        "200":
+          description: Latest available report for the given organization and cluster combination.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  report:
+                    type: string
+                    format: json
+                  status:
+                    type: string
+                    example: "ok"

--- a/openapi.yml
+++ b/openapi.yml
@@ -5,10 +5,6 @@ info:
   description: Aggregation service for the results of running Insights rules.
   version: 0.1.0
 
-servers:
-  - url: http://127.0.0.1:8080/api/v1
-    description: Local instance of the insights results aggregation service.
-
 paths:
   /organization:
     get:


### PR DESCRIPTION
# Description

Added the OpenAPI 3.0 specification for the three main endpoints. Currently, the `/` path is not defined in the specification because it's not properly configured.

*See #55 (The issue is likely not completely solved by this PR yet.)*

This specification is written in YAML, not JSON, because, as strange as it sounds, it seemed slightly more readable. However, the Swagger Editor allows a one-click conversion option from YAML to JSON, so that shouldn't be a problem. Most libraries that handle the specifications also seem to be able to handle both formats.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

The specification should allow testing of the endpoints (and in reverse a check of the specification as well, assumming the API works correctly), but I haven't managed to get it to work due to a missing CORS header.

Check out <https://github.com/getkin/kin-openapi>. It could possible be helpful, but I'm not entirely sure how much / what exactly it does.