### PR TITLE
Removed buck-it from smoke tests

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -22,7 +22,7 @@ if (env.CHANGE_TARGET == "stable" && env.CHANGE_ID) {
     execSmokeTest (
         ocDeployerBuilderPath: "ccx-data-pipeline/insights-results-aggregator",
         ocDeployerComponentPath: "ccx-data-pipeline/insights-results-aggregator",
-        ocDeployerServiceSets: "ccx-data-pipeline,ingress,buck-it,platform-mq",
+        ocDeployerServiceSets: "ccx-data-pipeline,ingress,platform-mq",
         iqePlugins: ["iqe-ccx-plugin"],
         pytestMarker: ["smoke"]
     )


### PR DESCRIPTION
# Description

`buck-it` was decommissioned. `insights-storage-broker` is used instead and it's part of ingress template. 

## Type of change

- Smoke tests (no changes in the code)

## Testing steps

It can be tested only in a PR to the stable branch.
