### PR TITLE
Gosec on ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,15 @@ goconst: ## Run goconst checker
 	@echo "Running goconst checker"
 	./goconst.sh
 
+gosec: ## Run gosec checker
+	@echo "Running gosec checker"
+	./gosec.sh
+
 abcgo: ## Run ABC metrics checker
 	@echo "Run ABC metrics checker"
 	./abcgo.sh
 
-style: fmt vet lint cyclo shellcheck errcheck goconst ineffassign abcgo ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
+style: fmt vet lint cyclo shellcheck errcheck goconst gosec ineffassign abcgo ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
 
 run: clean build ## Build the project and executes the binary
 	./insights-results-aggregator

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ To run REST API tests use the following command:
 * `golint` as a linter for all Go sources stored in this repository
 * `gocyclo` to report all functions and methods with too high cyclomatic complexity. The cyclomatic complexity of a function is calculated according to the following rules: 1 is the base complexity of a function +1 for each 'if', 'for', 'case', '&&' or '||' Go Report Card warns on functions with cyclomatic complexity > 9
 * `goconst` to find repeated strings that could be replaced by a constant
+* `gosec` to inspect source code for security problems by scanning the Go AST
 * `ineffassign` to detect and print all ineffectual assignments in Go code
 * `errcheck` for checking for all unchecked errors in go programs
 * `shellcheck` to perform static analysis for all shell scripts used in this repository

--- a/content/content.go
+++ b/content/content.go
@@ -68,6 +68,7 @@ type RuleContentDirectory map[string]RuleContent
 func readFilesIntoByteArrayPointers(baseDir string, fileMap map[string]*[]byte) error {
 	for name, ptr := range fileMap {
 		var err error
+		// #nosec G304
 		*ptr, err = ioutil.ReadFile(path.Join(baseDir, name))
 		if err != nil {
 			return err

--- a/gosec.sh
+++ b/gosec.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+cd "$(dirname "$0")" || exit
+
+echo -e "${BLUE}Security issues detection${NC}"
+
+go get github.com/securego/gosec/cmd/gosec
+
+if ! gosec ./...
+then
+    echo -e "${RED}Potential security issues detected!${NC}"
+    exit 1
+else
+    echo -e "${GREEN}No potential security issues has been detected${NC}"
+    exit 0
+fi

--- a/server/auth.go
+++ b/server/auth.go
@@ -34,7 +34,8 @@ type contextKey string
 
 const (
 	// ContextKeyUser is a constant for user authentication token in request
-	ContextKeyUser        = contextKey("user")
+	ContextKeyUser = contextKey("user")
+	// #nosec G101
 	malformedTokenMessage = "Malformed authentication token"
 )
 


### PR DESCRIPTION
# Description

Run gosec on CI

Fixes #401 

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

It can be started locally by using `make gosec`