### PR TITLE
Discard older/outdated reports

### DIFF
--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -233,6 +233,10 @@ func TestDBStorageWriteReportForClusterFakePostgresOK(t *testing.T) {
 	mockStorage, expects := helpers.MustGetMockStorageWithExpectsForDriver(t, storage.DBDriverPostgres)
 	defer helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
 
+	expects.ExpectQuery(`SELECT last_checked_at FROM report`).
+		WillReturnRows(expects.NewRows([]string{"last_checked_at"})).
+		RowsWillBeClosed()
+
 	expects.ExpectPrepare("INSERT INTO report").
 		WillBeClosed().
 		ExpectExec().


### PR DESCRIPTION
# Description

If a consumed report has an older timestamp than one that's already present in the database, log a warning and throw it away. Only the report with the newest timestamp will be kept in the database and an older one will not be able to replace it.

Fixes #352

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing steps

`make before_commit`