### PR TITLE
Add .EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+indent_size = unset
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[openapi.json]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
# Description

Added EditorConfig to make code style (outside of Go code) slightly more consistent. Same thing as what we did in the external data pipeline a couple of months back.

I'm doing this mainly for YAML config files and Markdown files, which tend to be very inconsistent with their indentation. Also to prevent missing final newlines in files.

If this makes your IDE reformat any file in a strange way, please tweak the .EditorConfig or let me know.

Fixes #281 

## Type of change

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)

## Testing steps

Letting your IDE format any of the existing files shouldn't break it. If it does, let me know.