### PR TITLE
Improving errcheck implementation

### DIFF
--- a/configuration_test.go
+++ b/configuration_test.go
@@ -45,13 +45,6 @@ func removeFile(t *testing.T, filename string) {
 	}
 }
 
-func fileClose(file *os.File) {
-	err := file.Close()
-	if err != nil {
-		panic(err)
-	}
-}
-
 // TestLoadConfiguration loads a configuration file for testing
 func TestLoadConfiguration(t *testing.T) {
 	err := os.Unsetenv("INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE")

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -55,6 +55,13 @@ var (
 	testOrgWhiteList = mapset.NewSetWith(types.OrgID(1))
 )
 
+func closeStorage(t *testing.T, storage storage.Storage) {
+	err := storage.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestConsumerConstructorNoKafka(t *testing.T) {
 	storageCfg := storage.Configuration{
 		Driver:           "sqlite3",
@@ -64,7 +71,7 @@ func TestConsumerConstructorNoKafka(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer storage.Close()
+	defer closeStorage(t, storage)
 
 	brokerCfg := broker.Configuration{
 		Address: "localhost:1234",
@@ -256,7 +263,7 @@ func dummyConsumer(s storage.Storage, whitelist bool) consumer.Consumer {
 }
 func TestProcessEmptyMessage(t *testing.T) {
 	storage := helpers.MustGetMockStorage(t, true)
-	defer storage.Close()
+	defer closeStorage(t, storage)
 
 	c := dummyConsumer(storage, true)
 
@@ -279,7 +286,7 @@ func TestProcessEmptyMessage(t *testing.T) {
 
 func TestProcessCorrectMessage(t *testing.T) {
 	storage := helpers.MustGetMockStorage(t, true)
-	defer storage.Close()
+	defer closeStorage(t, storage)
 
 	c := dummyConsumer(storage, true)
 
@@ -348,7 +355,7 @@ func TestProcessingMessageWithClosedStorage(t *testing.T) {
 
 func TestProcessingMessageWithWrongDateFormat(t *testing.T) {
 	storage := helpers.MustGetMockStorage(t, true)
-	defer storage.Close()
+	defer closeStorage(t, storage)
 
 	c := dummyConsumer(storage, true)
 

--- a/goerrcheck.sh
+++ b/goerrcheck.sh
@@ -16,9 +16,4 @@
 
 go get github.com/kisielk/errcheck
 
-OUTPUT=`errcheck ./... | awk '$2 !~ /defer/ {print}'`
-
-[[ ! -z "$OUTPUT" ]] && EXIT_VALUE=1
-
-echo "$OUTPUT"
-exit $EXIT_VALUE
+errcheck ./...

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -84,7 +84,9 @@ func GetDBVersion(db *sql.DB) (Version, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	// Read the first (and hopefully the only) row in the table.
 	if !rows.Next() {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -175,6 +175,10 @@ type Report struct {
 	ReportedAt types.Timestamp     `json:"reported_at"`
 }
 
+func closeRows(rows *sql.Rows) {
+	_ = rows.Close()
+}
+
 // ListOfOrgs reads list of all organizations that have at least one cluster report
 func (storage DBStorage) ListOfOrgs() ([]types.OrgID, error) {
 	orgs := []types.OrgID{}
@@ -183,7 +187,7 @@ func (storage DBStorage) ListOfOrgs() ([]types.OrgID, error) {
 	if err != nil {
 		return orgs, err
 	}
-	defer rows.Close()
+	defer closeRows(rows)
 
 	for rows.Next() {
 		var orgID types.OrgID
@@ -206,7 +210,7 @@ func (storage DBStorage) ListOfClustersForOrg(orgID types.OrgID) ([]types.Cluste
 	if err != nil {
 		return clusters, err
 	}
-	defer rows.Close()
+	defer closeRows(rows)
 
 	for rows.Next() {
 		var clusterName string
@@ -247,7 +251,7 @@ func (storage DBStorage) WriteReportForCluster(
 	clusterName types.ClusterName,
 	report types.ClusterReport,
 	lastCheckedTime time.Time,
-) error {
+) (err error) {
 	var query string
 
 	switch storage.dbDriverType {
@@ -267,7 +271,9 @@ func (storage DBStorage) WriteReportForCluster(
 	if err != nil {
 		return err
 	}
-	defer statement.Close()
+	defer func() {
+		err = statement.Close()
+	}()
 
 	t := time.Now()
 

--- a/types/types.go
+++ b/types/types.go
@@ -23,7 +23,7 @@ type OrgID uint64
 type ClusterName string
 
 // ClusterReport represents cluster report
-type ClusterReport jsonb
+type ClusterReport string
 
 // Timestamp represents any timestamp in a form gathered from database
 // TODO: need to be improved

--- a/types/types.go
+++ b/types/types.go
@@ -23,7 +23,7 @@ type OrgID uint64
 type ClusterName string
 
 // ClusterReport represents cluster report
-type ClusterReport string
+type ClusterReport jsonb
 
 // Timestamp represents any timestamp in a form gathered from database
 // TODO: need to be improved


### PR DESCRIPTION
# Description

Improve the errcheck implementation script, avoiding ignore `defer` calls, modifying the code of the application to perform checks about the error returned values

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps
Run `make test style` to run the unit tests and the style checks. Both Makefile rules should be executed without any problem