### PR TITLE
Adding check UUID format for cluster name in HTTP requests

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ func (server HTTPServer) listOfClustersForOrganization(writer http.ResponseWrite
 	}
 }
 
-func (server HTTPServer) ReadReportForCluster(writer http.ResponseWriter, request *http.Request) {
+func (server HTTPServer) readReportForCluster(writer http.ResponseWriter, request *http.Request) {
 	organizationID, err := server.readOrganizationID(writer, request)
 	if err != nil {
 		// everything has been handled already
@@ -192,7 +192,7 @@ func (server HTTPServer) Initialize(address string) http.Handler {
 	router.HandleFunc(server.Config.APIPrefix, server.mainEndpoint).Methods("GET")
 	router.HandleFunc(server.Config.APIPrefix+"organization", server.listOfOrganizations).Methods("GET")
 	router.HandleFunc(server.Config.APIPrefix+"cluster/{organization}", server.listOfClustersForOrganization).Methods("GET")
-	router.HandleFunc(server.Config.APIPrefix+"report/{organization}/{cluster}", server.ReadReportForCluster).Methods("GET")
+	router.HandleFunc(server.Config.APIPrefix+"report/{organization}/{cluster}", server.readReportForCluster).Methods("GET")
 
 	// Prometheus metrics
 	router.Handle(server.Config.APIPrefix+"metrics", promhttp.Handler()).Methods("GET")

--- a/server/server.go
+++ b/server/server.go
@@ -133,7 +133,7 @@ func (server HTTPServer) readClusterName(writer http.ResponseWriter, request *ht
 		return types.ClusterName(""), errors.New(message)
 	}
 
-	if _, parseErr := uuid.Parse(clusterName); parseErr != nil {
+	if _, err := uuid.Parse(clusterName); err != nil {
 		const message = "Cluster name format is invalid"
 		log.Println(message)
 		responses.SendInternalServerError(writer, message)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,3 +15,76 @@ limitations under the License.
 */
 
 package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RedHatInsights/insights-results-aggregator/server"
+)
+
+var config = server.Configuration{
+	Address:   ":8080",
+	APIPrefix: "/api/test/",
+}
+
+func executeRequest(server *server.HTTPServer, req *http.Request) *httptest.ResponseRecorder {
+	router := server.Initialize(config.Address)
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	return rr
+}
+
+func checkResponseCode(t *testing.T, expected, actual int) {
+	if expected != actual {
+		t.Errorf("Expected response code %d. Got %d\n", expected, actual)
+	}
+}
+
+func TestReadReportForClusterMissingOrgIdAndClusterName(t *testing.T) {
+	server := server.New(config, nil)
+	req, err := http.NewRequest("GET", config.APIPrefix+"report/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := executeRequest(server, req).Result()
+	checkResponseCode(t, http.StatusNotFound, response.StatusCode)
+}
+
+func TestReadReportForClusterMissingClusterName(t *testing.T) {
+	server := server.New(config, nil)
+	req, err := http.NewRequest("GET", config.APIPrefix+"report/12345", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := executeRequest(server, req).Result()
+	checkResponseCode(t, http.StatusNotFound, response.StatusCode)
+}
+
+func TestReadReportForClusterBadOrgID(t *testing.T) {
+	server := server.New(config, nil)
+	req, err := http.NewRequest("GET", config.APIPrefix+"report/bad_org_id", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := executeRequest(server, req).Result()
+	// It responses with NotFound because it cannot be stored in the DB
+	checkResponseCode(t, http.StatusNotFound, response.StatusCode)
+}
+
+func TestReadReportForClusterBadClusterName(t *testing.T) {
+	server := server.New(config, nil)
+	req, err := http.NewRequest("GET", config.APIPrefix+"report/12345/aaaa", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := executeRequest(server, req).Result()
+	checkResponseCode(t, http.StatusInternalServerError, response.StatusCode)
+}


### PR DESCRIPTION
# Description

Checking UUID format on the cluster name for the get reports HTTP requests.

I added some unit tests for the server package. IDK if it is aligned with the rest of the unit tests or even if it is well done because this are my first unit tests in Go

Fixes #69 

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
Usual "make test"
