### PR TITLE
Fix image building in OCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM registry.redhat.io/rhel8/go-toolset:1.13 AS builder
 
-COPY . insights-results-aggregator
+COPY . /tmp/insights-results-aggregator
 
 ARG GITHUB_API_TOKEN
 
@@ -28,14 +28,14 @@ RUN umask 0022 && \
     echo "echo $GITHUB_API_TOKEN" > $GIT_ASKPASS && \
     chmod +x /tmp/git-askpass.sh && \
     git -C $RULES_CONTENT_DIR clone $RULES_REPO $RULES_CONTENT_DIR && \
-    cd insights-results-aggregator && \
+    cd /tmp/insights-results-aggregator && \
     make build && \
     chmod a+x insights-results-aggregator
 
 FROM registry.redhat.io/ubi8-minimal
 
-COPY --from=builder /opt/app-root/src/insights-results-aggregator/insights-results-aggregator .
-COPY --from=builder /opt/app-root/src/insights-results-aggregator/openapi.json /openapi/openapi.json
+COPY --from=builder /tmp/insights-results-aggregator/insights-results-aggregator .
+COPY --from=builder /tmp/insights-results-aggregator/openapi.json /openapi/openapi.json
 # copy just the rule content instead of the whole repository
 COPY --from=builder /tmp/rules-content/content/ /rules-content
 # copy tutorial/fake rule hit on all reports


### PR DESCRIPTION
# Description

`registry.redhat.io/rhel8/go-toolset:1.13` has some filesystem permission change, therefore, we should build everything in `/tmp`

Fixes #710 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Built locally.
