### PR TITLE
Added missing error checks in configuration test

### DIFF
--- a/configuration_test.go
+++ b/configuration_test.go
@@ -116,11 +116,20 @@ func TestLoadConfigurationOverrideFromEnv(t *testing.T) {
 		PGParams:         "",
 	}, storageCfg)
 
-	os.Setenv("INSIGHTS_RESULTS_AGGREGATOR__STORAGE__DB_DRIVER", "postgres")
-	os.Setenv(
+	err := os.Setenv("INSIGHTS_RESULTS_AGGREGATOR__STORAGE__DB_DRIVER", "postgres")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Setenv(
 		"INSIGHTS_RESULTS_AGGREGATOR__STORAGE__PG_PASSWORD",
 		"some very secret password",
 	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	storageCfg = main.LoadStorageConfiguration()
 	assert.Equal(t, storage.Configuration{


### PR DESCRIPTION
# Description

Added missing error checks in configuration test

Fixes #175 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
Run `make test` as usual.