### PR TITLE
Cover storage with tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-operator-utils v0.0.0-20200212101518-5819e1fc31a9
 	github.com/Shopify/sarama v1.26.0
 	github.com/bitly/go-simplejson v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
+github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/RedHatInsights/insights-operator-controller v0.0.0-20200207074239-4acd9b4389a5 h1:0S3mo1yQ70zC6hWYU0DyJEq1RVETTyCWGQxT0sJgOA8=
 github.com/RedHatInsights/insights-operator-utils v0.0.0-20200128100540-06c122fd8a86 h1:iypZgR01YTg1vYzALrZdZ17R2zGi6NNQJG+9BWxoZGc=

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -32,10 +32,6 @@ const (
 	SQLHooksKeyQueryBeginTime = sqlHooksKeyQueryBeginTime
 )
 
-var (
-	GetDataSourceForDriverFromConfig = getDataSourceForDriverFromConfig
-)
-
 func GetConnection(storage *DBStorage) *sql.DB {
 	return storage.connection
 }

--- a/storage/rule_feedback.go
+++ b/storage/rule_feedback.go
@@ -77,7 +77,7 @@ func (storage DBStorage) addOrUpdateUserFeedbackOnRuleForCluster(
 	userID types.UserID,
 	userVotePtr *UserVote,
 	messagePtr *string,
-) (outError error) {
+) error {
 	updateVote := false
 	updateMessage := false
 	userVote := UserVoteNone
@@ -103,7 +103,10 @@ func (storage DBStorage) addOrUpdateUserFeedbackOnRuleForCluster(
 		return err
 	}
 	defer func() {
-		outError = statement.Close()
+		err := statement.Close()
+		if err != nil {
+			log.Error().Err(err).Msg("Unable to close statement")
+		}
 	}()
 
 	now := time.Now()
@@ -123,7 +126,7 @@ func (storage DBStorage) constructUpsertClusterRuleUserFeedback(updateVote bool,
 	var query string
 
 	switch storage.dbDriverType {
-	case DBDriverSQLite3, DBDriverPostgres:
+	case DBDriverSQLite3, DBDriverPostgres, DBDriverGeneral:
 		query = `
 			INSERT INTO cluster_rule_user_feedback
 			(cluster_id, rule_id, user_id, user_vote, added_at, updated_at, message)

--- a/storage/sql_hooks_test.go
+++ b/storage/sql_hooks_test.go
@@ -25,45 +25,81 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
+	"github.com/mattn/go-sqlite3"
+
 	"github.com/rs/zerolog"
 
 	"github.com/RedHatInsights/insights-results-aggregator/storage"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInitAndGetSQLDriverWithLogsOK(t *testing.T) {
-	logger := zerolog.New(os.Stdout).With().Str("type", "SQL").Logger()
-	driverName, err := storage.InitAndGetSQLDriverWithLogs(storage.DBDriverSQLite3, &logger)
-	if err != nil {
-		t.Fatal(err)
-	}
+//func TestInitAndGetSQLDriverWithLogsOK(t *testing.T) {
+//	logger := zerolog.New(os.Stdout).With().Str("type", "SQL").Logger()
+//	driverName, err := storage.InitAndGetSQLDriverWithLogs(storage.DBDriverSQLite3, &logger)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	assert.Equal(t, "sqlite3WithHooks", driverName)
+//
+//	driverName, err = storage.InitAndGetSQLDriverWithLogs(storage.DBDriverPostgres, &logger)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	assert.Equal(t, "postgresWithHooks", driverName)
+//}
+//
+//func TestInitAndGetSQLDriverWithLogsDriverNotFound(t *testing.T) {
+//	logger := zerolog.New(os.Stdout).With().Str("type", "SQL").Logger()
+//	const nonExistingDriver = -1
+//	_, err := storage.InitAndGetSQLDriverWithLogs(nonExistingDriver, &logger)
+//	if err == nil || err.Error() != fmt.Sprintf("driver '%v' is not supported", nonExistingDriver) {
+//		t.Fatal(fmt.Errorf("expected driver not supported error, got %+v", err))
+//	}
+//}
 
+func TestInitSQLDriverWithLogs(t *testing.T) {
+	logger := zerolog.New(os.Stdout).With().Str("type", "SQL").Logger()
+
+	driverName := storage.InitSQLDriverWithLogs(
+		&sqlite3.SQLiteDriver{},
+		"sqlite3",
+		&logger,
+	)
 	assert.Equal(t, "sqlite3WithHooks", driverName)
 
-	driverName, err = storage.InitAndGetSQLDriverWithLogs(storage.DBDriverPostgres, &logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	driverName = storage.InitSQLDriverWithLogs(
+		&pq.Driver{},
+		"postgres",
+		&logger,
+	)
 	assert.Equal(t, "postgresWithHooks", driverName)
 }
 
-func TestInitAndGetSQLDriverWithLogsDriverNotFound(t *testing.T) {
+// TestInitSQLDriverWithLogsMultipleCalls tests if InitSQLDriverWithLogs
+// does not panic on multiple calls and is idempotent
+func TestInitSQLDriverWithLogsMultipleCalls(t *testing.T) {
 	logger := zerolog.New(os.Stdout).With().Str("type", "SQL").Logger()
-	const nonExistingDriver = -1
-	_, err := storage.InitAndGetSQLDriverWithLogs(nonExistingDriver, &logger)
-	if err == nil || err.Error() != fmt.Sprintf("driver '%v' is not supported", nonExistingDriver) {
-		t.Fatal(fmt.Errorf("expected driver not supported error, got %+v", err))
+
+	for i := 0; i < 10; i++ {
+		driverName := storage.InitSQLDriverWithLogs(
+			&sqlite3.SQLiteDriver{},
+			"sqlite3",
+			&logger,
+		)
+		assert.Equal(t, "sqlite3WithHooks", driverName)
 	}
 }
 
 func TestSQLHooksLoggingArgsJSON(t *testing.T) {
 	const query = "SELECT 1"
-	var params = []interface{}{}
+	params := make([]interface{}, 0)
 
 	buf := new(bytes.Buffer)
 	logger := zerolog.New(buf).With().Str("type", "SQL").Logger()
-	hooks := storage.SQLHooks{&logger}
+	hooks := storage.SQLHooks{SQLQueriesLogger: &logger}
 
 	_, err := hooks.Before(context.Background(), query, params...)
 	if err != nil {
@@ -99,7 +135,7 @@ func TestSQLHooksLoggingArgsNotJSON(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	logger := zerolog.New(buf).With().Str("type", "SQL").Logger()
-	hooks := storage.SQLHooks{&logger}
+	hooks := storage.SQLHooks{SQLQueriesLogger: &logger}
 
 	_, err := hooks.Before(context.Background(), query, params...)
 	if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -87,6 +87,8 @@ const (
 	DBDriverSQLite3 DBDriver = iota
 	// DBDriverPostgres shows that db driver is postrgres
 	DBDriverPostgres
+	// general sql(used for mock now)
+	DBDriverGeneral
 
 	// driverNotSupportedMessage is a template for error message displayed
 	// in all situations where given DB driver is not supported
@@ -98,9 +100,8 @@ const (
 // sql package. It is possible to configure connection via Configuration structure.
 // SQLQueriesLog is log for sql queries, default is nil which means nothing is logged
 type DBStorage struct {
-	connection    *sql.DB
-	configuration Configuration
-	dbDriverType  DBDriver
+	connection   *sql.DB
+	dbDriverType DBDriver
 }
 
 // New function creates and initializes a new instance of Storage interface
@@ -133,18 +134,21 @@ func New(configuration Configuration) (*DBStorage, error) {
 	}
 
 	log.Printf("Making connection to data storage, driver=%s datasource=%s", configuration.Driver, dataSource)
-	connection, err := sql.Open(driverName, dataSource)
 
+	connection, err := sql.Open(driverName, dataSource)
 	if err != nil {
 		log.Error().Err(err).Msg("Can not connect to data storage")
 		return nil, err
 	}
 
+	return NewFromConnection(connection, driverType), nil
+}
+
+func NewFromConnection(connection *sql.DB, dbDriverType DBDriver) *DBStorage {
 	return &DBStorage{
-		connection:    connection,
-		configuration: configuration,
-		dbDriverType:  driverType,
-	}, nil
+		connection:   connection,
+		dbDriverType: dbDriverType,
+	}
 }
 
 func getDataSourceForDriverFromConfig(driverType DBDriver, configuration Configuration) (string, error) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -346,7 +346,7 @@ func (storage DBStorage) GetContentForRules(reportRules types.ReportRules) ([]ty
 	}
 
 	if err := rows.Err(); err != nil {
-		log.Error().Err(err).Msg("SQL error while retrieving content for rules")
+		log.Error().Err(err).Msg("SQL rows error while retrieving content for rules")
 		return rules, err
 	}
 

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -556,5 +556,5 @@ func TestDBStorageVoteOnRuleDBCloseError(t *testing.T) {
 	err := mockStorage.VoteOnRule(testdata.ClusterName, testdata.Rule1ID, testUserID, storage.UserVoteNone)
 	helpers.FailOnError(t, err)
 
-	assert.Contains(t, errStr, buf.String())
+	assert.Contains(t, buf.String(), errStr)
 }

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -16,7 +16,9 @@ package storage_test
 
 import (
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/RedHatInsights/insights-results-aggregator/content"
 	"github.com/RedHatInsights/insights-results-aggregator/storage"
@@ -300,4 +302,113 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 			RiskOfChange: 0,
 		},
 	}, res)
+}
+
+func TestDBStorageVoteOnRule(t *testing.T) {
+	for _, vote := range []storage.UserVote{
+		storage.UserVoteDislike, storage.UserVoteLike, storage.UserVoteNone,
+	} {
+		mockStorage := helpers.MustGetMockStorage(t, true)
+
+		helpers.FailOnError(t, mockStorage.VoteOnRule(
+			testClusterName, testRuleID, testUserID, vote,
+		))
+
+		feedback, err := mockStorage.GetUserFeedbackOnRule(testClusterName, testRuleID, testUserID)
+		helpers.FailOnError(t, err)
+
+		assert.Equal(t, testClusterName, feedback.ClusterID)
+		assert.Equal(t, testRuleID, feedback.RuleID)
+		assert.Equal(t, testUserID, feedback.UserID)
+		assert.Equal(t, "", feedback.Message)
+		assert.Equal(t, vote, feedback.UserVote)
+
+		helpers.FailOnError(t, mockStorage.Close())
+	}
+}
+
+func TestDBStorageChangeVote(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	helpers.FailOnError(t, mockStorage.VoteOnRule(
+		testClusterName, testRuleID, testUserID, storage.UserVoteLike,
+	))
+	// just to be sure that addedAt != to updatedAt
+	time.Sleep(1 * time.Millisecond)
+	helpers.FailOnError(t, mockStorage.VoteOnRule(
+		testClusterName, testRuleID, testUserID, storage.UserVoteDislike,
+	))
+
+	feedback, err := mockStorage.GetUserFeedbackOnRule(testClusterName, testRuleID, testUserID)
+	helpers.FailOnError(t, err)
+
+	assert.Equal(t, testClusterName, feedback.ClusterID)
+	assert.Equal(t, testRuleID, feedback.RuleID)
+	assert.Equal(t, testUserID, feedback.UserID)
+	assert.Equal(t, "", feedback.Message)
+	assert.Equal(t, storage.UserVoteDislike, feedback.UserVote)
+	assert.NotEqual(t, feedback.AddedAt, feedback.UpdatedAt)
+}
+
+func TestDBStorageTextFeedback(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	helpers.FailOnError(t, mockStorage.AddOrUpdateFeedbackOnRule(
+		testClusterName, testRuleID, testUserID, "test feedback",
+	))
+
+	feedback, err := mockStorage.GetUserFeedbackOnRule(testClusterName, testRuleID, testUserID)
+	helpers.FailOnError(t, err)
+
+	assert.Equal(t, testClusterName, feedback.ClusterID)
+	assert.Equal(t, testRuleID, feedback.RuleID)
+	assert.Equal(t, testUserID, feedback.UserID)
+	assert.Equal(t, "test feedback", feedback.Message)
+	assert.Equal(t, storage.UserVoteNone, feedback.UserVote)
+}
+
+func TestDBStorageFeedbackChangeMessage(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	helpers.FailOnError(t, mockStorage.AddOrUpdateFeedbackOnRule(
+		testClusterName, testRuleID, testUserID, "message1",
+	))
+	// just to be sure that addedAt != to updatedAt
+	time.Sleep(1 * time.Millisecond)
+	helpers.FailOnError(t, mockStorage.AddOrUpdateFeedbackOnRule(
+		testClusterName, testRuleID, testUserID, "message2",
+	))
+
+	feedback, err := mockStorage.GetUserFeedbackOnRule(testClusterName, testRuleID, testUserID)
+	helpers.FailOnError(t, err)
+
+	assert.Equal(t, testClusterName, feedback.ClusterID)
+	assert.Equal(t, testRuleID, feedback.RuleID)
+	assert.Equal(t, testUserID, feedback.UserID)
+	assert.Equal(t, "message2", feedback.Message)
+	assert.Equal(t, storage.UserVoteNone, feedback.UserVote)
+	assert.NotEqual(t, feedback.AddedAt, feedback.UpdatedAt)
+}
+
+func TestDBStorageFeedbackErrorItemNotFound(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	_, err := mockStorage.GetUserFeedbackOnRule(testClusterName, testRuleID, testUserID)
+	if _, ok := err.(*storage.ItemNotFoundError); err == nil || !ok {
+		t.Fatalf("expected ItemNotFoundError, got %T, %+v", err, err)
+	}
+}
+
+func TestDBStorageFeedbackErrorDBError(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	helpers.MustCloseStorage(t, mockStorage)
+
+	_, err := mockStorage.GetUserFeedbackOnRule(testClusterName, testRuleID, testUserID)
+	if err == nil || !strings.Contains(err.Error(), "database is closed") {
+		t.Fatalf("expected sql database is closed error, got %T, %+v", err, err)
+	}
 }

--- a/tests/helpers/errors.go
+++ b/tests/helpers/errors.go
@@ -16,11 +16,13 @@ package helpers
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // FailOnError wraps result of function with one argument
 func FailOnError(t *testing.T, err error) {
-	if err != nil {
-		t.Fatal(err)
-	}
+	// TODO: get rid of this function at all
+	// TODO: and replace all occurences with assert.NoError and assert.NoErrorf
+	assert.NoError(t, err)
 }

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -17,6 +17,8 @@ package helpers
 import (
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+
 	"github.com/RedHatInsights/insights-results-aggregator/storage"
 )
 
@@ -55,4 +57,14 @@ func MustGetMockStorage(t *testing.T, init bool) storage.Storage {
 // MustCloseStorage closes storage and panics if it wasn't successful
 func MustCloseStorage(t *testing.T, s storage.Storage) {
 	FailOnError(t, s.Close())
+}
+
+// MustGetMockStorageWithExpects returns mock db storage
+// with a driver "github.com/DATA-DOG/go-sqlmock" which requires you to write expect
+// before each query, so first try to use MustGetMockStorage
+func MustGetMockStorageWithExpects(t *testing.T) (storage.Storage, sqlmock.Sqlmock) {
+	connection, expects, err := sqlmock.New()
+	FailOnError(t, err)
+
+	return storage.NewFromConnection(connection, storage.DBDriverGeneral), expects
 }

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -62,11 +62,23 @@ func MustCloseStorage(t *testing.T, s storage.Storage) {
 // MustGetMockStorageWithExpects returns mock db storage
 // with a driver "github.com/DATA-DOG/go-sqlmock" which requires you to write expect
 // before each query, so first try to use MustGetMockStorage
+// don't forget to call MustCloseMockStorageWithExpects
 func MustGetMockStorageWithExpects(t *testing.T) (storage.Storage, sqlmock.Sqlmock) {
+	return MustGetMockStorageWithExpectsForDriver(t, storage.DBDriverGeneral)
+}
+
+// MustGetMockStorageWithExpectsForDriver returns mock db storage
+// with specified driver type and
+// with a driver "github.com/DATA-DOG/go-sqlmock" which requires you to write expect
+// before each query, so first try to use MustGetMockStorage
+// don't forget to call MustCloseMockStorageWithExpects
+func MustGetMockStorageWithExpectsForDriver(
+	t *testing.T, driverType storage.DBDriver,
+) (storage.Storage, sqlmock.Sqlmock) {
 	connection, expects, err := sqlmock.New()
 	FailOnError(t, err)
 
-	return storage.NewFromConnection(connection, storage.DBDriverGeneral), expects
+	return storage.NewFromConnection(connection, driverType), expects
 }
 
 // MustCloseMockStorageWithExpects closes mock storage with expects and panics if it wasn't successful

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -68,3 +68,15 @@ func MustGetMockStorageWithExpects(t *testing.T) (storage.Storage, sqlmock.Sqlmo
 
 	return storage.NewFromConnection(connection, storage.DBDriverGeneral), expects
 }
+
+// MustCloseMockStorageWithExpects closes mock storage with expects and panics if it wasn't successful
+func MustCloseMockStorageWithExpects(
+	t *testing.T, mockStorage storage.Storage, expects sqlmock.Sqlmock,
+) {
+	if err := expects.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+
+	expects.ExpectClose()
+	FailOnError(t, mockStorage.Close())
+}

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -146,7 +146,7 @@ var (
 	"info": []
 }
 `)
-	// "last_checked_at": "` + LastCheckedAt.Format(time.RFC3339Nano) + `"
+
 	Report3RulesExpectedResponse = `
 {
   "report": {


### PR DESCRIPTION
# Description

Covered almost everything expect sql.open(it seems to be too tricky) and statement.close(because of possible bug in Go https://github.com/golang/go/issues/37973)

Fixes #341
Fixes #344
Fixes #345 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

`make before_commit`