### PR TITLE
Incorporate abc metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ goconst: ## Run goconst checker
 	@echo "Running goconst checker"
 	./goconst.sh
 
-style: fmt vet lint cyclo shellcheck errcheck goconst ineffassign ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
+abcgo: ## Run ABC metrics checker
+	@echo "Run ABC metrics checker"
+	./abcgo.sh
+
+style: fmt vet lint cyclo shellcheck errcheck goconst ineffassign abcgo ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
 
 run: clean build ## Build the project and executes the binary
 	./insights-results-aggregator

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ To run REST API tests use the following command:
 * `ineffassign` to detect and print all ineffectual assignments in Go code
 * `errcheck` for checking for all unchecked errors in go programs
 * `shellcheck` to perform static analysis for all shell scripts used in this repository
+* `abcgo` to measure ABC metrics for Go source code and check if the metrics does not exceed specified threshold
 
 Please note that all checks mentioned above have to pass for the change to be merged into master branch.
 

--- a/abcgo.sh
+++ b/abcgo.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+go get -u github.com/droptheplot/abcgo
+
+echo -e "${BLUE}ABC metric${NC}"
+abcgo -path .
+
+threshold=40
+echo -e "${BLUE}Functions with ABC metrics greater than ${threshold}${NC}:"
+
+if [[ $(abcgo -path . -sort -format raw | awk "\$4>${threshold}" | tee /dev/tty | wc -l) -ne 0 ]]
+then
+    echo -e "${RED}Functions with too high ABC metrics detected!${NC}"
+    exit 1
+else
+    echo -e "${GREEN}ABC metrics is ok for all functions in all packages${NC}"
+    exit 0
+fi
+


### PR DESCRIPTION
# Description

Incorporate ABC metrics + check for threshold into CI

Fixes #402

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

Can be run locally by using `make abcgo`. Please see `make help`.