### PR TITLE
Fix name of openapi.json file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cd insights-results-aggregator && \
 FROM registry.access.redhat.com/ubi8-minimal
 
 COPY --from=builder /go/insights-results-aggregator/insights-results-aggregator .
-COPY --from=builder /go/insights-results-aggregator/openapi.json /data
+COPY --from=builder /go/insights-results-aggregator/openapi.json /openapi/openapi.json
 
 RUN chmod a+x /insights-results-aggregator
 


### PR DESCRIPTION
# Description
The full path of the `openapi.json` file should be provided in `COPY` command of the dockerfile.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

