### PR TITLE
[PoC] Monkey patching sarama functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run: clean build ## Build the project and executes the binary
 	./insights-results-aggregator
 
 test: clean build ## Run the unit tests
-	@go test -coverprofile coverage.out $(shell go list ./... | grep -v tests)
+	@go test -gcflags -l -coverprofile coverage.out $(shell go list ./... | grep -v tests)
 
 integration_tests: ## Run all integration tests
 	@echo "Running all integration tests"

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/RedHatInsights/insights-results-aggregator/tests/testdata"
 
+	"bou.ke/monkey"
 	"github.com/Shopify/sarama"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/stretchr/testify/assert"
@@ -377,6 +378,17 @@ func TestKafkaConsumer_New_MockBroker(t *testing.T) {
 		defer mockBroker.MustClose(t)
 		defer helpers.MustCloseConsumer(t, mockConsumer)
 	}, testCaseTimeLimit)
+}
+
+func TestMonkeyPatch(t *testing.T) {
+	guard := monkey.Patch(sarama.NewClient, helpers.NewMockClient)
+	defer guard.Unpatch()
+
+	consumer, err := consumer.NewWithSaramaConfig(broker.Configuration{}, nil, nil, false)
+
+	if consumer != nil || err == nil {
+		t.Fatal("WTF!")
+	}
 }
 
 func TestKafkaConsumer_New_MockBrokerNoTopicError(t *testing.T) {

--- a/tests/helpers/sarama_mocks.go
+++ b/tests/helpers/sarama_mocks.go
@@ -1,0 +1,16 @@
+package helpers
+
+import (
+	"errors"
+
+	"github.com/Shopify/sarama"
+)
+
+// func NewConsumerFromClient(client Client) (Consumer, error)
+func NewMockConsumerFromClient(client sarama.Client) (sarama.Consumer, error) {
+	return nil, errors.New("Monkey patched!!")
+}
+
+func NewMockClient(addrs []string, conf *sarama.Config) (sarama.Client, error) {
+	return nil, errors.New("Money patched!!")
+}


### PR DESCRIPTION
# Description

Please, don't merge this PR yet. It is a prove of concept about using monkey patching for sarama library.
With monkey patches we can be able to substitute any `sarama` function (well, any Go function) and use a mocked version that returns whatever we want.

If you find this useful, I could write some utility methods that allow to set "expectations" instead of writing mock methods for every usage of every function, because it won't scale.

I have some concerns about using this "monkey" library due to some comments that I have read, for example:

> github.com/bouk/monkey makes assumptions about the structure of the compiled code that are not at all guaranteed by the language spec, so you should not expect it to continue to work in general.
[Source](https://github.com/golang/go/issues/27708#issuecomment-421997870).

If you agree and we can live with these cons, I will go ahead and start to add new utilities to being able to mock almost every function we want with expectations, if needed.

## Type of change
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
I needed to add the `-gcflag` for running tests because monkey package doesn't work well with enabled inlining.