### PR TITLE
Minor fix in Travis CI automation. Mismatching stage names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ jobs:
 stages:
   - style
   - unit tests
-  - REST API tests
+  - integration tests


### PR DESCRIPTION
# Description

Minor problem with stage names. Mismatch between `jobs` and `stages` section

Fixes #162 

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps
Usual testing run by CI