### PR TITLE
Fixing Makefile to execute shellcheck over the whole Bash base code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean build fmt lint vet run test cover style cyclo
+.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo json-check style run test cover integration_tests rest_api_tests rules_content sqlite_db license before_commit help
 
 SOURCES:=$(shell find . -name '*.go')
 
@@ -31,7 +31,7 @@ ineffassign: ## Run ineffassign checker
 	./ineffassign.sh
 
 shellcheck: ## Run shellcheck
-	shellcheck **/*.sh
+	shellcheck *.sh */*.sh
 
 errcheck: ## Run errcheck
 	@echo "Running errcheck"

--- a/abcgo.sh
+++ b/abcgo.sh
@@ -15,8 +15,6 @@
 
 threshold=45
 
-RED=$(tput setaf 1)
-GREEN=$(tput setaf 2)
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)
 GREEN_BG=$(tput setab 2)

--- a/gosec.sh
+++ b/gosec.sh
@@ -20,11 +20,6 @@ NC=$(tput sgr0) # No Color
 
 GO_SEC_ARGS=""
 
-VERBOSE=false
-if [[ $* == *verbose* ]]; then
-    VERBOSE=true
-fi
-
 if [[ $* != *verbose* ]]; then
     GO_SEC_ARGS="-quiet"
 fi

--- a/test.sh
+++ b/test.sh
@@ -95,8 +95,9 @@ function test_rest_api() {
     # Without this, the DB could be locked because
     # the migrations have not yet finished.
     sleep 2
-    for i in {1..5}; do
-        populate_db_with_mock_data 2>/dev/null && break || sleep 1
+    for _ in {1..5}; do
+        populate_db_with_mock_data 2>/dev/null && break
+        sleep 1
     done
 
     echo "Building REST API tests utility"
@@ -124,9 +125,9 @@ function test_rest_api() {
 function test_openapi() {
     echo "Testing OpenAPI specifications file"
     # shellcheck disable=2181
-    docker run --rm -v "${PWD}":/local/:Z openapitools/openapi-generator-cli validate -i ./local/openapi.json
 
-    if [ $? -eq 0 ]; then
+    if docker run --rm -v "${PWD}":/local/:Z openapitools/openapi-generator-cli validate -i ./local/openapi.json
+    then
         echo "OpenAPI spec file is OK"
     else
         echo "OpenAPI spec file validation failed"

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -15,11 +15,12 @@
 
 
 CONFIG_FILE=config-devel.toml
-POSTGRES_PORT=$(cat $CONFIG_FILE | grep -i pg_port | grep -E -o '[0-9]+')
+POSTGRES_PORT=$(grep -i pg_port $CONFIG_FILE | grep -E -o '[0-9]+')
 
 function run_unit_tests() {
-    go test -coverprofile coverage.out $(go list ./... | grep -v tests)
-    if [ $? -ne 0 ]; then
+    files=$(go list ./... | grep -v tests)
+    if ! go test -coverprofile coverage.out "$files"
+    then
         echo "unit tests failed"
         exit 1
     fi
@@ -29,7 +30,7 @@ echo "running unit tests with sqlite in memory"
 # tests with sqlite
 run_unit_tests
 
-if netstat -nltp 2>/dev/null | grep $POSTGRES_PORT >/dev/null; then
+if netstat -nltp 2>/dev/null | grep "$POSTGRES_PORT" >/dev/null; then
     # tests with postgres
     export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB="postgres"
     export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS="admin"

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -18,8 +18,8 @@ CONFIG_FILE=config-devel.toml
 POSTGRES_PORT=$(grep -i pg_port $CONFIG_FILE | grep -E -o '[0-9]+')
 
 function run_unit_tests() {
-    files=$(go list ./... | grep -v tests)
-    if ! go test -coverprofile coverage.out "$files"
+    # shellcheck disable=SC2046
+    if ! go test -coverprofile coverage.out $(go list ./... | grep -v tests | tr '\n' ' ')
     then
         echo "unit tests failed"
         exit 1

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -21,7 +21,7 @@ function clean_up() {
 trap clean_up EXIT
 
 RULES_REPO="https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp.git"
-SCRIPT_DIR="$(dirname $(realpath $0))"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 CONTENT_DIR="${SCRIPT_DIR}/rules-content"
 TUTORIAL_RULE_CONTENT_DIR="${SCRIPT_DIR}/rules/tutorial/content"
 
@@ -30,24 +30,19 @@ RULES_CONTENT="${CLONE_TEMP_DIR}/content/"
 
 echo "Attempting to clone repository into ${CLONE_TEMP_DIR}"
 
-git clone "${RULES_REPO}" "${CLONE_TEMP_DIR}"
-if [ $? -ne 0 ]
+if ! git clone "${RULES_REPO}" "${CLONE_TEMP_DIR}"
 then
     echo "Couldn't clone rules repository"
     exit 1
 fi
 
-rm -rf "${CONTENT_DIR}"
-
-if [ $? -ne 0 ]
+if ! rm -rf "${CONTENT_DIR}"
 then
     echo "Couldn't remove previous content"
     exit 1
 fi
 
-mv "${RULES_CONTENT}" "${CONTENT_DIR}"
-
-if [ $? -ne 0 ]
+if ! mv "${RULES_CONTENT}" "${CONTENT_DIR}"
 then
     echo "Couldn't move rules content from cloned repository"
     exit 1


### PR DESCRIPTION
# Description

The current `make shellcheck` execution only checks a minimal subset of our Bash scripts. It is needed to run it over the whole Bash codebase.

Fixes #715

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)

## Testing steps

CI