### PR TITLE
Auth in REST API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ auth_type = "xrh"
 * `auth` turns on or turns authentication
 * `auth_type` set type of auth, it means which header to use for auth `x-rh-identity` or `Authorization`. Can be used only with `auth = true`. Possible options: `jwt`, `xrh`
 
-Please note that if `auth` is turned off, not all REST API endpoints will be usable. Whole REST API schema is satisfied only for `auth = true`.
+Please note that if `auth` configuration option is turned off, not all REST API endpoints will be usable. Whole REST API schema is satisfied only for `auth = true`.
 
 ## Local setup
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ auth_type = "xrh"
 * `auth` turns on or turns authentication
 * `auth_type` set type of auth, it means which header to use for auth `x-rh-identity` or `Authorization`. Can be used only with `auth = true`. Possible options: `jwt`, `xrh`
 
+Please note that if `auth` is turned off, not all REST API endpoints will be usable. Whole REST API schema is satisfied only for `auth = true`.
+
 ## Local setup
 
 There is a `docker-compose` configuration that provisions a minimal stack of Insight Platform and

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -247,6 +247,7 @@ func TestLoadConfigurationFromFile(t *testing.T) {
 		Address:     ":8080",
 		APIPrefix:   "/api/v1/",
 		APISpecFile: "openapi.json",
+		AuthType:    "xrh",
 		Debug:       true,
 	}, main.GetServerConfiguration())
 
@@ -340,6 +341,7 @@ func TestLoadConfigurationFromEnv(t *testing.T) {
 		Address:     ":8080",
 		APIPrefix:   "/api/v1/",
 		APISpecFile: "openapi.json",
+		AuthType:    "xrh",
 		Debug:       true,
 	}, main.GetServerConfiguration())
 

--- a/server/server.go
+++ b/server/server.go
@@ -374,6 +374,8 @@ func (server *HTTPServer) Initialize(address string) http.Handler {
 		noAuthURLs := []string{
 			metricsURL,
 			openAPIURL,
+			metricsURL + "?", // to be able to test using Frisby
+			openAPIURL + "?", // to be able to test using Frisby
 		}
 		router.Use(func(next http.Handler) http.Handler { return server.Authentication(next, noAuthURLs) })
 	}

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -21,6 +21,7 @@ address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
 auth = false
+auth_type = "xrh"
 
 [storage]
 db_driver = "sqlite3"

--- a/tests/rest/organizations.go
+++ b/tests/rest/organizations.go
@@ -66,6 +66,7 @@ func contentSizeForOrganizationResponse(orgIDs ...int) int {
 // checkOrganizationsEndpointWithPostfix checks if the end point to return list of organizations responds correctly to HTTP GET command
 func checkOrganizationsEndpointWithPostfix(postfix string) {
 	f := frisby.Create("Check the end point to return list of organizations by HTTP GET method").Get(apiURL + "organizations" + postfix)
+	setAuthHeader(f)
 	f.Send()
 	f.ExpectStatus(200)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)

--- a/tests/rest/reports.go
+++ b/tests/rest/reports.go
@@ -30,6 +30,7 @@ func constructURLForReportForOrgCluster(organizationID string, clusterID string)
 func checkReportEndpointForKnownOrganizationAndKnownCluster() {
 	url := constructURLForReportForOrgCluster("1", knownClusterForOrganization1)
 	f := frisby.Create("Check the end point to return report for existing organization and cluster ID").Get(url)
+	setAuthHeader(f)
 	f.Send()
 	f.ExpectStatus(200)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -40,6 +41,7 @@ func checkReportEndpointForKnownOrganizationAndKnownCluster() {
 func checkReportEndpointForKnownOrganizationAndUnknownCluster() {
 	url := constructURLForReportForOrgCluster("1", unknownClusterForOrganization1)
 	f := frisby.Create("Check the end point to return report for existing organization and non-existing cluster ID").Get(url)
+	setAuthHeader(f)
 	f.Send()
 	f.ExpectStatus(404)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -50,6 +52,7 @@ func checkReportEndpointForKnownOrganizationAndUnknownCluster() {
 func checkReportEndpointForUnknownOrganizationAndKnownCluster() {
 	url := constructURLForReportForOrgCluster("100000", knownClusterForOrganization1)
 	f := frisby.Create("Check the end point to return report for non-existing organization and non-existing cluster ID").Get(url)
+	setAuthHeaderForOrganization(f, 100000)
 	f.Send()
 	f.ExpectStatus(404)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -60,6 +63,7 @@ func checkReportEndpointForUnknownOrganizationAndKnownCluster() {
 func checkReportEndpointForUnknownOrganizationAndUnknownCluster() {
 	url := constructURLForReportForOrgCluster("100000", unknownClusterForOrganization1)
 	f := frisby.Create("Check the end point to return report for non-existing organization and non-existing cluster ID").Get(url)
+	setAuthHeaderForOrganization(f, 100000)
 	f.Send()
 	f.ExpectStatus(404)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -70,6 +74,7 @@ func checkReportEndpointForUnknownOrganizationAndUnknownCluster() {
 func reproducerForIssue384() {
 	url := constructURLForReportForOrgCluster("000000000000000000000000000000000000", "1")
 	f := frisby.Create("Reproducer for issue #384 (https://github.com/RedHatInsights/insights-results-aggregator/issues/384)").Get(url)
+	setAuthHeader(f)
 	f.Send()
 	f.ExpectStatus(400)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
@@ -80,6 +85,7 @@ func reproducerForIssue384() {
 func checkReportEndpointForImproperOrganization() {
 	url := constructURLForReportForOrgCluster("foobar", knownClusterForOrganization1)
 	f := frisby.Create("Check the end point to return report for improper organization").Get(url)
+	setAuthHeader(f)
 	f.Send()
 	f.ExpectStatus(400)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -16,7 +16,8 @@ address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
 debug = true
-auth = false
+auth = true
+auth_type = "xrh"
 
 [storage]
 db_driver = "sqlite3"


### PR DESCRIPTION
# Description

Auth. in all REST API tests.

Fixes #431

## Type of change

- REST API tests
- Documentation update

## Testing steps

Run `make rest_api_tests` as usual.