### PR TITLE
Added IsLocalInstance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
 debug = true
 auth = true
+auth_type = "xrh"
 ```
 
 * `address` is host and port which server should listen to
@@ -140,6 +141,7 @@ auth = true
 * `api_spec_file` is the location of a required OpenAPI specifications file
 * `debug` is developer mode that enables some special API endpoints not used on production
 * `auth` turns on or turns authentication
+* `auth_type` set type of auth, it means which header to use for auth `x-rh-identity` or `Authorization`. Can be used only with `auth = true`. Possible options: `jwt`, `xrh`
 
 ## Local setup
 

--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,7 @@ api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
 debug = true
 auth = false
+auth_type = "xrh"
 
 [storage]
 db_driver = "sqlite3"

--- a/server/auth.go
+++ b/server/auth.go
@@ -71,7 +71,7 @@ func (server *HTTPServer) Authentication(next http.Handler, noAuthURLs []string)
 		}
 		var tokenHeader string
 		// In case of testing on local machine we don't take x-rh-identity header, but instead Authorization with JWT token in it
-		if server.Config.Debug {
+		if server.Config.AuthType == "jwt" {
 			tokenHeader = r.Header.Get("Authorization") //Grab the token from the header
 			splitted := strings.Split(tokenHeader, " ") //The token normally comes in format `Bearer {token-body}`, we check if the retrieved token matched this requirement
 			if len(splitted) != 2 {
@@ -100,7 +100,7 @@ func (server *HTTPServer) Authentication(next http.Handler, noAuthURLs []string)
 		tk := &Token{}
 
 		// If we took JWT token, it has different structure then x-rh-identity
-		if server.Config.Debug {
+		if server.Config.AuthType == "jwt" {
 			jwt := &JWTPayload{}
 			err = json.Unmarshal([]byte(decoded), jwt)
 			if err != nil { //Malformed token, returns with http code 403 as usual

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -29,6 +29,7 @@ var configAuth = server.Configuration{
 	APIPrefix: "/api/test/",
 	Debug:     false,
 	Auth:      true,
+	AuthType:  "xrh",
 }
 
 var configAuth2 = server.Configuration{
@@ -36,6 +37,7 @@ var configAuth2 = server.Configuration{
 	APIPrefix: "/api/test/",
 	Debug:     true,
 	Auth:      true,
+	AuthType:  "jwt",
 }
 
 // TestMissingAuthToken checks how the missing auth. token header (expected in HTTP request) is handled

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -23,4 +23,5 @@ type Configuration struct {
 	APISpecFile string `mapstructure:"api_spec_file" toml:"api_spec_file"`
 	Debug       bool   `mapstructure:"debug" toml:"debug"`
 	Auth        bool   `mapstructure:"auth" toml:"auth"`
+	AuthType    string `mapstructure:"auth_type" toml:"auth_type"`
 }


### PR DESCRIPTION
# Description

Replaced `debug` option with `is_local_instance` to define which auth header to use.

Fixes https://github.com/RedHatInsights/insights-results-aggregator/issues/394

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Just run with `is_local_instance = true`
