### PR TITLE
Add cover rule to Makefile to display test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean build fmt lint vet run test style cyclo
+.PHONY: help clean build fmt lint vet run test cover style cyclo
 
 SOURCES:=$(shell find . -name '*.go')
 
@@ -60,6 +60,9 @@ run: clean build ## Build the project and executes the binary
 
 test: clean build ## Run the unit tests
 	@go test -coverprofile coverage.out $(shell go list ./... | grep -v tests)
+
+cover: test
+	@go tool cover -html=coverage.out
 
 integration_tests: ## Run all integration tests
 	@echo "Running all integration tests"


### PR DESCRIPTION
# Description

Issuing `make cover` will run the unit tests and then show you the test coverage report in your default browser.

It is equivalent to running:

```sh
make test
go tool cover -html=coverage.out
```

However, this is imo much easier and I have no idea why it hasn't been done before. It has been bugging me for many weeks now, so I've decided to add this.

I didn't bother writing the rule properly to only re-run the tests if necessary, but I believe it doesn't matter and at least we won't suffer from any caching-related issues.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

`make before_commit && make cover`
