### PR TITLE
added debug endpoints to delete rule and rule_error_key

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -532,6 +532,41 @@
             }
           }
         }
+      },
+      "delete": {
+        "summary": "Deletes a rule with provided ruleId",
+        "operationId": "deleteRule",
+        "description": "[DEBUG ONLY] Deletes a rule with provided ruleId",
+        "parameters": [
+          {
+            "name": "ruleId",
+            "in": "path",
+            "required": true,
+            "description": "ID of the rule to be deleted",
+            "schema": {
+              "type": "string",
+              "example": "some.python.module"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "status ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/rules/{ruleId}/error_keys/{errorKey}": {
@@ -539,6 +574,51 @@
         "summary": "Creates or updates rule_error_key with provided ruleId and errorKey",
         "operationId": "createOrUpdateRuleErrorKey",
         "description": "[DEBUG ONLY] Creates or updates rule_error_key with provided data in body",
+        "parameters": [
+          {
+            "name": "ruleId",
+            "in": "path",
+            "required": true,
+            "description": "ID of the rule to be created or updated",
+            "schema": {
+              "type": "string",
+              "example": "some.python.module"
+            }
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "errorKey to be created",
+            "schema": {
+              "type": "string",
+              "example": "ek"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "status ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Deletes rule_error_key with provided ruleId and errorKey",
+        "operationId": "deleteRuleErrorKey",
+        "description": "[DEBUG ONLY] Deletes rule_error_key with provided ruleId and errorKey",
         "parameters": [
           {
             "name": "ruleId",

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -38,9 +38,9 @@ const (
 	ResetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/reset_vote"
 	// GetVoteOnRuleEndpoint is an endpoint to get vote on rule. DEBUG only
 	GetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/get_vote"
-	// RuleEndpoint is an endpoint to create a rule. DEBUG only
+	// RuleEndpoint is an endpoint to create&delete a rule. DEBUG only
 	RuleEndpoint = "rules/{rule_id}"
-	// RuleErrorKeyEndpoint is an endpoint to create a rule_error_key. DEBUG only
+	// RuleErrorKeyEndpoint is an endpoint to create&delete a rule_error_key. DEBUG only
 	RuleErrorKeyEndpoint = "rules/{rule_id}/error_keys/{error_key}"
 	// ClustersForOrganizationEndpoint returns all clusters for {organization}
 	ClustersForOrganizationEndpoint = "organizations/{organization}/clusters"

--- a/server/server.go
+++ b/server/server.go
@@ -315,6 +315,25 @@ func (server *HTTPServer) createRule(writer http.ResponseWriter, request *http.R
 	}
 }
 
+func (server *HTTPServer) deleteRule(writer http.ResponseWriter, request *http.Request) {
+	ruleID, err := readRuleID(writer, request)
+	if err != nil {
+		// everything has been handled already
+		return
+	}
+
+	err = server.Storage.DeleteRule(ruleID)
+	if err != nil {
+		handleServerError(writer, err)
+		return
+	}
+
+	err = responses.SendResponse(writer, responses.BuildOkResponse())
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}
+
 func (server *HTTPServer) createRuleErrorKey(writer http.ResponseWriter, request *http.Request) {
 	ruleID, err := readRuleID(writer, request)
 	if err != nil {
@@ -348,6 +367,31 @@ func (server *HTTPServer) createRuleErrorKey(writer http.ResponseWriter, request
 	err = responses.SendResponse(writer, responses.BuildOkResponseWithData(
 		"rule_error_key", ruleErrorKey,
 	))
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}
+
+func (server *HTTPServer) deleteRuleErrorKey(writer http.ResponseWriter, request *http.Request) {
+	ruleID, err := readRuleID(writer, request)
+	if err != nil {
+		// everything has been handled already
+		return
+	}
+
+	errorKey, err := readErrorKey(writer, request)
+	if err != nil {
+		// everything has been handled already
+		return
+	}
+
+	err = server.Storage.DeleteRuleErrorKey(ruleID, errorKey)
+	if err != nil {
+		handleServerError(writer, err)
+		return
+	}
+
+	err = responses.SendResponse(writer, responses.BuildOkResponse())
 	if err != nil {
 		log.Error().Err(err).Msg(responseDataError)
 	}
@@ -493,6 +537,8 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 		router.HandleFunc(apiPrefix+GetVoteOnRuleEndpoint, server.getVoteOnRule).Methods(http.MethodGet)
 		router.HandleFunc(apiPrefix+RuleEndpoint, server.createRule).Methods(http.MethodPost)
 		router.HandleFunc(apiPrefix+RuleErrorKeyEndpoint, server.createRuleErrorKey).Methods(http.MethodPost)
+		router.HandleFunc(apiPrefix+RuleEndpoint, server.deleteRule).Methods(http.MethodDelete)
+		router.HandleFunc(apiPrefix+RuleErrorKeyEndpoint, server.deleteRuleErrorKey).Methods(http.MethodDelete)
 	}
 
 	// common REST API endpoints

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -767,3 +767,103 @@ func TestDBStorage_CreateRuleErrorKey_DBError(t *testing.T) {
 	})
 	assert.EqualError(t, err, "sql: database is closed")
 }
+
+func TestDBStorage_DeleteRule(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	err := mockStorage.CreateRule(types.Rule{
+		Module: "module",
+	})
+	helpers.FailOnError(t, err)
+
+	err = mockStorage.DeleteRule("module")
+	helpers.FailOnError(t, err)
+}
+
+func TestDBStorage_DeleteRule_NotFound(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	err := mockStorage.DeleteRule("module")
+	assert.EqualError(t, err, "Item with ID module was not found in the storage")
+}
+
+func TestDBStorage_DeleteRule_DBError(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	helpers.MustCloseStorage(t, mockStorage)
+
+	err := mockStorage.DeleteRule("module")
+	assert.EqualError(t, err, "sql: database is closed")
+}
+
+func TestDBStorage_DeleteRuleErrorKey(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	err := mockStorage.CreateRule(types.Rule{
+		Module:     "module",
+		Name:       "name",
+		Summary:    "summary",
+		Reason:     "reason",
+		Resolution: "resolution",
+		MoreInfo:   "more_info",
+	})
+	helpers.FailOnError(t, err)
+
+	err = mockStorage.CreateRuleErrorKey(types.RuleErrorKey{
+		ErrorKey:    "error_key",
+		RuleModule:  "module",
+		Condition:   "condition",
+		Description: "description",
+		Impact:      1,
+		Likelihood:  2,
+		PublishDate: testdata.LastCheckedAt,
+		Active:      true,
+		Generic:     "generic",
+	})
+	helpers.FailOnError(t, err)
+
+	err = mockStorage.DeleteRuleErrorKey("module", "error_key")
+	helpers.FailOnError(t, err)
+}
+
+func TestDBStorage_DeleteRuleErrorKey_NotFound(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+	defer helpers.MustCloseStorage(t, mockStorage)
+
+	err := mockStorage.DeleteRuleErrorKey("module", "error_key")
+	assert.EqualError(t, err, "Item with ID module/error_key was not found in the storage")
+}
+
+func TestDBStorage_DeleteRuleErrorKey_DBError(t *testing.T) {
+	mockStorage := helpers.MustGetMockStorage(t, true)
+
+	err := mockStorage.CreateRule(types.Rule{
+		Module:     "module",
+		Name:       "name",
+		Summary:    "summary",
+		Reason:     "reason",
+		Resolution: "resolution",
+		MoreInfo:   "more_info",
+	})
+	helpers.FailOnError(t, err)
+
+	err = mockStorage.CreateRuleErrorKey(types.RuleErrorKey{
+		ErrorKey:    "error_key",
+		RuleModule:  "module",
+		Condition:   "condition",
+		Description: "description",
+		Impact:      1,
+		Likelihood:  2,
+		PublishDate: testdata.LastCheckedAt,
+		Active:      true,
+		Generic:     "generic",
+	})
+	helpers.FailOnError(t, err)
+
+	helpers.MustCloseStorage(t, mockStorage)
+
+	err = mockStorage.DeleteRuleErrorKey("module", "error_key")
+	assert.EqualError(t, err, "sql: database is closed")
+}


### PR DESCRIPTION
# Description

Debug endpoints to cleanup after integration tests

Fixes #495
Fixes #496

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Unit tests (no changes in the code)

## Testing steps

`make before_commit`
