### PR TITLE
Removed unused service from smoke tests

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -22,7 +22,7 @@ if (env.CHANGE_TARGET == "stable" && env.CHANGE_ID) {
     execSmokeTest (
         ocDeployerBuilderPath: "ccx-data-pipeline/insights-results-aggregator",
         ocDeployerComponentPath: "ccx-data-pipeline/insights-results-aggregator",
-        ocDeployerServiceSets: "ccx-data-pipeline,ingress,buck-it,engine,platform-mq",
+        ocDeployerServiceSets: "ccx-data-pipeline,ingress,buck-it,platform-mq",
         iqePlugins: ["iqe-ccx-plugin"],
         pytestMarker: ["smoke"]
     )


### PR DESCRIPTION
# Description
insights-engine is not required for our backend.

## Type of change

- Tests (no changes in the code)
