### PR TITLE
Reason resolution

### DIFF
--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -73,6 +73,10 @@ func TestStartService(t *testing.T) {
 		os.Clearenv()
 
 		mustLoadConfiguration("./tests/tests")
+		setEnvSettings(t, map[string]string{
+			"INSIGHTS_RESULTS_AGGREGATOR__STORAGE__DB_DRIVER":         "sqlite3",
+			"INSIGHTS_RESULTS_AGGREGATOR__STORAGE__SQLITE_DATASOURCE": ":memory:",
+		})
 
 		go func() {
 			main.StartService()

--- a/openapi.json
+++ b/openapi.json
@@ -216,6 +216,14 @@
                                 "type": "string",
                                 "description": "Details of the rule - templates rendered on frontend."
                               },
+                              "reason": {
+                                "type": "string",
+                                "description": "Reason for the issue, giving the user more accurate description of the cause."
+                              },
+                              "resolution": {
+                                "type": "string",
+                                "description": "Resolution steps of the issue, possibly linking to a resolution article in the knowledge base."
+                              },
                               "created_at": {
                                 "type": "string",
                                 "format": "date",

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -367,12 +367,23 @@ func getExtraDataFromReportRules(rules []types.RuleContentResponse, reportRules 
 func (storage DBStorage) GetContentForRules(reportRules types.ReportRules) ([]types.RuleContentResponse, error) {
 	rules := make([]types.RuleContentResponse, 0)
 
-	query := `SELECT rek.error_key, rek.rule_module, rek.description, rek.generic || r.resolution, rek.publish_date,
-		rek.impact, rek.likelihood
-		FROM rule r
-		INNER JOIN rule_error_key rek
-		ON r.module = rek.rule_module
-		WHERE %v`
+	query := `
+	SELECT 
+		rek.error_key,
+		rek.rule_module,
+		rek.description,
+		rek.generic,
+		r.reason,
+		r.resolution,
+		rek.publish_date,
+		rek.impact,
+		rek.likelihood
+	FROM
+		rule r
+	INNER JOIN
+		rule_error_key rek ON r.module = rek.rule_module
+	WHERE %v
+	`
 
 	whereInStatement := constructWhereClauseForContent(reportRules)
 	query = fmt.Sprintf(query, whereInStatement)
@@ -393,6 +404,8 @@ func (storage DBStorage) GetContentForRules(reportRules types.ReportRules) ([]ty
 			&rule.RuleModule,
 			&rule.Description,
 			&rule.Generic,
+			&rule.Reason,
+			&rule.Resolution,
 			&rule.CreatedAt,
 			&impact,
 			&likelihood,

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -120,7 +120,7 @@ var (
 		Rules: map[string]content.RuleContent{
 			"rc": content.RuleContent{
 				Summary:    []byte("summary"),
-				Reason:     []byte("summary"),
+				Reason:     []byte("reason"),
 				Resolution: []byte("resolution"),
 				MoreInfo:   []byte("more info"),
 				Plugin: content.RulePluginInfo{
@@ -302,7 +302,9 @@ func TestDBStorageGetContentForRulesOK(t *testing.T) {
 			ErrorKey:     "ek",
 			RuleModule:   string(testRuleID),
 			Description:  "description",
-			Generic:      "genericresolution",
+			Generic:      "generic",
+			Reason:       "reason",
+			Resolution:   "resolution",
 			CreatedAt:    "1970-01-01T00:00:00Z",
 			TotalRisk:    1,
 			RiskOfChange: 0,
@@ -347,7 +349,9 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 			ErrorKey:     "ek1",
 			RuleModule:   "test.rule1",
 			Description:  "rule 1 description",
-			Generic:      "rule 1 detailsrule 1 resolution",
+			Generic:      "rule 1 details",
+			Reason:       "rule 1 reason",
+			Resolution:   "rule 1 resolution",
 			CreatedAt:    "1970-01-01T00:00:00Z",
 			TotalRisk:    3,
 			RiskOfChange: 0,
@@ -357,7 +361,9 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 			ErrorKey:     "ek2",
 			RuleModule:   "test.rule2",
 			Description:  "rule 2 description",
-			Generic:      "rule 2 detailsrule 2 resolution",
+			Generic:      "rule 2 details",
+			Reason:       "rule 2 reason",
+			Resolution:   "rule 2 resolution",
 			CreatedAt:    "1970-01-02T00:00:00Z",
 			TotalRisk:    4,
 			RiskOfChange: 0,
@@ -367,7 +373,9 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 			ErrorKey:     "ek3",
 			RuleModule:   "test.rule3",
 			Description:  "rule 3 description",
-			Generic:      "rule 3 detailsrule 3 resolution",
+			Generic:      "rule 3 details",
+			Reason:       "rule 3 reason",
+			Resolution:   "rule 3 resolution",
 			CreatedAt:    "1970-01-03T00:00:00Z",
 			TotalRisk:    2,
 			RiskOfChange: 0,
@@ -388,6 +396,8 @@ func TestDBStorageGetContentForRulesScanError(t *testing.T) {
 		"rule_module",
 		"description",
 		"generic",
+		"reason",
+		"resolution",
 		"publish_date",
 		"impact",
 		"likelihood",
@@ -431,13 +441,15 @@ func TestDBStorageGetContentForRulesRowsError(t *testing.T) {
 		"rule_module",
 		"description",
 		"generic",
+		"reason",
+		"resolution",
 		"publish_date",
 		"impact",
 		"likelihood",
 	}
 
 	values := []driver.Value{
-		"ek", "rule_module", "desc", "generic", 0, 0, 0,
+		"ek", "rule_module", "desc", "generic", "reason", "resolution", 0, 0, 0,
 	}
 
 	// return bad values

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -220,7 +220,9 @@ var (
 			{
 				"rule_id": "` + string(Rule1ID) + `",
 				"description": "` + Rule1Description + `",
-				"details": "` + Rule1Details + Rule1Resolution + `",
+				"details": "` + Rule1Details + `",
+				"reason": "` + Rule1Reason + `",
+				"resolution": "` + Rule1Resolution + `",
 				"created_at": "` + Rule1CreatedAt + `",
 				"total_risk": 3,
 				"risk_of_change": 0,
@@ -229,7 +231,9 @@ var (
 			{
 				"rule_id": "` + string(Rule2ID) + `",
 				"description": "` + Rule2Description + `",
-				"details": "` + Rule2Details + Rule2Resolution + `",
+				"details": "` + Rule2Details + `",
+				"reason": "` + Rule2Reason + `",
+				"resolution": "` + Rule2Resolution + `",
 				"created_at": "` + Rule2CreatedAt + `",
 				"total_risk": 4,
 				"risk_of_change": 0,
@@ -238,7 +242,9 @@ var (
 			{
 				"rule_id": "` + string(Rule3ID) + `",
 				"description": "` + Rule3Description + `",
-				"details": "` + Rule3Details + Rule3Resolution + `",
+				"details": "` + Rule3Details + `",
+				"reason": "` + Rule3Reason + `",
+				"resolution": "` + Rule3Resolution + `",
 				"created_at": "` + Rule3CreatedAt + `",
 				"total_risk": 2,
 				"risk_of_change": 0,

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -21,7 +21,7 @@ org_whitelist_file = "org_whitelist.csv"
 
 [storage]
 db_driver = "sqlite3"
-sqlite_datasource = ":memory:"
+sqlite_datasource = "./test.db"
 
 [content]
 path = "./tests/content/ok/"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -21,7 +21,7 @@ org_whitelist_file = "org_whitelist.csv"
 
 [storage]
 db_driver = "sqlite3"
-sqlite_datasource = "./test.db"
+sqlite_datasource = ":memory:"
 
 [content]
 path = "./tests/content/ok/"

--- a/types/types.go
+++ b/types/types.go
@@ -62,14 +62,16 @@ type ReportResponseMeta struct {
 
 // RuleContentResponse represents a single rule in the response of /report endpoint
 type RuleContentResponse struct {
-	ErrorKey     string      `json:"-"`
-	RuleModule   string      `json:"rule_id"`
-	Description  string      `json:"description"`
-	Generic      string      `json:"details"`
 	CreatedAt    string      `json:"created_at"`
-	TotalRisk    int         `json:"total_risk"`
+	Description  string      `json:"description"`
+	ErrorKey     string      `json:"-"`
+	Generic      string      `json:"details"`
+	Reason       string      `json:"reason"`
+	Resolution   string      `json:"resolution"`
 	RiskOfChange int         `json:"risk_of_change"`
+	RuleModule   string      `json:"rule_id"`
 	TemplateData interface{} `json:"extra_data"`
+	TotalRisk    int         `json:"total_risk"`
 }
 
 // RuleID represents type for rule id


### PR DESCRIPTION
# Description
This adds `reason.md` and `resolution.md` to the rules in API response for cluster report and removes the concatenating of `generic.md` and `resolution.md` into one. 

Both `reason` and `resolution` can (and already do) contain **dot.js templating syntax** along the markdown.

The `extra_data` containing the template data doesn't change, and it will contain data for ALL the templates (as in there are no "extra_data" for each reason, resolution, generic..., its always as one in the report), so it has to be reused for rendering each of them.

I also updated `tests/tests.toml` so that it uses `:memory:` datasource, because I had a mig0006 applied (enable/disable) and it made tests fail, thanks @Sergey1011010 for the catch

Fixes #654 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

`make before_commit` + responses visually
