### PR TITLE
add pull of insights rules content repository to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,18 @@ FROM golang:1.13 AS builder
 
 COPY . insights-results-aggregator
 
+ARG SOURCE_REPOSITORY_URL
+
+# get CA cert for SSL
+RUN wget https://password.corp.redhat.com/RH-IT-Root-CA.crt -P /tmp
+ENV GIT_SSL_CAINFO=/tmp/RH-IT-Root-CA.crt
+ENV RULES_CONTENT_DIR=/rules_content
+
+# clone rules content repository
+RUN umask 0022 && \
+    mkdir -p $RULES_CONTENT_DIR && \
+    git -C $RULES_CONTENT_DIR clone $SOURCE_REPOSITORY_URL $RULES_CONTENT_DIR
+
 RUN cd insights-results-aggregator && \
     make build
 
@@ -23,6 +35,8 @@ FROM registry.access.redhat.com/ubi8-minimal
 
 COPY --from=builder /go/insights-results-aggregator/insights-results-aggregator .
 COPY --from=builder /go/insights-results-aggregator/openapi.json /openapi/openapi.json
+# copy just the content of the rules, not the whole repository
+COPY --from=builder /rules_content/content /rules_content
 
 RUN chmod a+x /insights-results-aggregator
 


### PR DESCRIPTION
# Description

The repository defined by the build argument `SOURCE_REPOSITORY_URL` (variable because the repo will change from gitlab to github soon) is now pulled on image build and only the actual directory of the content is copied to the container. Discussed with Ivo and the full path for a single rule will be
`/rules_content/external/rules/cluster_wide_proxy_auth_check`

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps
Tested manually by checking if the root `/rules_content` directory contains the files