### PR TITLE
Add minimal migration CLI functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Aggregator service consists of three main parts:
 ![data_flow](./doc/customer-facing-services-architecture.png)
 
 1. Event about new data from insights operator is consumed from Kafka. That event contains (among other things) URL to S3 Bucket
-2. Insights operator data is read from S3 Bucket and insigts rules are applied to that data
+2. Insights operator data is read from S3 Bucket and Insights rules are applied to that data
 3. Results (basically organization ID + cluster name + insights results JSON) are stored back into Kafka, but into different topic
 4. That results are consumed by Insights rules aggregator service that caches them
 5. The service provides such data via REST API to other tools, like OpenShift Cluster Manager web UI, OpenShift console, etc.
@@ -128,7 +128,7 @@ CREATE TABLE cluster_rule_toggle (
     disabled_at TIMESTAMP NULL,
     enabled_at TIMESTAMP NULL,
     updated_at TIMESTAMP NOT NULL,
-    
+
     CHECK (disabled >= 0 AND disabled <= 1),
 
     PRIMARY KEY(cluster_id, rule_id, user_id)
@@ -252,10 +252,10 @@ enable_cors = true
 * `address` is host and port which server should listen to
 * `api_prefix` is prefix for RestAPI path
 * `api_spec_file` is the location of a required OpenAPI specifications file
-* `debug` is developer mode that enables some special API endpoints not used on production. In production, `false` is used everytime.
-* `auth` turns on or turns authentication. Please note that this option can be set to `false` only in devel environment. In production, `true` is used everytime.
+* `debug` is developer mode that enables some special API endpoints not used on production. In production, `false` is used every time.
+* `auth` turns on or turns authentication. Please note that this option can be set to `false` only in devel environment. In production, `true` is used every time.
 * `auth_type` set type of auth, it means which header to use for auth `x-rh-identity` or `Authorization`. Can be used only with `auth = true`. Possible options: `jwt`, `xrh`
-* `use_https` is option to turn on TLS server. Please note that this option can be set to `false` only in devel environment. In production, `true` is used everytime.
+* `use_https` is option to turn on TLS server. Please note that this option can be set to `false` only in devel environment. In production, `true` is used every time.
 * `enable_cors` is option to turn on CORS header, that allows to connect from different hosts (**don't use it in production**)
 
 Please note that if `auth` configuration option is turned off, not all REST API endpoints will be usable. Whole REST API schema is satisfied only for `auth = true`.
@@ -339,6 +339,26 @@ pg_params = "sslmode=disable"
 
 This service contains an implementation of a simple database migration mechanism that allows semi-automatic transitions between various database versions as well as building the latest version of the database from scratch.
 
+The migrations are no longer performed during initialization of the service to make running multiple instances of the service in parallel against the same database safer. Instead, the database migration version can now be set using the built-in CLI sub-command `migration` (aliases: `migrations` and `migrate`).
+
+#### Printing information about database migrations
+
+```shell
+./insights-results-aggregator migrations
+```
+
+#### Upgrading the database to the latest available migration
+
+```shell
+./insights-results-aggregator migration latest
+```
+
+#### Downgrading to the base (empty) database migration version
+
+```shell
+./insights-results-aggregator migration 0
+```
+
 Before using the migration mechanism, it is first necessary to initialize the migration information table `migration_info`. This can be done using the `migration.InitInfoTable(*sql.DB)` function. Any attempt to get or set the database version without initializing this table first will result in a `no such table: migration_info` error from the SQL driver.
 
 New migrations must be added manually into the code, because it was decided that modifying the list of migrations at runtime is undesirable.
@@ -381,14 +401,12 @@ In debug mode, standard Golang pprof interface is available at `/debug/pprof/`
 
 Common usage (for using pprof against local instance):
 
-```
+```shell
 go tool pprof localhost:8080/debug/pprof/profile
 ```
 
 A practical example is available here:
-https://medium.com/@paulborile/profiling-a-golang-rest-api-server-635fa0ed45f3
-
-
+<https://medium.com/@paulborile/profiling-a-golang-rest-api-server-635fa0ed45f3>
 
 ## Authentication
 
@@ -424,7 +442,7 @@ If aggregator didn't get identity token or got invalid one, then it returns erro
 
 Please look into document [CONTRIBUTING.md](CONTRIBUTING.md) that contains all information about how to contribute to this project.
 
-Please look also at [Definitiot of Done](DoD.md) document with further informations.
+Please look also at [Definition of Done](DoD.md) document with further information.
 
 ## Testing
 
@@ -433,7 +451,7 @@ tl;dr: `make before_commit` will run most of the checks by magic
 The following tests can be run to test your code in `insights-results-aggregator`.
 Detailed information about each type of test is included in the corresponding subsection:
 
-1. Unit tests: checks behaviour of all units in source code (methods, functions)
+1. Unit tests: checks behavior of all units in source code (methods, functions)
 1. REST API Tests: test the real REST API of locally deployed application with database initialized with test data only
 1. Integration tests: the integration tests for `insights-results-aggregator` service
 1. Metrics tests: test whether Prometheus metrics are exposed as expected
@@ -471,9 +489,9 @@ By default all logs from the application aren't shown, if you want to see them, 
 
 * Unit tests that use the standard tool `go test`.
 * `go fmt` tool to check code formatting. That tool is run with `-s` flag to perform [following transformations](https://golang.org/cmd/gofmt/#hdr-The_simplify_command)
-* `go vet` to report likely mistakes in source code, for example suspicious constructs, such as Printf calls whose arguments do not align with the format string.
+* `go vet` to report likely mistakes in source code, for example suspicious constructs, such as `Printf` calls whose arguments do not align with the format string.
 * `golint` as a linter for all Go sources stored in this repository
-* `gocyclo` to report all functions and methods with too high cyclomatic complexity. The cyclomatic complexity of a function is calculated according to the following rules: 1 is the base complexity of a function +1 for each 'if', 'for', 'case', '&&' or '||' Go Report Card warns on functions with cyclomatic complexity > 9
+* `gocyclo` to report all functions and methods with too high cyclomatic complexity. The cyclomatic complexity of a function is calculated according to the following rules: 1 is the base complexity of a function +1 for each `if`, `for`, `case`, `&&` or `||` Go Report Card warns on functions with cyclomatic complexity > 9
 * `goconst` to find repeated strings that could be replaced by a constant
 * `gosec` to inspect source code for security problems by scanning the Go AST
 * `ineffassign` to detect and print all ineffectual assignments in Go code
@@ -487,7 +505,7 @@ History of checks performed by CI is available at [RedHatInsights / insights-res
 
 ## Rules
 
-The user has the ability to disable a rule/health check recommendation that they're not interested in to stop it from showing in OCM. The user also has the ability to re-enable the rule, in case they later become interested in it, or in the case of an accidental disable, for exapmle.
+The user has the ability to disable a rule/health check recommendation that they're not interested in to stop it from showing in OCM. The user also has the ability to re-enable the rule, in case they later become interested in it, or in the case of an accidental disable, for example.
 
 This is made possible by using these two endpoints:
 `clusters/{cluster}/rules/{rule_id}/disable`
@@ -501,7 +519,7 @@ Directory `rules/tutorial/` contains tutorial rule that is 'hit' by any cluster.
 
 Data to be consumed by aggregator through Kafka broker is prepared in repository [RedHatInsights / insights-results-aggregator-data](https://github.com/RedHatInsights/insights-results-aggregator-data). Description of these data is [available there](https://github.com/RedHatInsights/insights-results-aggregator-data/blob/master/README.md).
 
-## Utilitites
+## Utilities
 
 Utilities are stored in `utils` subdirectory.
 
@@ -509,9 +527,9 @@ Utilities are stored in `utils` subdirectory.
 
 Simple checker if all JSONs have the correct syntax (not scheme).
 
-Usage:
+#### Script usage
 
-```
+```text
 usage: json_check.py [-h] [-v]
 
 optional arguments:

--- a/aggregator.go
+++ b/aggregator.go
@@ -337,7 +337,7 @@ func printMigrationInfo(dbConn *sql.DB) int {
 	currMigVer, err := migration.GetDBVersion(dbConn)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to get current DB version")
-		return ExitStatusPrepareDbError
+		return ExitStatusMigrationError
 	}
 
 	log.Info().Msgf("Current DB version: %d", currMigVer)
@@ -354,7 +354,7 @@ func setMigrationVersion(dbConn *sql.DB, versStr string) int {
 		vers, err := strconv.Atoi(versStr)
 		if err != nil {
 			log.Error().Err(err).Msg("Unable to parse target migration version")
-			return ExitStatusPrepareDbError
+			return ExitStatusMigrationError
 		}
 
 		targetVersion = migration.Version(vers)
@@ -362,7 +362,7 @@ func setMigrationVersion(dbConn *sql.DB, versStr string) int {
 
 	if err := migration.SetDBVersion(dbConn, targetVersion); err != nil {
 		log.Error().Err(err).Msg("Unable to perform migration")
-		return ExitStatusPrepareDbError
+		return ExitStatusMigrationError
 	}
 
 	log.Info().Msgf("Database version is now %d", targetVersion)
@@ -389,7 +389,7 @@ func performMigrations() int {
 
 	default:
 		log.Error().Msg("Unexpected number of arguments to migrations command (expected 0-1)")
-		return ExitStatusPrepareDbError
+		return ExitStatusMigrationError
 	}
 }
 

--- a/aggregator.go
+++ b/aggregator.go
@@ -117,6 +117,7 @@ func prepareDB() int {
 	if autoMigrate {
 		if err := dbStorage.MigrateToLatest(); err != nil {
 			log.Error().Err(err).Msg("unable to migrate DB to latest version")
+			return ExitStatusPrepareDbError
 		}
 	}
 

--- a/aggregator.go
+++ b/aggregator.go
@@ -321,6 +321,7 @@ func performMigrations() int {
 
 	if err := migration.InitInfoTable(dbConn); err != nil {
 		log.Error().Err(err).Msg("Unable to initialize migration info table")
+		return ExitStatusPrepareDbError
 	}
 
 	switch len(migrationArgs) {

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -79,6 +79,10 @@ func TestStartService(t *testing.T) {
 			"INSIGHTS_RESULTS_AGGREGATOR__STORAGE__SQLITE_DATASOURCE": ":memory:",
 		})
 
+		// It is necessary to perform migrations for this test
+		// because the service won't run on top of an empty DB.
+		*main.AutoMigratePtr = true
+
 		go func() {
 			main.StartService()
 		}()

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -70,6 +70,10 @@ func TestCreateStorage(t *testing.T) {
 }
 
 func TestStartService(t *testing.T) {
+	// It is necessary to perform migrations for this test
+	// because the service won't run on top of an empty DB.
+	*main.AutoMigratePtr = true
+
 	helpers.RunTestWithTimeout(t, func(t *testing.T) {
 		os.Clearenv()
 
@@ -79,10 +83,6 @@ func TestStartService(t *testing.T) {
 			"INSIGHTS_RESULTS_AGGREGATOR__STORAGE__SQLITE_DATASOURCE": ":memory:",
 		})
 
-		// It is necessary to perform migrations for this test
-		// because the service won't run on top of an empty DB.
-		*main.AutoMigratePtr = true
-
 		go func() {
 			main.StartService()
 		}()
@@ -91,10 +91,13 @@ func TestStartService(t *testing.T) {
 		errCode := main.StopService()
 		assert.Equal(t, main.ExitStatusOK, errCode)
 	}, testsTimeout)
+
+	*main.AutoMigratePtr = false
 }
 
 func TestStartServiceWithMockBroker(t *testing.T) {
 	const topicName = "topic"
+	*main.AutoMigratePtr = true
 
 	helpers.RunTestWithTimeout(t, func(t *testing.T) {
 		mockBroker := sarama.NewMockBroker(t, 0)
@@ -129,6 +132,8 @@ func TestStartServiceWithMockBroker(t *testing.T) {
 		errCode := main.StopService()
 		assert.Equal(t, main.ExitStatusOK, errCode)
 	}, testsTimeout)
+
+	*main.AutoMigratePtr = false
 }
 
 func TestStartService_DBError(t *testing.T) {
@@ -189,8 +194,12 @@ func TestPrepareDB(t *testing.T) {
 		"INSIGHTS_RESULTS_AGGREGATOR__CONTENT__PATH": "./tests/content/ok/",
 	})
 
+	*main.AutoMigratePtr = true
+
 	errCode := main.PrepareDB()
 	assert.Equal(t, main.ExitStatusOK, errCode)
+
+	*main.AutoMigratePtr = false
 }
 
 func TestPrepareDB_NoRulesDirectory(t *testing.T) {
@@ -277,8 +286,12 @@ func TestStartService_BadBrokerAndServerAddress(t *testing.T) {
 		"INSIGHTS_RESULTS_AGGREGATOR__CONTENT__PATH": "./tests/content/ok/",
 	})
 
+	*main.AutoMigratePtr = true
+
 	errCode := main.StartService()
 	assert.Equal(t, main.ExitStatusConsumerError+main.ExitStatusServerError, errCode)
+
+	*main.AutoMigratePtr = false
 }
 
 // TestPrintVersionInfo is dummy ATM - we'll check versions etc. in integration tests

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -302,7 +302,7 @@ func TestPrintEnv(t *testing.T) {
 func TestGetDBForMigrations(t *testing.T) {
 	db, dbConn, exitCode := main.GetDBForMigrations()
 	assert.Equal(t, main.ExitStatusOK, exitCode)
-	defer db.Close()
+	defer helpers.MustCloseStorage(t, db)
 
 	row := dbConn.QueryRow("SELECT version FROM migration_info")
 	var version migration.Version
@@ -314,7 +314,7 @@ func TestGetDBForMigrations(t *testing.T) {
 func TestPrintMigrationInfo(t *testing.T) {
 	db, dbConn, exitCode := main.GetDBForMigrations()
 	assert.Equal(t, exitCode, main.ExitStatusOK)
-	defer db.Close()
+	defer helpers.MustCloseStorage(t, db)
 
 	exitCode = main.PrintMigrationInfo(dbConn)
 	assert.Equal(t, main.ExitStatusOK, exitCode)
@@ -326,7 +326,7 @@ func TestPrintMigrationInfoClosedDB(t *testing.T) {
 	db, dbConn, exitCode := main.GetDBForMigrations()
 	assert.Equal(t, exitCode, main.ExitStatusOK)
 	// Close DB connection immediately.
-	db.Close()
+	helpers.MustCloseStorage(t, db)
 
 	exitCode = main.PrintMigrationInfo(dbConn)
 	assert.Equal(t, main.ExitStatusMigrationError, exitCode)
@@ -336,7 +336,7 @@ func TestPrintMigrationInfoClosedDB(t *testing.T) {
 func TestSetMigrationVersionZero(t *testing.T) {
 	db, dbConn, exitCode := main.GetDBForMigrations()
 	assert.Equal(t, exitCode, main.ExitStatusOK)
-	defer db.Close()
+	defer helpers.MustCloseStorage(t, db)
 
 	exitCode = main.SetMigrationVersion(dbConn, "0")
 	assert.Equal(t, main.ExitStatusOK, exitCode)
@@ -351,7 +351,7 @@ func TestSetMigrationVersionZero(t *testing.T) {
 func TestSetMigrationVersionLatest(t *testing.T) {
 	db, dbConn, exitCode := main.GetDBForMigrations()
 	assert.Equal(t, exitCode, main.ExitStatusOK)
-	defer db.Close()
+	defer helpers.MustCloseStorage(t, db)
 
 	exitCode = main.SetMigrationVersion(dbConn, "latest")
 	assert.Equal(t, main.ExitStatusOK, exitCode)
@@ -368,7 +368,7 @@ func TestSetMigrationVersionClosedDB(t *testing.T) {
 	db, dbConn, exitCode := main.GetDBForMigrations()
 	assert.Equal(t, exitCode, main.ExitStatusOK)
 	// Close DB connection immediately.
-	db.Close()
+	helpers.MustCloseStorage(t, db)
 
 	exitCode = main.SetMigrationVersion(dbConn, "0")
 	assert.Equal(t, main.ExitStatusMigrationError, exitCode)
@@ -380,7 +380,7 @@ func TestSetMigrationVersionInvalid(t *testing.T) {
 	db, dbConn, exitCode := main.GetDBForMigrations()
 	assert.Equal(t, exitCode, main.ExitStatusOK)
 	// Close DB connection immediately.
-	db.Close()
+	helpers.MustCloseStorage(t, db)
 
 	exitCode = main.SetMigrationVersion(dbConn, "")
 	assert.Equal(t, main.ExitStatusMigrationError, exitCode)

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -30,6 +30,7 @@ import (
 
 	main "github.com/RedHatInsights/insights-results-aggregator"
 	"github.com/RedHatInsights/insights-results-aggregator/conf"
+	"github.com/RedHatInsights/insights-results-aggregator/migration"
 	"github.com/RedHatInsights/insights-results-aggregator/storage"
 	"github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
 )
@@ -279,4 +280,144 @@ func TestStartService_BadBrokerAndServerAddress(t *testing.T) {
 // TestPrintVersionInfo is dummy ATM - we'll check versions etc. in integration tests
 func TestPrintVersionInfo(t *testing.T) {
 	main.PrintVersionInfo()
+}
+
+// TestPrintHelp checks that printing help returns OK exit code.
+func TestPrintHelp(t *testing.T) {
+	assert.Equal(t, main.ExitStatusOK, main.PrintHelp())
+}
+
+// TestPrintConfig checks that printing configuration info returns OK exit code.
+func TestPrintConfig(t *testing.T) {
+	assert.Equal(t, main.ExitStatusOK, main.PrintConfig())
+}
+
+// TestPrintEnv checks that printing environment variables returns OK exit code.
+func TestPrintEnv(t *testing.T) {
+	assert.Equal(t, main.ExitStatusOK, main.PrintEnv())
+}
+
+// TestGetDBForMigrations checks that the function ensures the existence of
+// the migration_info table and that the SQL DB connection works correctly.
+func TestGetDBForMigrations(t *testing.T) {
+	db, dbConn, exitCode := main.GetDBForMigrations()
+	assert.Equal(t, main.ExitStatusOK, exitCode)
+	defer db.Close()
+
+	row := dbConn.QueryRow("SELECT version FROM migration_info")
+	var version migration.Version
+	err := row.Scan(&version)
+	assert.NoError(t, err, "unable to read version from migration info table")
+}
+
+// TestPrintMigrationInfo checks that printing migration info exits with OK code.
+func TestPrintMigrationInfo(t *testing.T) {
+	db, dbConn, exitCode := main.GetDBForMigrations()
+	assert.Equal(t, exitCode, main.ExitStatusOK)
+	defer db.Close()
+
+	exitCode = main.PrintMigrationInfo(dbConn)
+	assert.Equal(t, main.ExitStatusOK, exitCode)
+}
+
+// TestPrintMigrationInfoClosedDB checks that printing migration info with
+// a closed DB connection results in a migration error exit code.
+func TestPrintMigrationInfoClosedDB(t *testing.T) {
+	db, dbConn, exitCode := main.GetDBForMigrations()
+	assert.Equal(t, exitCode, main.ExitStatusOK)
+	// Close DB connection immediately.
+	db.Close()
+
+	exitCode = main.PrintMigrationInfo(dbConn)
+	assert.Equal(t, main.ExitStatusMigrationError, exitCode)
+}
+
+// TestSetMigrationVersionZero checks that it is possible to set migration version to 0.
+func TestSetMigrationVersionZero(t *testing.T) {
+	db, dbConn, exitCode := main.GetDBForMigrations()
+	assert.Equal(t, exitCode, main.ExitStatusOK)
+	defer db.Close()
+
+	exitCode = main.SetMigrationVersion(dbConn, "0")
+	assert.Equal(t, main.ExitStatusOK, exitCode)
+
+	version, err := migration.GetDBVersion(dbConn)
+	assert.NoError(t, err, "unable to get migration version")
+
+	assert.Equal(t, migration.Version(0), version)
+}
+
+// TestSetMigrationVersionZero checks that it is to upgrade DB to the latest migration.
+func TestSetMigrationVersionLatest(t *testing.T) {
+	db, dbConn, exitCode := main.GetDBForMigrations()
+	assert.Equal(t, exitCode, main.ExitStatusOK)
+	defer db.Close()
+
+	exitCode = main.SetMigrationVersion(dbConn, "latest")
+	assert.Equal(t, main.ExitStatusOK, exitCode)
+
+	version, err := migration.GetDBVersion(dbConn)
+	assert.NoError(t, err, "unable to get migration version")
+
+	assert.Equal(t, migration.GetMaxVersion(), version)
+}
+
+// TestSetMigrationVersionClosedDB checks that setting the migration version
+// with a closed DB connection results in a migration error exit code.
+func TestSetMigrationVersionClosedDB(t *testing.T) {
+	db, dbConn, exitCode := main.GetDBForMigrations()
+	assert.Equal(t, exitCode, main.ExitStatusOK)
+	// Close DB connection immediately.
+	db.Close()
+
+	exitCode = main.SetMigrationVersion(dbConn, "0")
+	assert.Equal(t, main.ExitStatusMigrationError, exitCode)
+}
+
+// TestSetMigrationVersionInvalid checks that when supplied an invalid version
+// argument, the set version function exits with a migration error code.
+func TestSetMigrationVersionInvalid(t *testing.T) {
+	db, dbConn, exitCode := main.GetDBForMigrations()
+	assert.Equal(t, exitCode, main.ExitStatusOK)
+	// Close DB connection immediately.
+	db.Close()
+
+	exitCode = main.SetMigrationVersion(dbConn, "")
+	assert.Equal(t, main.ExitStatusMigrationError, exitCode)
+}
+
+// TestPerformMigrationsPrint checks that the command for
+// printing migration info exits with the OK exit code.
+func TestPerformMigrationsPrint(t *testing.T) {
+	oldArgs := os.Args
+
+	os.Args = []string{os.Args[0], "migrations"}
+	exitCode := main.PerformMigrations()
+	assert.Equal(t, main.ExitStatusOK, exitCode)
+
+	os.Args = oldArgs
+}
+
+// TestPerformMigrationsPrint checks that the command for
+// setting migration version exits with the OK exit code.
+func TestPerformMigrationsSet(t *testing.T) {
+	oldArgs := os.Args
+
+	os.Args = []string{os.Args[0], "migrations", "0"}
+	exitCode := main.PerformMigrations()
+	assert.Equal(t, main.ExitStatusOK, exitCode)
+
+	os.Args = oldArgs
+}
+
+// TestPerformMigrationsPrint checks that supplying too many arguments
+// to the migration sub-commands results in the migration error exit code.
+func TestPerformMigrationsTooManyArgs(t *testing.T) {
+	oldArgs := os.Args
+
+	os.Args = []string{os.Args[0], "migrations", "hello", "world"}
+	exitCode := main.PerformMigrations()
+	assert.Equal(t, main.ExitStatusMigrationError, exitCode)
+
+	os.Args = oldArgs
 }

--- a/export_test.go
+++ b/export_test.go
@@ -38,4 +38,5 @@ var (
 	PrintMigrationInfo    = printMigrationInfo
 	SetMigrationVersion   = setMigrationVersion
 	PerformMigrations     = performMigrations
+	AutoMigratePtr        = &autoMigrate
 )

--- a/export_test.go
+++ b/export_test.go
@@ -31,4 +31,11 @@ var (
 	StartConsumer         = startConsumer
 	StartServer           = startServer
 	PrintVersionInfo      = printVersionInfo
+	PrintHelp             = printHelp
+	PrintConfig           = printConfig
+	PrintEnv              = printEnv
+	GetDBForMigrations    = getDBForMigrations
+	PrintMigrationInfo    = printMigrationInfo
+	SetMigrationVersion   = setMigrationVersion
+	PerformMigrations     = performMigrations
 )

--- a/server/server_read_report_test.go
+++ b/server/server_read_report_test.go
@@ -157,6 +157,8 @@ func TestHttpServer_readReportForCluster_getContentForRule_DBError(t *testing.T)
 	mockStorage := storage.NewFromConnection(connection, storage.DBDriverSQLite3)
 	defer helpers.MustCloseStorage(t, mockStorage)
 
+	helpers.FailOnError(t, mockStorage.MigrateToLatest())
+
 	err = mockStorage.Init()
 	helpers.FailOnError(t, err)
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -202,16 +202,18 @@ func initAndGetDriver(configuration Configuration) (driverType DBDriver, driverN
 	return
 }
 
-// Init method is doing initialization like creating tables in underlying database
-func (storage DBStorage) Init() error {
-	// Perform all defined migrations on the database.
+// MigrateToLatest migrates the database to the latest available
+// migration version. This must be done before an Init() call.
+func (storage DBStorage) MigrateToLatest() error {
 	if err := migration.InitInfoTable(storage.connection); err != nil {
 		return err
 	}
-	if err := migration.SetDBVersion(storage.connection, migration.GetMaxVersion()); err != nil {
-		return err
-	}
+	return migration.SetDBVersion(storage.connection, migration.GetMaxVersion())
+}
 
+// Init performs all database initialization
+// tasks necessary for futher service operation.
+func (storage DBStorage) Init() error {
 	// Read clusterName:LastChecked dictionary from DB.
 	rows, err := storage.connection.Query("SELECT cluster, last_checked_at FROM report")
 	if err != nil {

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -774,6 +774,8 @@ func TestDBStorageVoteOnRuleUnsupportedDriverError(t *testing.T) {
 	mockStorage := storage.NewFromConnection(connection, -1)
 	defer helpers.MustCloseStorage(t, mockStorage)
 
+	helpers.FailOnError(t, mockStorage.MigrateToLatest())
+
 	err = mockStorage.Init()
 	helpers.FailOnError(t, err)
 

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,7 @@
 
 COLORS_RED='\033[0;31m'
 COLORS_RESET='\033[0m'
-LOG_LEVEL="error"
+LOG_LEVEL="fatal"
 VERBOSE=false
 
 if [[ $* == *verbose* ]]; then
@@ -64,7 +64,10 @@ fi
 function migrate_db_to_latest() {
     echo "Migrating DB to the latest migration version..."
 
-    if ./insights-results-aggregator migrate latest >/dev/null; then
+    if INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE=./tests/tests \
+        ./insights-results-aggregator migrate latest >/dev/null
+    then
+
         echo "Database migration was successful"
         return 0
     else

--- a/test.sh
+++ b/test.sh
@@ -61,11 +61,23 @@ else
     exit 1
 fi
 
+function migrate_db_to_latest() {
+    echo "Migrating DB to the latest migration version..."
+
+    if ./insights-results-aggregator migrate latest >/dev/null; then
+        echo "Database migration was successful"
+        return 0
+    else
+        echo "Unable to migrate DB"
+        return 1
+    fi
+}
+
 function populate_db_with_mock_data() {
     echo "Populating db with mock data..."
 
     if ./local_storage/populate_db_with_mock_data.sh; then
-        echo "Done"
+        echo "Database successfully populated with mock data"
         return 0
     else
         echo "Unable to populate db with mock data"
@@ -88,17 +100,11 @@ function start_service() {
 }
 
 function test_rest_api() {
+    migrate_db_to_latest
     start_service
-    # Retry populating the database with mock data N times.
-    # Wait 2 seconds between the retry starts to settle down
-    # Wait 1 second between attempts.
-    # Without this, the DB could be locked because
-    # the migrations have not yet finished.
     sleep 2
-    for _ in {1..5}; do
-        populate_db_with_mock_data 2>/dev/null && break
-        sleep 1
-    done
+    populate_db_with_mock_data
+    sleep 1
 
     echo "Building REST API tests utility"
     if go build -o rest-api-tests tests/rest_api_tests.go; then

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,7 @@
 
 COLORS_RED='\033[0;31m'
 COLORS_RESET='\033[0m'
-LOG_LEVEL="fatal"
+LOG_LEVEL="error"
 VERBOSE=false
 
 if [[ $* == *verbose* ]]; then

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -131,6 +131,7 @@ func mustGetSqliteStorage(tb testing.TB, datasource string, init bool) storage.S
 	sqliteStorage := storage.NewFromConnection(db, storage.DBDriverSQLite3)
 
 	if init {
+		FailOnError(tb, sqliteStorage.MigrateToLatest())
 		FailOnError(tb, sqliteStorage.Init())
 	}
 
@@ -165,6 +166,7 @@ func MustGetPostgresStorage(tb testing.TB, init bool) (storage.Storage, func()) 
 	FailOnError(tb, err)
 
 	if init {
+		FailOnError(tb, postgresStorage.MigrateToLatest())
 		FailOnError(tb, postgresStorage.Init())
 	}
 


### PR DESCRIPTION
# Description

Not sure if we're really gonna use this, but I believe it could do the job, at least until we decide to move onto a real migration library/framework.

- [x] Executing the `insights-results-aggregator migration latest` command will update the database to the latest migration version.
- [x] Regular start-up of the Aggregator (in service mode) will not perform any DB migrations.

*Marked as WIP because it's WIP, but also because currently the fuction has a ridiculously high cyclomatic complexity, so it may be a bit difficult to review with confidence.*

Fixes #541

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Testing steps

Just manually testing the command so far.