### PR TITLE
fixed offset column in conumser error table

### DIFF
--- a/migration/migration5.go
+++ b/migration/migration5.go
@@ -24,16 +24,18 @@ var mig5 = Migration{
 	StepUp: func(tx *sql.Tx) error {
 		_, err := tx.Exec(`
 			CREATE TABLE consumer_error (
-				"topic"           VARCHAR NOT NULL,
-				"partition"       INTEGER NOT NULL,
-				"offset"          INTEGER NOT NULL,
-				"key"             VARCHAR,
-				"produced_at"     TIMESTAMP NOT NULL,
-				"consumed_at"     TIMESTAMP NOT NULL,
-				"message"         VARCHAR,
-				"error"           VARCHAR NOT NULL,
-				PRIMARY KEY("topic", "partition", "offset")
-			)`)
+				topic           VARCHAR NOT NULL,
+				partition       INTEGER NOT NULL,
+				topic_offset    INTEGER NOT NULL,
+				key             VARCHAR,
+				produced_at     TIMESTAMP NOT NULL,
+				consumed_at     TIMESTAMP NOT NULL,
+				message         VARCHAR,
+				error           VARCHAR NOT NULL,
+
+				PRIMARY KEY(topic, partition, topic_offset)
+			)
+		`)
 		return err
 	},
 	StepDown: func(tx *sql.Tx) error {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -635,7 +635,7 @@ func (storage DBStorage) GetConnection() *sql.DB {
 // WriteConsumerError writes a report about a consumer error into the storage.
 func (storage DBStorage) WriteConsumerError(msg *sarama.ConsumerMessage, consumerErr error) error {
 	_, err := storage.connection.Exec(`
-		INSERT INTO consumer_error (topic, partition, offset, key, produced_at, consumed_at, message, error)
+		INSERT INTO consumer_error (topic, partition, topic_offset, key, produced_at, consumed_at, message, error)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 		msg.Topic, msg.Partition, msg.Offset, msg.Key, msg.Timestamp, time.Now().UTC(), msg.Value, consumerErr.Error())
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -607,7 +607,7 @@ func TestDBStorageWriteConsumerError(t *testing.T) {
 	row := conn.QueryRow(`
 		SELECT key, message, produced_at, consumed_at, error
 		FROM consumer_error
-		WHERE topic = $1 AND partition = $2 AND offset = $3
+		WHERE topic = $1 AND partition = $2 AND topic_offset = $3
 	`, testTopic, testPartition, testOffset)
 
 	var storageKey []byte


### PR DESCRIPTION
# Description

Fixes #484

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run with postgres and see that consumer errors are written into the table and `make before_commit`
