### PR TITLE
Add UPSERT benchmarks and move to Postgres

### DIFF
--- a/storage/generic_insert_benchmark_test.go
+++ b/storage/generic_insert_benchmark_test.go
@@ -145,7 +145,7 @@ func BenchmarkStorageUpsertWithoutConflict(b *testing.B) {
 
 	for benchIter := 0; benchIter < b.N; benchIter++ {
 		for rowId := 0; rowId < rowCount; rowId++ {
-			if _, err := conn.Exec(upsertQuery, rowId+1, "John Doe", "Hello World!"); err != nil {
+			if _, err := conn.Exec(upsertQuery, (benchIter*rowCount)+rowId+1, "John Doe", "Hello World!"); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/storage/generic_insert_benchmark_test.go
+++ b/storage/generic_insert_benchmark_test.go
@@ -20,18 +20,35 @@ import (
 
 	"github.com/RedHatInsights/insights-results-aggregator/storage"
 	"github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
+	"github.com/rs/zerolog"
 )
 
 const (
-	rowCount    = 10000
+	rowCount    = 1000
 	insertQuery = "INSERT INTO benchmark_tab (name, value) VALUES ($1, $2);"
+	upsertQuery = "INSERT INTO benchmark_tab (id, name, value) VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET name=$2, value=$3;"
+	// SQLite alternative to the upsert query above:
+	// upsertQuery = "REPLACE INTO benchmark_tab (id, name, value) VALUES ($1, $2, $3);"
 )
 
 func mustPrepareBenchmark(b *testing.B) (storage.Storage, *sql.DB) {
-	mockStorage := helpers.MustGetMockStorage(b, false)
+	// Postgres queries are very verbose at DEBUG log level, so it's better
+	// to silence them this way to make benchmark results easier to find.
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	mockStorage, _ := helpers.MustGetPostgresStorage(b)
+	// Alternative using the file-based SQLite DB storage:
+	// mockStorage, _ := helpers.MustGetSQLiteFileStorage(b)
+	// Old version using the in-memory SQLite DB storage:
+	// mockStorage := helpers.MustGetMockStorage(b, false)
+
 	conn := storage.GetConnection(mockStorage.(*storage.DBStorage))
 
-	if _, err := conn.Exec("CREATE TABLE benchmark_tab (id SERIAL, name VARCHAR(256), value VARCHAR(4096));"); err != nil {
+	if _, err := conn.Exec("DROP TABLE IF EXISTS benchmark_tab;"); err != nil {
+		b.Fatal(err)
+	}
+
+	if _, err := conn.Exec("CREATE TABLE benchmark_tab (id SERIAL PRIMARY KEY, name VARCHAR(256), value VARCHAR(4096));"); err != nil {
 		b.Fatal(err)
 	}
 
@@ -113,6 +130,38 @@ func BenchmarkStorageGenericInsertPrepareExecMany(b *testing.B) {
 
 		for rowId := 0; rowId < rowCount; rowId++ {
 			if _, err := stmt.Exec("John Doe", "Hello World!"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	mustCleanupAfterBenchmark(b, stor, conn)
+}
+
+// BenchmarkStorageUpsertWithoutConflict inserts many non-conflicting
+// rows into the benchmark table using the upsert query.
+func BenchmarkStorageUpsertWithoutConflict(b *testing.B) {
+	stor, conn := mustPrepareBenchmark(b)
+
+	for benchIter := 0; benchIter < b.N; benchIter++ {
+		for rowId := 0; rowId < rowCount; rowId++ {
+			if _, err := conn.Exec(upsertQuery, rowId+1, "John Doe", "Hello World!"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	mustCleanupAfterBenchmark(b, stor, conn)
+}
+
+// BenchmarkStorageUpsertConflict insert many mutually conflicting
+// rows into the benchmark table using the uspert query.
+func BenchmarkStorageUpsertConflict(b *testing.B) {
+	stor, conn := mustPrepareBenchmark(b)
+
+	for benchIter := 0; benchIter < b.N; benchIter++ {
+		for rowId := 0; rowId < rowCount; rowId++ {
+			if _, err := conn.Exec(upsertQuery, 1, "John Doe", "Hello World!"); err != nil {
 				b.Fatal(err)
 			}
 		}


### PR DESCRIPTION
# Description

- Added two benchmarks for UPSERT
  - One for a case with no row conflicts
  - Second for a case where each row has a conflict
- Moved existing benchmarks from in-memory SQLite to PostgreSQL
  - The `10000` iterations are now far too many and the benchmarks were too slow, so the number has been decreased to just `1000`. The performance differences should still be apparent.

*Resolves `CCXDEV-1581`*

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

`make before_commit && ./benchmark.sh 'BenchmarkStorage'`

### Output:

```log
BenchmarkStorageGenericInsertExecDirectlySingle-4           1065           1502679 ns/op
BenchmarkStorageGenericInsertPrepareExecSingle-4             687           1677917 ns/op
BenchmarkStorageGenericInsertExecDirectlyMany-4                1        1772513951 ns/op
BenchmarkStorageGenericInsertPrepareExecMany-4                 1        1542057814 ns/op
BenchmarkStorageUpsertWithoutConflict-4                        1        2101882790 ns/op
BenchmarkStorageUpsertConflict-4                               1        2021282726 ns/op
```

### Output (with `-benchtime=10s`):

```log
BenchmarkStorageGenericInsertExecDirectlySingle-4           6752           1832175 ns/op
BenchmarkStorageGenericInsertPrepareExecSingle-4            7492           1674676 ns/op
BenchmarkStorageGenericInsertExecDirectlyMany-4                6        1954964999 ns/op
BenchmarkStorageGenericInsertPrepareExecMany-4                 7        1599436157 ns/op
BenchmarkStorageUpsertWithoutConflict-4                        6        1863413252 ns/op
BenchmarkStorageUpsertConflict-4                               7        1956901567 ns/op
```