### PR TITLE
Auth server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,14 @@ address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
 debug = true
+auth = true
 ```
 
 * `address` is host and port which server should listen to
 * `api_prefix` is prefix for RestAPI path
 * `api_spec_file` is the location of a required OpenAPI specifications file
-* `debug` is developer mode that turns off authentication
+* `debug` is developer mode that enables some special API endpoints not used on production
+* `auth` turns on or turns authentication
 
 ## Local setup
 

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -15,6 +15,7 @@ address = ":8080"
 api_prefix = "/api/insights-results-aggregator/v1/"
 api_spec_file = "openapi.json"
 debug = true
+auth = false
 
 [storage]
 db_driver = "postgres"

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,7 @@ address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
 debug = true
+auth = false
 
 [storage]
 db_driver = "sqlite3"

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -28,6 +28,7 @@ var configAuth = server.Configuration{
 	Address:   ":8080",
 	APIPrefix: "/api/test/",
 	Debug:     false,
+	Auth:      true,
 }
 
 // TestMissingAuthToken checks how the missing auth. token header (expected in HTTP request) is handled

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -22,4 +22,5 @@ type Configuration struct {
 	APIPrefix   string `mapstructure:"api_prefix" toml:"api_prefix"`
 	APISpecFile string `mapstructure:"api_spec_file" toml:"api_spec_file"`
 	Debug       bool   `mapstructure:"debug" toml:"debug"`
+	Auth        bool   `mapstructure:"auth" toml:"auth"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -305,12 +305,15 @@ func (server *HTTPServer) Initialize(address string) http.Handler {
 
 	router := mux.NewRouter().StrictSlash(true)
 	router.Use(server.LogRequest)
-	if !server.Config.Debug {
+
+	// enable authentication, but only if it is setup in configuration
+	if server.Config.Auth {
 		router.Use(server.Authentication)
 	}
 
 	apiPrefix := server.Config.APIPrefix
 
+	// it is possible to use special REST API endpoints in debug mode
 	if server.Config.Debug {
 		router.HandleFunc(apiPrefix+"organizations/{organizations}", server.deleteOrganizations).Methods(http.MethodDelete)
 		router.HandleFunc(apiPrefix+"clusters/{clusters}", server.deleteClusters).Methods(http.MethodDelete)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,6 +44,7 @@ var config = server.Configuration{
 	APIPrefix:   "/api/test/",
 	APISpecFile: "openapi.json",
 	Debug:       true,
+	Auth:        false,
 }
 
 const (
@@ -356,6 +357,8 @@ func TestServerStart(t *testing.T) {
 			// will use any free port
 			Address:   ":0",
 			APIPrefix: config.APIPrefix,
+			Auth:      true,
+			Debug:     true,
 		}, nil)
 
 		go func() {

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -18,6 +18,7 @@ org_whitelist = "org_whitelist.csv"
 address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
+auth = false
 
 [storage]
 db_driver = "sqlite3"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -15,6 +15,7 @@ address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
 debug = true
+auth = false
 
 [storage]
 db_driver = "sqlite3"


### PR DESCRIPTION
# Description

Ability to setup/enforce server auth mode.

Fixes #328

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

See CI please. Additionally it would be possible to play with `auth` flag in configuration and check whether the authorization part works as expected (it is not tested much ATM).