### PR TITLE
Added prod tag for non-debug endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -142,7 +142,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "prod"
+        ]
       }
     },
     "/report/{orgId}/{clusterId}": {
@@ -254,7 +257,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "prod"
+        ]
       }
     },
     "/clusters/{clusterId}/rules/{ruleId}/like": {
@@ -302,7 +308,8 @@
           }
         },
         "tags": [
-          "rule"
+          "rule",
+          "prod"
         ]
       }
     },
@@ -351,7 +358,8 @@
           }
         },
         "tags": [
-          "rule"
+          "rule",
+          "prod"
         ]
       }
     },
@@ -400,7 +408,8 @@
           }
         },
         "tags": [
-          "rule"
+          "rule",
+          "prod"
         ]
       }
     },


### PR DESCRIPTION
# Description

This PR adds a new `prod` tag for all non-debug endpoints. The intention of that is filtering endpoints for fuzzy testing using schemathesis. Example of usage is [here](https://github.com/kiwicom/schemathesis/blob/master/test/test_filters.py#L59)

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Python client was successfully generated with the given openapi.json.
