### PR TITLE
Adding a check for the ClusterName UUID format

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -24,6 +24,7 @@ import (
 	"log"
 
 	"github.com/Shopify/sarama"
+	"github.com/google/uuid"
 
 	"github.com/RedHatInsights/insights-results-aggregator/broker"
 	"github.com/RedHatInsights/insights-results-aggregator/metrics"
@@ -95,6 +96,13 @@ func parseMessage(messageValue []byte) (types.OrgID, types.ClusterName, interfac
 	if deserialized.Report == nil {
 		return 0, "", "", errors.New("Missing required attribute 'Report'")
 	}
+
+	_, err = uuid.Parse(string(*deserialized.ClusterName))
+
+	if err != nil {
+		return 0, "", "", errors.New("Cluster name is not a UUID")
+	}
+
 	return *deserialized.Organization, *deserialized.ClusterName, *deserialized.Report, nil
 }
 

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -108,6 +108,22 @@ func TestParseProperMessage(t *testing.T) {
 	}
 }
 
+func TestParseProperMessageWrongClusterName(t *testing.T) {
+	const message = `
+{"OrgID":1,
+ "ClusterName":"this is not a UUID",
+ "Report":"{}"}
+`
+	_, _, _, err := consumer.ParseMessage([]byte(message))
+	if err == nil {
+		t.Fatal("Error is expected to be returned for a wrong ClusterName format")
+	}
+	errorMessage := err.Error()
+	if !strings.HasPrefix(errorMessage, "Cluster name is not a UUID") {
+		t.Fatal("Improper error message: " + errorMessage)
+	}
+}
+
 func TestParseMessageWithoutOrgID(t *testing.T) {
 	const message = `
 {"ClusterName":"aaaaaaaa-bbbb-cccc-dddd-000000000000",

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/RedHatInsights/insights-operator-utils v0.0.0-20200212101518-5819e1fc31a9
 	github.com/Shopify/sarama v1.26.0
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=


### PR DESCRIPTION
# Description

Checks that the received ClusterName is a proper UUID using the  github.com/google/uuid package.
If it is not an UUID, the processMessage will fail and an adequate error reported

Fixes #68 

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps
make default test
