### PR TITLE
Put WriteReport function into transaction

### DIFF
--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -233,14 +233,16 @@ func TestDBStorageWriteReportForClusterFakePostgresOK(t *testing.T) {
 	mockStorage, expects := helpers.MustGetMockStorageWithExpectsForDriver(t, storage.DBDriverPostgres)
 	defer helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
 
+	expects.ExpectBegin()
+
 	expects.ExpectQuery(`SELECT last_checked_at FROM report`).
 		WillReturnRows(expects.NewRows([]string{"last_checked_at"})).
 		RowsWillBeClosed()
 
-	expects.ExpectPrepare("INSERT INTO report").
-		WillBeClosed().
-		ExpectExec().
+	expects.ExpectExec("INSERT INTO report").
 		WillReturnResult(driver.ResultNoRows)
+
+	expects.ExpectCommit()
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.LastCheckedAt,


### PR DESCRIPTION
# Description

To avoid any mysterious race conditions in the future, I put the whole WriterReportForCluster into a DB transaction.

In order for this to be possible without a ton of rollback/commit logic, I had to remove the prepared SQL statement which was used for the actual upsert query. I belive this shouldn't have much of an impact on performance as the statement was executed just once per prepare anyways.

*Edit: We should now be at a total 90% test coverage.*

## Type of change

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)

## Testing steps

`make before_commit` expect the OpenAPI check still keeps on crashing (see #409), but that should be totaly unrelated.
