### PR TITLE
fix openapi report endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -231,7 +231,9 @@
                               },
                               "risk_of_change": {
                                 "type": "integer",
+                                "description": "Risk of change - values paired with corresponding UI elements. 0 returned when not defined, therefore to hide the UI.",
                                 "enum": [
+                                  0,
                                   1,
                                   2,
                                   3,


### PR DESCRIPTION
# Description

The value `0` is returned when `risk_of_change` is not defined in the rule content, meaning the UI element should be hidden. (already implemented on UI)

Fixes #531 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
`make before_commit`
