### PR TITLE
fixed zerolog: could not write event: short write

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -75,7 +75,16 @@ func (writer UnJSONWriter) Write(bytes []byte) (int, error) {
 		stringifiedObj += fmt.Sprintf("%+v=%+v; ", strings.ToUpper(key), val)
 	}
 
-	return writer.Write([]byte(stringifiedObj))
+	written, err := writer.Write([]byte(stringifiedObj))
+	if err != nil {
+		return written, err
+	}
+
+	if written < len(stringifiedObj) {
+		return written, fmt.Errorf("too few bytes were written")
+	}
+
+	return len(bytes), nil
 }
 
 // InitZerolog initializes zerolog with provided configs to use proper stdout and/or CloudWatch logging


### PR DESCRIPTION
# Description

io.MultiWriter was not happy that different writers wrote different amount of bytes, so fixed it.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

`make before_commit` & see that no error message is in logs
