### PR TITLE
Fix issues 357 358 359

### DIFF
--- a/local_storage/test_data_sqlite.sql
+++ b/local_storage/test_data_sqlite.sql
@@ -23,3 +23,10 @@ insert into report (org_id, cluster, report, reported_at, last_checked_at) value
 insert into report (org_id, cluster, report, reported_at, last_checked_at) values (3, 'addddddd-0000-0000-0000-000000000000', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 insert into report (org_id, cluster, report, reported_at, last_checked_at) values (4, 'addddddd-bbbb-0000-0000-000000000000', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 insert into report (org_id, cluster, report, reported_at, last_checked_at) values (4, 'addddddd-bbbb-cccc-0000-000000000000', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+delete from rule;
+insert into rule(module, name, summary, reason, resolution, more_info) values ('foo', 'foo', 'summary', 'reason', 'resolution', 'more info');
+insert into rule(module, name, summary, reason, resolution, more_info) values ('bar', 'bar', 'summary', 'reason', 'resolution', 'more info');
+insert into rule(module, name, summary, reason, resolution, more_info) values ('xyzzy', 'xyzzy', 'summary', 'reason', 'resolution', 'more info');
+
+delete from cluster_rule_user_feedback;

--- a/test.sh
+++ b/test.sh
@@ -86,9 +86,11 @@ function start_service() {
 function test_rest_api() {
 	start_service
 	# Retry populating the database with mock data N times.
+        # Wait 2 seconds between the retry starts to settle down
 	# Wait 1 second between attempts.
 	# Without this, the DB could be locked because
 	# the migrations have not yet finished.
+	sleep 2
 	for i in {1..5}
 	do
 		populate_db_with_mock_data 2> /dev/null && break || sleep 1

--- a/tests/rest/rule_vote.go
+++ b/tests/rest/rule_vote.go
@@ -131,20 +131,16 @@ func checkItemNotFound(url string, message string) {
 
 // reproducerForIssue385 checks whether the issue https://github.com/RedHatInsights/insights-results-aggregator/issues/385 has been fixed
 func reproducerForIssue385() {
-	url := constructURLVoteForRule("000000000000000000000000000000000000", 0)
-	f := frisby.Create("Reproducer for issue #385 (https://github.com/RedHatInsights/insights-results-aggregator/issues/385)").Put(url)
-	setAuthHeader(f)
-	f.Send()
-	f.ExpectStatus(400)
-	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+	const message = "Reproducer for issue #385 (https://github.com/RedHatInsights/insights-results-aggregator/issues/385)"
+	// vote
+	url := constructURLVoteForRule(improperClusterID, anyRule)
+	checkInvalidUUIDFormat(url, message)
 
-	statusResponse := readStatusFromResponse(f)
-	if statusResponse.Status == "ok" {
-		f.AddError(fmt.Sprintf("Expected error status, but got '%s' instead", statusResponse.Status))
-	}
-	if !strings.Contains(statusResponse.Status, "Error: 'invalid UUID format'") {
-		f.AddError("Unexpected error reported")
-	}
+	// unvote
+	url = constructURLUnvoteForRule(improperClusterID, anyRule)
+	checkInvalidUUIDFormat(url, message)
 
-	f.PrintReport()
+	// reset vote
+	url = constructURLResetVoteForRule(improperClusterID, anyRule)
+	checkInvalidUUIDFormat(url, message)
 }

--- a/tests/rest/rule_vote.go
+++ b/tests/rest/rule_vote.go
@@ -144,3 +144,139 @@ func reproducerForIssue385() {
 	url = constructURLResetVoteForRule(improperClusterID, anyRule)
 	checkInvalidUUIDFormat(url, message)
 }
+
+// test the specified rule vote/unvote/reset REST API endpoint by using selected checker function
+func testRuleVoteAPIendpoint(clusters []string, rules []string, message string, urlConstructor func(string, string) string, checker func(string, string)) {
+	for _, cluster := range clusters {
+		for _, rule := range rules {
+			url := urlConstructor(cluster, rule)
+			checker(url, message)
+		}
+	}
+}
+
+// checkLikeKnownRuleForKnownCluster tests whether 'like' REST API endpoint works correctly for known rule and known cluster
+func checkLikeKnownRuleForKnownCluster() {
+	testRuleVoteAPIendpoint(knownClustersForOrganization1, knownRules,
+		"Test whether 'like' REST API endpoint works correctly for known rule and known cluster",
+		constructURLVoteForRule, checkOkStatus)
+}
+
+// checkDislikeKnownRuleForKnownCluster tests whether 'dislike' REST API endpoint works correctly for known rule and known cluster
+func checkDislikeKnownRuleForKnownCluster() {
+	testRuleVoteAPIendpoint(knownClustersForOrganization1, knownRules,
+		"Test whether 'dislike' REST API endpoint works correctly for known rule and known cluster",
+		constructURLUnvoteForRule, checkOkStatus)
+}
+
+// checkResetKnownRuleForKnownCluster tests whether 'reset vote' REST API endpoint works correctly for known rule and known cluster
+func checkResetKnownRuleForKnownCluster() {
+	testRuleVoteAPIendpoint(knownClustersForOrganization1, knownRules,
+		"Test whether 'reset vote' REST API endpoint works correctly for known rule and known cluster",
+		constructURLResetVoteForRule, checkOkStatus)
+}
+
+// checkLikeKnownRuleForUnknownCluster tests whether 'like' REST API endpoint works correctly for unknown rule and unknown cluster
+func checkLikeKnownRuleForUnknownCluster() {
+	testRuleVoteAPIendpoint(unknownClusters, knownRules,
+		"Test whether 'like' REST API endpoint works correctly for known rule and unknown cluster",
+		constructURLVoteForRule, checkItemNotFound)
+}
+
+// checkDislikeKnownRuleForUnknownCluster tests whether 'dislike' REST API endpoint works correctly for unknown rule and unknown cluster
+func checkDislikeKnownRuleForUnknownCluster() {
+	testRuleVoteAPIendpoint(unknownClusters, knownRules,
+		"Test whether 'dislike' REST API endpoint works correctly for known rule and unknown cluster",
+		constructURLUnvoteForRule, checkItemNotFound)
+}
+
+// checkResetKnownRuleForUnknownCluster tests whether 'reset vote' REST API endpoint works correctly for unknown rule and unknown cluster
+func checkResetKnownRuleForUnknownCluster() {
+	testRuleVoteAPIendpoint(unknownClusters, knownRules,
+		"Test whether 'reset vote' REST API endpoint works correctly for known rule and unknown cluster",
+		constructURLResetVoteForRule, checkItemNotFound)
+}
+
+// checkLikeKnownRuleForImproperCluster tests whether 'like' REST API endpoint works correctly for known rule and improper cluster id
+func checkLikeKnownRuleForImproperCluster() {
+	testRuleVoteAPIendpoint(improperClusterIDs, knownRules,
+		"Test whether 'like' REST API endpoint works correctly for known rule and improper cluster ID",
+		constructURLVoteForRule, checkInvalidUUIDFormat)
+}
+
+// checkDislikeKnownRuleForImproperCluster tests whether 'dislike' REST API endpoint works correctly for known rule and improper cluster id
+func checkDislikeKnownRuleForImproperCluster() {
+	testRuleVoteAPIendpoint(improperClusterIDs, knownRules,
+		"Test whether 'dilike' REST API endpoint works correctly for known rule and improper cluster ID",
+		constructURLUnvoteForRule, checkInvalidUUIDFormat)
+}
+
+// checkResetKnownRuleForImproperCluster tests whether 'reset vote' REST API endpoint works correctly for known rule and improper cluster id
+func checkResetKnownRuleForImproperCluster() {
+	testRuleVoteAPIendpoint(improperClusterIDs, knownRules,
+		"Test whether 'reset vote' REST API endpoint works correctly for known rule and improper cluster ID",
+		constructURLResetVoteForRule, checkInvalidUUIDFormat)
+}
+
+// checkLikeUnknownRuleForKnownCluster tests whether 'like' REST API endpoint works correctly for unknown rule and known cluster
+func checkLikeUnknownRuleForKnownCluster() {
+	testRuleVoteAPIendpoint(knownClustersForOrganization1, unknownRules,
+		"Test whether 'like' REST API endpoint works correctly for unknown rule and known cluster",
+		constructURLVoteForRule, checkItemNotFound)
+}
+
+// checkDislikeUnknownRuleForKnownCluster tests whether 'dislike' REST API endpoint works correctly for unknown rule and known cluster
+func checkDislikeUnknownRuleForKnownCluster() {
+	testRuleVoteAPIendpoint(knownClustersForOrganization1, unknownRules,
+		"Test whether 'dislike' REST API endpoint works correctly for unknown rule and known cluster",
+		constructURLUnvoteForRule, checkItemNotFound)
+}
+
+// checkResetUnknownRuleForKnownCluster tests whether 'reset vote' REST API endpoint works correctly for unknown rule and known cluster
+func checkResetUnknownRuleForKnownCluster() {
+	testRuleVoteAPIendpoint(knownClustersForOrganization1, unknownRules,
+		"Test whether 'reset vote' REST API endpoint works correctly for unknown rule and known cluster",
+		constructURLResetVoteForRule, checkItemNotFound)
+}
+
+// checkLikeUnknownRuleForUnknownCluster tests whether 'like' REST API endpoint works correctly for unknown rule and unknown cluster
+func checkLikeUnknownRuleForUnknownCluster() {
+	testRuleVoteAPIendpoint(unknownClusters, unknownRules,
+		"Test whether 'like' REST API endpoint works correctly for unknown rule and unknown cluster",
+		constructURLVoteForRule, checkItemNotFound)
+}
+
+// checkDislikeUnknownRuleForUnknownCluster tests whether 'dislike' REST API endpoint works correctly for unknown rule and unknown cluster
+func checkDislikeUnknownRuleForUnknownCluster() {
+	testRuleVoteAPIendpoint(unknownClusters, unknownRules,
+		"Test whether 'dislike' REST API endpoint works correctly for unknown rule and unknown cluster",
+		constructURLUnvoteForRule, checkItemNotFound)
+}
+
+// checkResetUnknownRuleForUnknownCluster tests whether 'reset vote' REST API endpoint works correctly for unknown rule and unknown cluster
+func checkResetUnknownRuleForUnknownCluster() {
+	testRuleVoteAPIendpoint(unknownClusters, unknownRules,
+		"Test whether 'reset vote' REST API endpoint works correctly for unknown rule and unknown cluster",
+		constructURLResetVoteForRule, checkItemNotFound)
+}
+
+// checkLikeUnknownRuleForImproperCluster tests whether 'like' REST API endpoint works correctly for unknown rule and improper cluster id
+func checkLikeUnknownRuleForImproperCluster() {
+	testRuleVoteAPIendpoint(improperClusterIDs, unknownRules,
+		"Test whether 'like' REST API endpoint works correctly for unknown rule and improper cluster ID",
+		constructURLVoteForRule, checkInvalidUUIDFormat)
+}
+
+// checkDislikeUnknownRuleForImproperCluster tests whether 'dislike' REST API endpoint works correctly for unknown rule and improper cluster id
+func checkDislikeUnknownRuleForImproperCluster() {
+	testRuleVoteAPIendpoint(improperClusterIDs, unknownRules,
+		"Test whether 'dilike' REST API endpoint works correctly for unknown rule and improper cluster ID",
+		constructURLUnvoteForRule, checkInvalidUUIDFormat)
+}
+
+// checkResetUnknownRuleForImproperCluster tests whether 'reset vote' REST API endpoint works correctly for unknown rule and improper cluster id
+func checkResetUnknownRuleForImproperCluster() {
+	testRuleVoteAPIendpoint(improperClusterIDs, unknownRules,
+		"Test whether 'reset vote' REST API endpoint works correctly for unknown rule and improper cluster ID",
+		constructURLResetVoteForRule, checkInvalidUUIDFormat)
+}

--- a/tests/rest/rule_vote.go
+++ b/tests/rest/rule_vote.go
@@ -29,6 +29,8 @@ const (
 
 	anyRule   = "0" // we don't care
 	knownRule = "foo"
+
+	unexpectedErrorStatusMessage = "Expected error status, but got '%s' instead"
 )
 
 var knownClustersForOrganization1 []string = []string{
@@ -102,7 +104,7 @@ func checkInvalidUUIDFormat(url string, message string) {
 
 	statusResponse := readStatusFromResponse(f)
 	if statusResponse.Status == "ok" {
-		f.AddError(fmt.Sprintf("Expected error status, but got '%s' instead", statusResponse.Status))
+		f.AddError(fmt.Sprintf(unexpectedErrorStatusMessage, statusResponse.Status))
 	}
 	if !strings.Contains(statusResponse.Status, "Error: 'invalid UUID ") {
 		f.AddError(fmt.Sprintf("Unexpected error reported: %v", statusResponse.Status))
@@ -120,7 +122,7 @@ func checkItemNotFound(url string, message string) {
 
 	statusResponse := readStatusFromResponse(f)
 	if statusResponse.Status == "ok" {
-		f.AddError(fmt.Sprintf("Expected error status, but got '%s' instead", statusResponse.Status))
+		f.AddError(fmt.Sprintf(unexpectedErrorStatusMessage, statusResponse.Status))
 	}
 	if !strings.Contains(statusResponse.Status, "was not found in the storage") {
 		f.AddError(fmt.Sprintf("Unexpected error reported: %v", statusResponse.Status))

--- a/tests/rest/rule_vote.go
+++ b/tests/rest/rule_vote.go
@@ -23,8 +23,110 @@ import (
 	"github.com/verdverm/frisby"
 )
 
-func constructURLVoteForRule(clusterID string, ruleID int) string {
-	return fmt.Sprintf("%sclusters/%s/rules/%d/like", apiURL, clusterID, ruleID)
+const (
+	improperClusterID = "000000000000000000000000000000000000"
+	knownCluster      = "00000000-0000-0000-0000-000000000000"
+
+	anyRule   = "0" // we don't care
+	knownRule = "foo"
+)
+
+var knownClustersForOrganization1 []string = []string{
+	"00000000-0000-0000-0000-000000000000",
+	"00000000-0000-0000-ffff-000000000000",
+	"00000000-0000-0000-0000-ffffffffffff",
+}
+
+var unknownClusters []string = []string{
+	"abcdef00-0000-0000-0000-000000000000",
+	"abcdef00-0000-0000-1111-000000000000",
+	"abcdef00-0000-0000-ffff-000000000000",
+}
+
+var improperClusterIDs []string = []string{
+	"xyz",                                   // definitely wrong
+	"00000000-0000-0000-0000-00000000000",   // shorter by one character
+	"0000000-0000-0000-0000-000000000000",   // shorter by one character
+	"00000000-000-0000-0000-000000000000",   // shorter by one character
+	"00000000-0000-000-0000-000000000000",   // shorter by one character
+	"00000000-0000-0000-000-000000000000",   // shorter by one character
+	"00000000-0000-0000-0000-fffffffffffff", // longer by one character
+	"00000000f-0000-0000-0000-ffffffffffff", // longer by one character
+	"00000000-0000f-0000-0000-ffffffffffff", // longer by one character
+	"00000000-0000-0000f-0000-ffffffffffff", // longer by one character
+	"00000000-0000-0000-0000f-ffffffffffff", // longer by one character
+}
+
+var knownRules []string = []string{
+	"foo",
+	"bar",
+	"xyzzy",
+}
+
+var unknownRules []string = []string{
+	"rule1",
+	"rule2",
+	"rule3",
+}
+
+func constructURLVoteForRule(clusterID string, ruleID string) string {
+	return fmt.Sprintf("%sclusters/%s/rules/%s/like", apiURL, clusterID, ruleID)
+}
+
+func constructURLUnvoteForRule(clusterID string, ruleID string) string {
+	return fmt.Sprintf("%sclusters/%s/rules/%s/dislike", apiURL, clusterID, ruleID)
+}
+
+func constructURLResetVoteForRule(clusterID string, ruleID string) string {
+	return fmt.Sprintf("%sclusters/%s/rules/%s/reset_vote", apiURL, clusterID, ruleID)
+}
+
+func checkOkStatus(url string, message string) {
+	f := frisby.Create(message).Put(url)
+	setAuthHeader(f)
+	f.Send()
+	f.ExpectStatus(200)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+	statusResponse := readStatusFromResponse(f)
+	if statusResponse.Status != "ok" {
+		f.AddError(fmt.Sprintf("Expected ok status, but got '%s' instead", statusResponse.Status))
+	}
+}
+
+func checkInvalidUUIDFormat(url string, message string) {
+	f := frisby.Create(message).Put(url)
+	setAuthHeader(f)
+	f.Send()
+	f.ExpectStatus(400)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	statusResponse := readStatusFromResponse(f)
+	if statusResponse.Status == "ok" {
+		f.AddError(fmt.Sprintf("Expected error status, but got '%s' instead", statusResponse.Status))
+	}
+	if !strings.Contains(statusResponse.Status, "Error: 'invalid UUID ") {
+		f.AddError(fmt.Sprintf("Unexpected error reported: %v", statusResponse.Status))
+	}
+
+	f.PrintReport()
+}
+
+func checkItemNotFound(url string, message string) {
+	f := frisby.Create(message).Put(url)
+	setAuthHeader(f)
+	f.Send()
+	f.ExpectStatus(404)
+	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
+
+	statusResponse := readStatusFromResponse(f)
+	if statusResponse.Status == "ok" {
+		f.AddError(fmt.Sprintf("Expected error status, but got '%s' instead", statusResponse.Status))
+	}
+	if !strings.Contains(statusResponse.Status, "was not found in the storage") {
+		f.AddError(fmt.Sprintf("Unexpected error reported: %v", statusResponse.Status))
+	}
+
+	f.PrintReport()
 }
 
 // reproducerForIssue385 checks whether the issue https://github.com/RedHatInsights/insights-results-aggregator/issues/385 has been fixed

--- a/tests/rest/server.go
+++ b/tests/rest/server.go
@@ -192,6 +192,24 @@ func ServerTests() {
 	reproducerForIssue384()
 
 	// tests for REST API endpoints for voting about rules
+	checkLikeKnownRuleForKnownCluster()
+	checkDislikeKnownRuleForKnownCluster()
+	checkResetKnownRuleForKnownCluster()
+	checkLikeKnownRuleForUnknownCluster()
+	checkDislikeKnownRuleForUnknownCluster()
+	checkResetKnownRuleForUnknownCluster()
+	checkLikeKnownRuleForImproperCluster()
+	checkDislikeKnownRuleForImproperCluster()
+	checkResetKnownRuleForImproperCluster()
+	checkLikeUnknownRuleForKnownCluster()
+	checkDislikeUnknownRuleForKnownCluster()
+	checkResetUnknownRuleForKnownCluster()
+	checkLikeUnknownRuleForUnknownCluster()
+	checkDislikeUnknownRuleForUnknownCluster()
+	checkResetUnknownRuleForUnknownCluster()
+	checkLikeUnknownRuleForImproperCluster()
+	checkDislikeUnknownRuleForImproperCluster()
+	checkResetUnknownRuleForImproperCluster()
 	reproducerForIssue385()
 
 	// tests for OpenAPI specification that is accessible via its endpoint as well


### PR DESCRIPTION
# Description

New REST API tests for endpoints to vote for rule, unvote for rule and for reset votes. Unfortunately we don't have endpoint to look for #votes so this is all we can do ATM.

Fixes #357 #358 #359

## Type of change

- REST API tests

## Testing steps

Please run `make rest_api_tests` as usual.