### PR TITLE
Skip outdated reports in consumer (using LastChecked cache instead of an extra SELECT query)

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -383,6 +383,11 @@ func (consumer *KafkaConsumer) ProcessMessage(msg *sarama.ConsumerMessage) error
 		lastCheckedTime,
 	)
 	if err != nil {
+		if err == storage.ErrOldReport {
+			logMessageInfo(consumer, msg, message, "Skipping because a more recent report already exists for this cluster")
+			return nil
+		}
+
 		logMessageError(consumer, msg, message, "Error writing report to database", err)
 		return err
 	}

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -17,11 +17,16 @@ limitations under the License.
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/rs/zerolog/log"
 )
+
+// ErrOldReport is an error returned if a more recent already
+// exists on the storage while attempting to write a report for a cluster.
+var ErrOldReport = errors.New("More recent report already exists in storage")
 
 // ItemNotFoundError shows that item with id ItemID wasn't found in the storage
 type ItemNotFoundError struct {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -205,7 +205,9 @@ func (storage DBStorage) Init() error {
 		)
 
 		if err := rows.Scan(&clusterName, &lastChecked); err != nil {
-			_ = rows.Close()
+			if closeErr := rows.Close(); closeErr != nil {
+				log.Error().Err(closeErr).Msg("Unable to close the DB rows handle")
+			}
 			return err
 		}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -99,7 +99,7 @@ type DBDriver int
 const (
 	// DBDriverSQLite3 shows that db driver is sqlite
 	DBDriverSQLite3 DBDriver = iota
-	// DBDriverPostgres shows that db driver is postrgres
+	// DBDriverPostgres shows that db driver is postgres
 	DBDriverPostgres
 	// DBDriverGeneral general sql(used for mock now)
 	DBDriverGeneral
@@ -112,6 +112,8 @@ const (
 type DBStorage struct {
 	connection   *sql.DB
 	dbDriverType DBDriver
+	// clusterLastCheckedDict is a dictionary of timestamps when the clusters were last checked.
+	clustersLastChecked map[types.ClusterName]time.Time
 }
 
 // New function creates and initializes a new instance of Storage interface
@@ -138,8 +140,9 @@ func New(configuration Configuration) (*DBStorage, error) {
 // NewFromConnection function creates and initializes a new instance of Storage interface from prepared connection
 func NewFromConnection(connection *sql.DB, dbDriverType DBDriver) *DBStorage {
 	return &DBStorage{
-		connection:   connection,
-		dbDriverType: dbDriverType,
+		connection:          connection,
+		dbDriverType:        dbDriverType,
+		clustersLastChecked: map[types.ClusterName]time.Time{},
 	}
 }
 
@@ -181,11 +184,38 @@ func initAndGetDriver(configuration Configuration) (driverType DBDriver, driverN
 
 // Init method is doing initialization like creating tables in underlying database
 func (storage DBStorage) Init() error {
+	// Perform all defined migrations on the database.
 	if err := migration.InitInfoTable(storage.connection); err != nil {
 		return err
 	}
+	if err := migration.SetDBVersion(storage.connection, migration.GetMaxVersion()); err != nil {
+		return err
+	}
 
-	return migration.SetDBVersion(storage.connection, migration.GetMaxVersion())
+	// Read clusterName:LastChecked dictionary from DB.
+	rows, err := storage.connection.Query("SELECT cluster, last_checked_at FROM report")
+	if err != nil {
+		return err
+	}
+
+	for rows.Next() {
+		var (
+			clusterName types.ClusterName
+			lastChecked time.Time
+		)
+
+		if err := rows.Scan(&clusterName, &lastChecked); err != nil {
+			_ = rows.Close()
+			return err
+		}
+
+		storage.clustersLastChecked[clusterName] = lastChecked
+	}
+
+	// Not using defer to close the rows here to:
+	// - make errcheck happy (it doesn't like ignoring returned errors),
+	// - return a possible error returned by the Close method.
+	return rows.Close()
 }
 
 // Close method closes the connection to database. Needs to be called at the end of application lifecycle.
@@ -371,7 +401,7 @@ func (storage DBStorage) GetContentForRules(reportRules types.ReportRules) ([]ty
 	rules := make([]types.RuleContentResponse, 0)
 
 	query := `
-	SELECT 
+	SELECT
 		rek.error_key,
 		rek.rule_module,
 		rek.description,
@@ -433,6 +463,21 @@ func (storage DBStorage) GetContentForRules(reportRules types.ReportRules) ([]ty
 	return rules, nil
 }
 
+func (storage DBStorage) getReportUpsertQuery() (string, error) {
+	switch storage.dbDriverType {
+	case DBDriverSQLite3:
+		return `INSERT OR REPLACE INTO report(org_id, cluster, report, reported_at, last_checked_at)
+		 VALUES ($1, $2, $3, $4, $5)`, nil
+	case DBDriverPostgres:
+		return `INSERT INTO report(org_id, cluster, report, reported_at, last_checked_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (org_id, cluster)
+		 DO UPDATE SET report = $3, reported_at = $4, last_checked_at = $5`, nil
+	default:
+		return "", fmt.Errorf("writing report with DB %v is not supported", storage.dbDriverType)
+	}
+}
+
 // WriteReportForCluster writes result (health status) for selected cluster for given organization
 func (storage DBStorage) WriteReportForCluster(
 	orgID types.OrgID,
@@ -440,21 +485,19 @@ func (storage DBStorage) WriteReportForCluster(
 	report types.ClusterReport,
 	lastCheckedTime time.Time,
 ) error {
-	var upsertQuery string
-
-	switch storage.dbDriverType {
-	case DBDriverSQLite3:
-		upsertQuery = `INSERT OR REPLACE INTO report(org_id, cluster, report, reported_at, last_checked_at)
-		 VALUES ($1, $2, $3, $4, $5)`
-	case DBDriverPostgres:
-		upsertQuery = `INSERT INTO report(org_id, cluster, report, reported_at, last_checked_at)
-		 VALUES ($1, $2, $3, $4, $5)
-		 ON CONFLICT (org_id, cluster)
-		 DO UPDATE SET report = $3, reported_at = $4, last_checked_at = $5`
-	default:
-		return fmt.Errorf("writing report with DB %v is not supported", storage.dbDriverType)
+	// Skip writing the report if it isn't newer than a report
+	// that is already in the database for the same cluster.
+	if oldLastChecked, exists := storage.clustersLastChecked[clusterName]; exists && !lastCheckedTime.After(oldLastChecked) {
+		return ErrOldReport
 	}
 
+	// Get the UPSERT query for writing a report into the database.
+	upsertQuery, err := storage.getReportUpsertQuery()
+	if err != nil {
+		return err
+	}
+
+	// Begin a new transaction.
 	tx, err := storage.connection.Begin()
 	if err != nil {
 		return err
@@ -466,7 +509,7 @@ func (storage DBStorage) WriteReportForCluster(
 		orgID, clusterName, lastCheckedTime)
 	err = convertDBError(err)
 	if err != nil {
-		log.Error().Err(err).Msg("Unable to find most recent report in database")
+		log.Error().Err(err).Msg("Unable to look up the most recent report in database")
 		_ = tx.Rollback()
 		return err
 	}
@@ -476,7 +519,6 @@ func (storage DBStorage) WriteReportForCluster(
 	if rows.Next() {
 		log.Warn().Msgf("Database already contains report for organization %d and cluster name %s more recent than %v",
 			orgID, clusterName, lastCheckedTime)
-
 		_ = tx.Rollback()
 		return nil
 	}
@@ -490,6 +532,7 @@ func (storage DBStorage) WriteReportForCluster(
 		return err
 	}
 
+	storage.clustersLastChecked[clusterName] = lastCheckedTime
 	metrics.WrittenReports.Inc()
 	return tx.Commit()
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -210,22 +210,13 @@ func TestDBStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 	helpers.FailOnError(t, err)
 
 	// Try to insert older report.
-	// If there's a way to check for a warning being logged,
-	// it would be quite handy to add it here.
 	err = mockStorage.WriteReportForCluster(
 		testOrgID,
 		testClusterName,
 		testClusterEmptyReport,
 		olderTime,
 	)
-	helpers.FailOnError(t, err)
-
-	_, timestamp, err := mockStorage.ReadReportForCluster(testOrgID, testClusterName)
-	helpers.FailOnError(t, err)
-
-	// Unfortunately, the ReadReport returns the timestamp as a different type than
-	// what has been initially inserted, so we need to format it in the same way here.
-	assert.Equal(t, types.Timestamp(newerTime.Format(time.RFC3339)), timestamp)
+	assert.Equal(t, storage.ErrOldReport, err)
 }
 
 // TestDBStorageWriteReportForClusterDroppedReportTable checks the error


### PR DESCRIPTION
# Description

Right now, every time a report is about to be written into database, we first check if it isn't older than an existing report already in the database. This approach is very slow because it required the execution of SQL query for every outdated report.

To make this check significantly faster, the `last_checked_at` values will be loaded into an in-memory dictionary and no SQL transaction will begin if the report is outdated. In case there will be multiple consumer instances running in parallel, the old check still remains present. However, it won't be executed for obviously/significantly outdated reports, which should still speed up the initial consumption of the already processed reports that happens due to some issues with the Kafka library.

Fixes #664 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)

## Testing steps

`make before_commit` as usual, including postgres-based tests
