### PR TITLE
add a way to update local rules content for testing purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config_my.toml
 coverage.out
 aggregator
 rest-api-tests
+rules-content

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ rest_api_tests: ## Run REST API tests
 	@echo "Running REST API tests"
 	@./test.sh rest_api
 
+rules_content: ## Update tests/content/ok directory with latest rules content
+	./update_rules_content.sh
+
 sqlite_db:
 	mv aggregator.db aggragator.db.backup
 	local_storage/create_database_sqlite.sh

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -21,10 +21,10 @@ function clean_up() {
 trap clean_up EXIT
 
 RULES_REPO="https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp.git"
-CONTENT_DIR="$( cd "$(dirname "$0")" && pwd )/tests/content"
-OK_RULES_DIR="${CONTENT_DIR}/ok"
+SCRIPT_DIR="$(dirname $(realpath $0))"
+CONTENT_DIR="${SCRIPT_DIR}/rules-content"
 
-CLONE_TEMP_DIR="${CONTENT_DIR}/tmp"
+CLONE_TEMP_DIR="${SCRIPT_DIR}/.tmp"
 EXTERNAL_RULES_CONTENT="${CLONE_TEMP_DIR}/content/external/rules/"
 RULES_CONFIG="${CLONE_TEMP_DIR}/content/config.yaml"
 
@@ -37,7 +37,7 @@ then
     exit 1
 fi
 
-rm -rf "$OK_RULES_DIR"
+rm -rf "${CONTENT_DIR}"
 
 if [ $? -ne 0 ]
 then
@@ -45,7 +45,7 @@ then
     exit 1
 fi
 
-mv "${EXTERNAL_RULES_CONTENT}" "${OK_RULES_DIR}" && mv "${RULES_CONFIG}" "${OK_RULES_DIR}"
+mv "${EXTERNAL_RULES_CONTENT}" "${CONTENT_DIR}" && mv "${RULES_CONFIG}" "${CONTENT_DIR}"
 
 if [ $? -ne 0 ]
 then
@@ -55,5 +55,5 @@ fi
 
 rm -rf "${CLONE_TEMP_DIR}"
 
-echo "tests/content/ok/ updated with latest rules"
+echo "${CONTENT_DIR} updated with latest rules"
 exit 0

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Updates the ./tests/content/ok/ directory with the latest rules to test against
+
+function clean_up() {
+    rm -rf "$CLONE_TEMP_DIR"
+}
+trap clean_up EXIT
+
+RULES_REPO="https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp.git"
+CONTENT_DIR="$( cd "$(dirname "$0")" && pwd )/tests/content"
+OK_RULES_DIR="${CONTENT_DIR}/ok"
+
+CLONE_TEMP_DIR="${CONTENT_DIR}/tmp"
+EXTERNAL_RULES_CONTENT="${CLONE_TEMP_DIR}/content/external/rules/"
+RULES_CONFIG="${CLONE_TEMP_DIR}/content/config.yaml"
+
+echo "Attempting to clone repository into ${CLONE_TEMP_DIR}"
+
+git clone "${RULES_REPO}" "${CLONE_TEMP_DIR}"
+if [ $? -ne 0 ]
+then
+    echo "Couldn't clone rules repository"
+    exit 1
+fi
+
+rm -rf "$OK_RULES_DIR"
+
+if [ $? -ne 0 ]
+then
+    echo "Couldn't remove previous content"
+    exit 1
+fi
+
+mv "${EXTERNAL_RULES_CONTENT}" "${OK_RULES_DIR}" && mv "${RULES_CONFIG}" "${OK_RULES_DIR}"
+
+if [ $? -ne 0 ]
+then
+    echo "Couldn't move rules content from cloned repository"
+    exit 1
+fi
+
+rm -rf "${CLONE_TEMP_DIR}"
+
+echo "tests/content/ok/ updated with latest rules"
+exit 0


### PR DESCRIPTION
# Description
I added a very simple (I'd like to say dumb) script that updates the `./tests/content/ok` directory with rules currently present in the [rules content directory](https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp/tree/master/content/external/rules).

This is just for local use as of now, you need to be in VPN to access that repo... so it's far from perfect, but you can use this to quickly test against real rules and with modifying the `INSIGHTS_RESULTS_AGGREGATOR__CONTENT__PATH` to use normally.

Right now, I'm not including the new content in the OK directory, because the rules parser currently needs some changes -- see #417 , but it can be used by @natiiix or whoever will work on that to test this.

The script also copies the content configuration file `config.yaml` needed to work on that task.

pls let me know if you have a better solution, I didnt want to spend too much time on it

Fixes #419

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Testing steps
`make before_commit` without updating the rules.
