### PR TITLE
Record consumer errors in storage

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -245,6 +245,10 @@ func (consumer *KafkaConsumer) Serve() {
 		if err != nil {
 			log.Error().Err(err).Msg("Error processing message consumed from Kafka")
 			consumer.numberOfErrorsConsumingMessages++
+
+			if err := consumer.Storage.WriteConsumerError(msg, err); err != nil {
+				log.Error().Err(err).Msg("Unable to write consumer error to storage")
+			}
 		} else {
 			consumer.numberOfSuccessfullyConsumedMessages++
 		}

--- a/migration/actual_migrations_test.go
+++ b/migration/actual_migrations_test.go
@@ -161,3 +161,28 @@ func TestAllMigrations_Migration3TableClusterRuleUserFeedbackDoesNotExist(t *tes
 	err = migration.SetDBVersion(db, 0)
 	assert.EqualError(t, err, "no such table: cluster_rule_user_feedback")
 }
+
+func TestMigration5TableAlreadyExists(t *testing.T) {
+	db := prepareDBAndInfo(t)
+	defer closeDB(t, db)
+
+	_, err := db.Exec(`CREATE TABLE consumer_error(c INTEGER)`)
+	helpers.FailOnError(t, err)
+
+	err = migration.SetDBVersion(db, migration.GetMaxVersion())
+	assert.EqualError(t, err, "table consumer_error already exists")
+}
+
+func TestMigration5NoSuchTable(t *testing.T) {
+	db := prepareDBAndInfo(t)
+	defer closeDB(t, db)
+
+	err := migration.SetDBVersion(db, migration.GetMaxVersion())
+	helpers.FailOnError(t, err)
+
+	_, err = db.Exec(`DROP TABLE consumer_error`)
+	helpers.FailOnError(t, err)
+
+	err = migration.SetDBVersion(db, 0)
+	assert.EqualError(t, err, "no such table: consumer_error")
+}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -47,6 +47,7 @@ var migrations = []Migration{
 	mig2,
 	mig3,
 	mig4,
+	mig5,
 }
 
 // GetMaxVersion returns the highest available migration version.

--- a/migration/migration5.go
+++ b/migration/migration5.go
@@ -1,0 +1,43 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"database/sql"
+)
+
+var mig5 = Migration{
+	StepUp: func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			CREATE TABLE consumer_error (
+				topic           VARCHAR NOT NULL,
+				partition       INTEGER NOT NULL,
+				offset          INTEGER NOT NULL,
+				key             VARCHAR,
+				produced_at     TIMESTAMP NOT NULL,
+				consumed_at     TIMESTAMP NOT NULL,
+				message         VARCHAR,
+				error           VARCHAR NOT NULL,
+				PRIMARY KEY(topic, partition, offset)
+			)`)
+		return err
+	},
+	StepDown: func(tx *sql.Tx) error {
+		_, err := tx.Exec(`DROP TABLE consumer_error`)
+		return err
+	},
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/RedHatInsights/insights-results-aggregator/tests/testdata"
+	"github.com/Shopify/sarama"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -577,4 +578,49 @@ func TestDBStorage_NewSQLite(t *testing.T) {
 		SQLiteDataSource: ":memory:",
 	})
 	helpers.FailOnError(t, err)
+}
+
+func TestDBStorageWriteConsumerError(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	testTopic := "topic"
+	var testPartition int32 = 2
+	var testOffset int64 = 10
+	testKey := []byte("key")
+	testMessage := []byte("value")
+	testProducedAt := time.Now().Add(-time.Hour).UTC()
+	testError := fmt.Errorf("Consumer error")
+
+	err := mockStorage.WriteConsumerError(&sarama.ConsumerMessage{
+		Topic:     testTopic,
+		Partition: testPartition,
+		Offset:    testOffset,
+		Key:       testKey,
+		Value:     testMessage,
+		Timestamp: testProducedAt,
+	}, testError)
+
+	assert.NoError(t, err)
+
+	conn := storage.GetConnection(mockStorage.(*storage.DBStorage))
+	row := conn.QueryRow(`
+		SELECT key, message, produced_at, consumed_at, error
+		FROM consumer_error
+		WHERE topic = $1 AND partition = $2 AND offset = $3
+	`, testTopic, testPartition, testOffset)
+
+	var storageKey []byte
+	var storageMessage []byte
+	var storageProducedAt time.Time
+	var storageConsumedAt time.Time
+	var storageError string
+	err = row.Scan(&storageKey, &storageMessage, &storageProducedAt, &storageConsumedAt, &storageError)
+	assert.NoError(t, err)
+
+	assert.Equal(t, testKey, storageKey)
+	assert.Equal(t, testMessage, storageMessage)
+	assert.Equal(t, testProducedAt, storageProducedAt)
+	assert.True(t, time.Now().UTC().After(storageConsumedAt))
+	assert.Equal(t, testError.Error(), storageError)
 }


### PR DESCRIPTION
# Description

When the consumer is unable to process a message from Kafka, it will log the error and then it will add a record to the storage. This record includes all information about the consumed message, the error message and when the incident happened.

Fixes #353 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Testing steps

`make before_commit` (still without the OpenAPI part)
