### PR TITLE
Added missing error checks in storage tests

### DIFF
--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -79,6 +79,13 @@ func expectErrorClosedStorage(t *testing.T, err error) {
 	}
 }
 
+func closeStorage(t *testing.T, mockStorage storage.Storage) {
+	err := mockStorage.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestNewStorage checks whether constructor for new storage returns error for improper storage configuration
 func TestNewStorage(t *testing.T) {
 	_, err := storage.New(storage.Configuration{
@@ -126,7 +133,7 @@ func TestNewStorageWithLoggingError(t *testing.T) {
 // TestMockDBStorageReadReportForClusterEmptyTable check the behaviour of method ReadReportForCluster
 func TestMockDBStorageReadReportForClusterEmptyTable(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ReadReportForCluster(testOrgID, testClusterName)
 	if _, ok := err.(*storage.ItemNotFoundError); err == nil || !ok {
@@ -143,13 +150,6 @@ func TestMockDBStorageReadReportForClusterEmptyTable(t *testing.T) {
 	)
 }
 
-func closeStorage(t *testing.T, mockStorage storage.Storage) {
-	err := mockStorage.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 // TestMockDBStorageReadReportForClusterClosedStorage check the behaviour of method ReadReportForCluster
 func TestMockDBStorageReadReportForClusterClosedStorage(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
@@ -163,7 +163,7 @@ func TestMockDBStorageReadReportForClusterClosedStorage(t *testing.T) {
 // TestMockDBStorageReadReportForCluster check the behaviour of method ReadReportForCluster
 func TestMockDBStorageReadReportForCluster(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	writeReportForCluster(t, mockStorage, testOrgID, testClusterName, `{"report":{}}`)
 	checkReportForCluster(t, mockStorage, testOrgID, testClusterName, `{"report":{}}`)
@@ -173,7 +173,7 @@ func TestMockDBStorageReadReportForCluster(t *testing.T) {
 // when the table with results does not exist
 func TestMockDBStorageReadReportNoTable(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, false)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ReadReportForCluster(testOrgID, testClusterName)
 	expectErrorEmptyTable(t, err)
@@ -197,7 +197,7 @@ func TestMockDBStorageWriteReportForClusterClosedStorage(t *testing.T) {
 // TestMockDBStorageListOfOrgs check the behaviour of method ListOfOrgs
 func TestMockDBStorageListOfOrgs(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	writeReportForCluster(t, mockStorage, 1, "1deb586c-fb85-4db4-ae5b-139cdbdf77ae", testClusterReport)
 	writeReportForCluster(t, mockStorage, 3, "a1bf5b15-5229-4042-9825-c69dc36b57f5", testClusterReport)
@@ -212,7 +212,7 @@ func TestMockDBStorageListOfOrgs(t *testing.T) {
 
 func TestMockDBStorageListOfOrgsNoTable(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, false)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ListOfOrgs()
 	expectErrorEmptyTable(t, err)
@@ -231,7 +231,7 @@ func TestMockDBStorageListOfOrgsClosedStorage(t *testing.T) {
 // TestMockDBStorageListOfClustersFor check the behaviour of method ListOfClustersForOrg
 func TestMockDBStorageListOfClustersForOrg(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	writeReportForCluster(t, mockStorage, 1, "eabb4fbf-edfa-45d0-9352-fb05332fdb82", testClusterReport)
 	writeReportForCluster(t, mockStorage, 1, "edf5f242-0c12-4307-8c9f-29dcd289d045", testClusterReport)
@@ -259,7 +259,7 @@ func TestMockDBStorageListOfClustersForOrg(t *testing.T) {
 
 func TestMockDBStorageListOfClustersNoTable(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, false)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ListOfClustersForOrg(5)
 	expectErrorEmptyTable(t, err)
@@ -278,7 +278,7 @@ func TestMockDBStorageListOfClustersClosedStorage(t *testing.T) {
 // TestMockDBReportsCount check the behaviour of method ReportsCount
 func TestMockDBReportsCount(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	cnt, err := mockStorage.ReportsCount()
 	if err != nil {
@@ -299,7 +299,7 @@ func TestMockDBReportsCount(t *testing.T) {
 
 func TestMockDBReportsCountNoTable(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, false)
-	defer mockStorage.Close()
+	defer closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ReportsCount()
 	expectErrorEmptyTable(t, err)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -143,10 +143,18 @@ func TestMockDBStorageReadReportForClusterEmptyTable(t *testing.T) {
 	)
 }
 
+func closeStorage(t *testing.T, mockStorage storage.Storage) {
+	err := mockStorage.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestMockDBStorageReadReportForClusterClosedStorage check the behaviour of method ReadReportForCluster
 func TestMockDBStorageReadReportForClusterClosedStorage(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	mockStorage.Close()
+	// we need to close storage right now
+	closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ReadReportForCluster(testOrgID, testClusterName)
 	expectErrorClosedStorage(t, err)
@@ -174,7 +182,8 @@ func TestMockDBStorageReadReportNoTable(t *testing.T) {
 // TestMockDBStorageWriteReportForClusterClosedStorage check the behaviour of method WriteReportForCluster
 func TestMockDBStorageWriteReportForClusterClosedStorage(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	mockStorage.Close()
+	// we need to close storage right now
+	closeStorage(t, mockStorage)
 
 	err := mockStorage.WriteReportForCluster(
 		testOrgID,
@@ -212,7 +221,8 @@ func TestMockDBStorageListOfOrgsNoTable(t *testing.T) {
 // TestMockDBStorageListOfOrgsClosedStorage check the behaviour of method ListOfOrgs
 func TestMockDBStorageListOfOrgsClosedStorage(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	mockStorage.Close()
+	// we need to close storage right now
+	closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ListOfOrgs()
 	expectErrorClosedStorage(t, err)
@@ -258,7 +268,8 @@ func TestMockDBStorageListOfClustersNoTable(t *testing.T) {
 // TestMockDBStorageListOfClustersClosedStorage check the behaviour of method ListOfOrgs
 func TestMockDBStorageListOfClustersClosedStorage(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, true)
-	mockStorage.Close()
+	// we need to close storage right now
+	closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ListOfClustersForOrg(5)
 	expectErrorClosedStorage(t, err)
@@ -296,7 +307,8 @@ func TestMockDBReportsCountNoTable(t *testing.T) {
 
 func TestMockDBReportsCountClosedStorage(t *testing.T) {
 	mockStorage := helpers.MustGetMockStorage(t, false)
-	mockStorage.Close()
+	// we need to close storage right now
+	closeStorage(t, mockStorage)
 
 	_, err := mockStorage.ReportsCount()
 	expectErrorClosedStorage(t, err)


### PR DESCRIPTION
# Description

#181 

Added missing error checks in storage tests

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
Please run `make test` as usual.