### PR TITLE
Search for rule content recursively

### DIFF
--- a/content/content_test.go
+++ b/content/content_test.go
@@ -89,3 +89,10 @@ func TestContentParseBadMetadataYAML(t *testing.T) {
 	_, err := content.ParseRuleContentDir("../tests/content/bad_metadata/")
 	assert.EqualError(t, err, errYAMLBadToken)
 }
+
+// TestContentParseBadMetadataYAML tests handling bad/incorrect metadata.yaml file
+func TestContentParseNoExternal(t *testing.T) {
+	noExternalPath := "../tests/content/no_external"
+	_, err := content.ParseRuleContentDir(noExternalPath)
+	assert.EqualError(t, err, fmt.Sprintf("open %s/external: no such file or directory", noExternalPath))
+}

--- a/tests/content/missing/external/rules/rule2/plugin.yaml
+++ b/tests/content/missing/external/rules/rule2/plugin.yaml
@@ -1,0 +1,13 @@
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/content/no_external/config.yaml
+++ b/tests/content/no_external/config.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+impact:
+  One: 1
+  Two: 2
+  Three: 3
+  Four: 4
+  Five: 5
+  Six: 6
+  Seven: 7
+  Eight: 8
+  Nine: 9


### PR DESCRIPTION
# Description

Apparently we should be able to search for rule content recursively while parsing it and this change aims to achieve precisely that.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

`make before_commit` without the OpenAPI test, which still keeps on crashing.