### PR TITLE
Pprof interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,21 @@ Currently, the following metrics are exposed:
 
 Additionally it is possible to consume all metrics provided by Go runtime. There metrics start with `go_` and `process_` prefixes.
 
+## pprof interface in debug mode
+
+In debug mode, standard Golang pprof interface is available at `/debug/pprof/`
+
+Common usage (for using pprof against local instance):
+
+```
+go tool pprof localhost:8080/debug/pprof/profile
+```
+
+A practical example is available here:
+https://medium.com/@paulborile/profiling-a-golang-rest-api-server-635fa0ed45f3
+
+
+
 ## Authentication
 
 Authentication is working through `x-rh-identity` token which is provided by 3scale. `x-rh-identity` is base64 encoded JSON, that includes data about user and organization, like:

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	_ "net/http/pprof"
 	"path/filepath"
 
 	"github.com/RedHatInsights/insights-operator-utils/responses"
@@ -532,6 +533,9 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 		router.HandleFunc(apiPrefix+RuleErrorKeyEndpoint, server.createRuleErrorKey).Methods(http.MethodPost)
 		router.HandleFunc(apiPrefix+RuleEndpoint, server.deleteRule).Methods(http.MethodDelete)
 		router.HandleFunc(apiPrefix+RuleErrorKeyEndpoint, server.deleteRuleErrorKey).Methods(http.MethodDelete)
+
+		// endpoints for pprof - needed for profiling, ie. usually in debug mode
+		router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 	}
 
 	// common REST API endpoints

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	// we just have to import this package in order to expose pprof interface in debug mode
 	_ "net/http/pprof"
 	"path/filepath"
 

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,8 @@ import (
 	"io"
 	"net/http"
 	// we just have to import this package in order to expose pprof interface in debug mode
+	// disable "G108 (CWE-): Profiling endpoint is automatically exposed on /debug/pprof"
+	// #nosec G108
 	_ "net/http/pprof"
 	"path/filepath"
 


### PR DESCRIPTION
# Description

Expose *pprof* interface in debug mode.

Fixes #685

## Type of change

- New feature (non-breaking change which adds functionality)

## Howto test

- Enable debug mode
- Disable auth
- Run aggregator service
- Open browser at `service_address/debug/pprof/`
- Or run `go tool pprof service_address/debug/pprof/profile` if you know *pprof*