### PR TITLE
Resulting image should contain openapi.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN cd insights-results-aggregator && \
 FROM registry.access.redhat.com/ubi8-minimal
 
 COPY --from=builder /go/insights-results-aggregator/insights-results-aggregator .
+COPY --from=builder /go/insights-results-aggregator/openapi.json /data
 
 RUN chmod a+x /insights-results-aggregator
 


### PR DESCRIPTION
# Description
We should include `openapi.json` in our resting image.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps
The image has been built successfully on my local machine.
