### PR TITLE
changed rules query so that it works on both PGSQL and SQLite

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -280,9 +280,9 @@ func constructWhereClause(reportRules types.ReportRules) string {
 		module := strings.TrimRight(rule.Module, ".report") // remove trailing .report from module name
 
 		if i == 0 {
-			singleVal = fmt.Sprintf(`VALUES ("%v", "%v")`, rule.ErrorKey, module)
+			singleVal = fmt.Sprintf(`VALUES ('%v', '%v')`, rule.ErrorKey, module)
 		} else {
-			singleVal = fmt.Sprintf(`, ("%v", "%v")`, rule.ErrorKey, module)
+			singleVal = fmt.Sprintf(`, ('%v', '%v')`, rule.ErrorKey, module)
 		}
 		statement = statement + singleVal
 	}


### PR DESCRIPTION
# Description
Fixes rules content query to support both db engines... I thought PG prefers `"` over `'`
Ugh, I forgot about previously set env variables.

Fixes #303 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
`make before_commit`
Manually tested endpoint with SQLite and PostgreSQL databases.
