### PR TITLE
Optional organization whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Aggregator service consists of three main parts:
 4. That results are consumed by Insights rules aggregator service that caches them
 5. The service provides such data via REST API to other tools, like OpenShift Cluster Manager web UI, OpenShift console, etc.
 
-Please note that results are filtered - only results for organizations listed in `org_whitelist.csv` are processed and cached in aggregator.
+Optionally, an organization whitelist can be enabled by the configuration variable `enable_org_whitelist`, which enables processing of a .csv file containing organization IDs (path specified by the config variable `org_whitelist`) and allows report processing only for these organizations. This feature is disbabled by default, and might be removed altogether in the near future.
 
 ### DB structure
 

--- a/broker/configuration.go
+++ b/broker/configuration.go
@@ -29,7 +29,7 @@ type Configuration struct {
 	PublishTopic        string     `mapstructure:"publish_topic" toml:"publish_topic"`
 	Group               string     `mapstructure:"group" toml:"group"`
 	Enabled             bool       `mapstructure:"enabled" toml:"enabled"`
-	OrgWhitelist        mapset.Set `mapstructure:"org_white_list" toml:"org_white_list"`
+	OrgWhitelist        mapset.Set `mapstructure:"org_whitelist_file" toml:"org_whitelist_file"`
 	OrgWhitelistEnabled bool       `mapstructure:"enable_org_whitelist" toml:"enable_org_whitelist"`
 	SaveOffset          bool       `mapstructure:"save_offset" toml:"save_offset"`
 }

--- a/broker/configuration.go
+++ b/broker/configuration.go
@@ -24,11 +24,12 @@ import (
 
 // Configuration represents configuration of Kafka broker
 type Configuration struct {
-	Address      string     `mapstructure:"address" toml:"address"`
-	Topic        string     `mapstructure:"topic" toml:"topic"`
-	PublishTopic string     `mapstructure:"publish_topic" toml:"publish_topic"`
-	Group        string     `mapstructure:"group" toml:"group"`
-	Enabled      bool       `mapstructure:"enabled" toml:"enabled"`
-	OrgWhitelist mapset.Set `mapstructure:"org_white_list" toml:"org_white_list"`
-	SaveOffset   bool       `mapstructure:"save_offset" toml:"save_offset"`
+	Address             string     `mapstructure:"address" toml:"address"`
+	Topic               string     `mapstructure:"topic" toml:"topic"`
+	PublishTopic        string     `mapstructure:"publish_topic" toml:"publish_topic"`
+	Group               string     `mapstructure:"group" toml:"group"`
+	Enabled             bool       `mapstructure:"enabled" toml:"enabled"`
+	OrgWhitelist        mapset.Set `mapstructure:"org_white_list" toml:"org_white_list"`
+	OrgWhitelistEnabled bool       `mapstructure:"enable_org_whitelist" toml:"enable_org_whitelist"`
+	SaveOffset          bool       `mapstructure:"save_offset" toml:"save_offset"`
 }

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -10,7 +10,7 @@ enable_org_whitelist = false
 path = "./tests/content/ok/"
 
 [processing]
-org_whitelist = "org_whitelist.csv"
+org_whitelist_file = "org_whitelist.csv"
 
 [server]
 address = ":8080"

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -4,6 +4,7 @@ topic = "ccx.ocp.results"
 group = "aggregator"
 enabled = true
 save_offset = true
+enable_org_whitelist = false
 
 [content]
 path = "./tests/content/ok/"

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ topic = "ccx.ocp.results"
 group = "aggregator"
 enabled = true
 save_offset = true
+enable_org_whitelist = false
 
 [content]
 path = "/rules-content"

--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ enable_org_whitelist = false
 path = "/rules-content"
 
 [processing]
-org_whitelist = "org_whitelist.csv"
+org_whitelist_file = "org_whitelist.csv"
 
 [server]
 address = ":8080"

--- a/configuration.go
+++ b/configuration.go
@@ -51,7 +51,7 @@ var config struct {
 	Broker     broker.Configuration `mapstructure:"broker" toml:"broker"`
 	Server     server.Configuration `mapstructure:"server" toml:"server"`
 	Processing struct {
-		OrgWhiteListFile string `mapstructure:"org_white_list_file" toml:"org_white_list_file"`
+		OrgWhiteListFile string `mapstructure:"org_whitelist" toml:"org_whitelist"`
 	} `mapstructure:"processing"`
 	Storage storage.Configuration `mapstructure:"storage" toml:"storage"`
 	Content struct {
@@ -116,6 +116,10 @@ func getBrokerConfiguration() broker.Configuration {
 }
 
 func getOrganizationWhitelist() mapset.Set {
+	if !config.Broker.OrgWhitelistEnabled {
+		return nil
+	}
+
 	if len(config.Processing.OrgWhiteListFile) == 0 {
 		config.Processing.OrgWhiteListFile = defaultOrgWhiteListFileName
 	}

--- a/configuration.go
+++ b/configuration.go
@@ -51,7 +51,7 @@ var config struct {
 	Broker     broker.Configuration `mapstructure:"broker" toml:"broker"`
 	Server     server.Configuration `mapstructure:"server" toml:"server"`
 	Processing struct {
-		OrgWhiteListFile string `mapstructure:"org_whitelist" toml:"org_whitelist"`
+		OrgWhiteListFile string `mapstructure:"org_whitelist_file" toml:"org_whitelist_file"`
 	} `mapstructure:"processing"`
 	Storage storage.Configuration `mapstructure:"storage" toml:"storage"`
 	Content struct {

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -201,7 +201,7 @@ func TestLoadConfigurationFromFile(t *testing.T) {
 		path = "/rules-content"
 
 		[processing]
-		org_whitelist = "org_whitelist.csv"
+		org_whitelist_file = "org_whitelist.csv"
 
 		[server]
 		address = ":8080"

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -195,6 +195,7 @@ func TestLoadConfigurationFromFile(t *testing.T) {
 		topic = "platform.results.ccx"
 		group = "aggregator"
 		enabled = true
+		enable_org_whitelist = true
 
 		[content]
 		path = "/rules-content"

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -15,7 +15,7 @@ path = "/rules-content"
 enabled = true
 
 [processing]
-org_whitelist = "org_whitelist.csv"
+org_whitelist_file = "org_whitelist.csv"
 
 [server]
 address = ":8080"

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -4,6 +4,7 @@ topic = "platform.results.ccx"
 group = "aggregator"
 enabled = false
 save_offset = false
+enable_org_whitelist = true
 
 [content]
 path = "/rules-content"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -10,7 +10,7 @@ enable_org_whitelist = true
 path = "./tests/content/ok/"
 
 [processing]
-org_whitelist = "org_whitelist.csv"
+org_whitelist_file = "org_whitelist.csv"
 
 [server]
 address = ":8080"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4,6 +4,7 @@ topic = "ccx.ocp.results"
 group = "aggregator"
 enabled = false
 save_offset = false
+enable_org_whitelist = true
 
 [content]
 path = "./tests/content/ok/"


### PR DESCRIPTION
# Description
Added option to enable whitelisting, since we dont want it now. I'm not deleting it yet because the requirements might change again really quick :) 
Also fixed a bug where the path defined by `org_whitelist` was always ignored. (also fixed in e2e)

Fixes #489 #577 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Documentation update

## Testing steps
`make before_commit`, locally tried `INSIGHTS_RESULTS_AGGREGATOR__PROCESSING__ORG_WHITELIST=` variable
