### PR TITLE
Add default content path when missing configuration

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -146,6 +146,10 @@ func getServerConfiguration() server.Configuration {
 
 // getContentPathConfiguration get the path to the content files from the configuration
 func getContentPathConfiguration() string {
+	if len(config.Content.ContentPath) == 0 {
+		config.Content.ContentPath = defaultContentPath
+	}
+
 	return config.Content.ContentPath
 }
 


### PR DESCRIPTION
# Description

When there is no content path configration in the configuration file nor environment variable, add a default value to it

Fixes #260 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Just CI
