### PR TITLE
More Postgres-related fixes to migration code

### DIFF
--- a/migration/migration1.go
+++ b/migration/migration1.go
@@ -27,8 +27,8 @@ var mig1 = Migration{
 				org_id          INTEGER NOT NULL,
 				cluster         VARCHAR NOT NULL UNIQUE,
 				report          VARCHAR NOT NULL,
-				reported_at     DATETIME,
-				last_checked_at DATETIME,
+				reported_at     TIMESTAMP,
+				last_checked_at TIMESTAMP,
 				PRIMARY KEY(org_id, cluster)
 			)`)
 		return err


### PR DESCRIPTION
# Description

This should fix the `pq: current transaction is aborted, commands ignored until end of transaction block` error and a couple of other problems specific to the Postgres driver.

The migration table initialization cannot happens in a transaction becase Postgres considers any error fatal and doesn't allow the transaction to continue. Therefore it makes no sense to wrap the check and table creation in a transaction.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

The aggregator should now successfully boot up using Postgres storage.