### PR TITLE
Fix Markdown linter warnings in various files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,40 +10,38 @@ Other code quality metrics are measured as well via [Go Report Card](https://gor
 
 Please, don't forget to call `make before_commit` to check style, run unit and integration tests and add license headers to new files
 
-
 ### Naming conventions
 
 Please try to follow [Style guideline for Go packages](https://rakyll.org/style-packages/) and [Package names](https://blog.golang.org/package-names)
-
 
 ## Submitting a pull request
 
 Before you submit your pull request consider the following guidelines:
 
 * Fork the repository and clone your fork
-  * open the following URL in your browser: https://github.com/RedHatInsights/insights-results-aggregator
+  * open the following URL in your browser: <https://github.com/RedHatInsights/insights-results-aggregator>
   * click on the 'Fork' button (near the top right corner)
   * select the account for fork
-  * open your forked repository in browser: https://github.com/YOUR_NAME/insights-results-aggregator
+  * open your forked repository in browser: <https://github.com/YOUR_NAME/insights-results-aggregator>
   * click on the 'Clone or download' button to get a command that can be used to clone the repository
 
 * Make your changes in a new git branch:
 
-     ```shell
-     git checkout -b bug/my-fix-branch master
-     ```
+  ```shell
+  git checkout -b bug/my-fix-branch master
+  ```
 
 * Create your patch, **ideally including appropriate test cases**
 * Include documentation that either describe a change to a behavior or the changed capability to an end user
 * Commit your changes using **a descriptive commit message**. If you are fixing an issue please include something like 'this closes issue #xyz'
-    * Please make sure your tests pass!
-    * Currently we use Travis CI for our automated testing.
+  * Please make sure your tests pass!
+  * Currently we use Travis CI for our automated testing.
 
 * Push your branch to GitHub:
 
-    ```shell
-    git push origin bug/my-fix-branch
-    ```
+  ```shell
+  git push origin bug/my-fix-branch
+  ```
 
 * When opening a pull request, select the `master` branch as a base.
 * Mark your pull request with **[WIP]** (Work In Progress) to get feedback but prevent merging (e.g. [WIP] Update CONTRIBUTING.md)

--- a/DoD.md
+++ b/DoD.md
@@ -1,11 +1,11 @@
 # Definition of Done
 
-## A deliverable is to be considered “done” when:
+## A deliverable is to be considered “done” when
 
-1. The feature/bug fix implemented - code is complete, documented and checked in 
-1. Unit tests written and running cleanly in the CI environment 
+1. The feature/bug fix implemented - code is complete, documented and checked in
+1. Unit tests written and running cleanly in the CI environment
 1. All linters are running cleanly in the CI environment
-1. Code changes reviewed by at least one peer 
-1. Acceptance criteria are verified and fulfilled 
+1. Code changes reviewed by at least one peer
+1. Acceptance criteria are verified and fulfilled
 1. Code merged in the main branch
-1. User docs completed, reviewed and published (if applicable)
+1. User docs completed, reviewed and published(if applicable)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,5 @@ Please delete options that are not relevant.
 - Documentation update
 
 ## Testing steps
+
 Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ All packages developed in this project have documentation available on [GoDoc se
 
 ## Configuration
 
-Configuration is done by toml config, default one is `config.toml` in working directory, 
-but it can be overwritten by `INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE` env var. 
+Configuration is done by toml config, default one is `config.toml` in working directory,
+but it can be overwritten by `INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE` env var.
 
 Also each key in config can be overwritten by corresponding env var. For example if you have config
 
-```
+```toml
 ...
 [storage]
 db_driver = "sqlite3"
@@ -107,23 +107,23 @@ pg_params = ""
 ...
 ```
 
-and environment variables 
+and environment variables
 
-```
+```shell
 INSIGHTS_RESULTS_AGGREGATOR__STORAGE__DB_DRIVER="postgres"
 INSIGHTS_RESULTS_AGGREGATOR__STORAGE__PG_PASSWORD="your secret password"
 ```
 
 the actual driver will be postgres with password "your secret password"
 
-It's very usefull for deploying docker containers and keeping some of your configuration 
+It's very useful for deploying docker containers and keeping some of your configuration
 outside of main config file(like passwords).
 
 ## Server configuration
 
 Server configuration is in section `[server]` in config file.
 
-```
+```toml
 [server]
 address = ":8080"
 api_prefix = "/api/v1/"
@@ -131,22 +131,22 @@ api_spec_file = "openapi.json"
 debug = true
 ```
 
- - `address` is host and port which server should listen to
- - `api_prefix` is prefix for RestAPI path
- - `api_spec_file` is the location of a required OpenAPI specifications file
- - `debug` is developer mode that turns off authentication
+* `address` is host and port which server should listen to
+* `api_prefix` is prefix for RestAPI path
+* `api_spec_file` is the location of a required OpenAPI specifications file
+* `debug` is developer mode that turns off authentication
 
 ## Local setup
 
 There is a `docker-compose` configuration that provisions a minimal stack of Insight Platform and
 a postgres database.
-You can download it here https://gitlab.cee.redhat.com/insights-qe/iqe-ccx-plugin/blob/master/docker-compose.yml
+You can download it here <https://gitlab.cee.redhat.com/insights-qe/iqe-ccx-plugin/blob/master/docker-compose.yml>
 
 ### Prerequisites
 
 * minio requires `../minio/data/` and `../minio/config` directories to be created
 * edit localhost line in your `/etc/hosts`:  `127.0.0.1       localhost kafka minio`
-* `ingress` image should present on your machine. You can build it locally from this repo https://github.com/RedHatInsights/insights-ingress-go
+* `ingress` image should present on your machine. You can build it locally from this repo <https://github.com/RedHatInsights/insights-ingress-go>
 
 ### Usage
 
@@ -159,7 +159,8 @@ You can download it here https://gitlab.cee.redhat.com/insights-qe/iqe-ccx-plugi
 Stop Minimal Insights Platform stack `podman-compose down` or `docker-compose down`
 
 In order to upload an insights archive, you can use `curl`:
-```
+
+```shell
 curl -k -vvvv -F "upload=@/path/to/your/archive.zip;type=application/vnd.redhat.testareno.archive+zip" http://localhost:3000/api/ingress/v1/upload -H "x-rh-identity: eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMSIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjEifX19Cg=="
 ```
 
@@ -171,12 +172,12 @@ It is possible to use the script `produce_insights_results` from `utils` to prod
 
 ## Database
 
-Aggregator is configured to use SQLite3 DB by default, but it also supports PostgreSQL. 
+Aggregator is configured to use SQLite3 DB by default, but it also supports PostgreSQL.
 In CI and QA environments, the configuration is overriden by environment variables to use PostgreSQL.
 
 To establish connection to PostgreSQL, the following configuration options need to be changed in `storage` section of `config.toml`:
 
-```
+```toml
 [storage]
 db_driver = "postgres"
 pg_username = "postgres"
@@ -206,7 +207,6 @@ See `/migration/migration.go` documentation for an overview of all available DB 
 Please look into document [CONTRIBUTING.md](CONTRIBUTING.md) that contains all information about how to contribute to this project.
 
 Please look also at [Definitiot of Done](DoD.md) document with further informations.
-
 
 ## Testing
 


### PR DESCRIPTION
# Description

Just fixed a couple of small issues I found in our Markdown files. Nothing important, but it kept bugging me every time I open them.

Fixes #282 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)

## Testing steps

There were no more warnings produced by my Markdown linter at the moment. If you find any more problems, feel free to report them.