### PR TITLE
Cleanup SQL queries and add license to pg_const

### DIFF
--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -321,7 +321,7 @@ func TestGetDBForMigrations(t *testing.T) {
 	assert.Equal(t, main.ExitStatusOK, exitCode)
 	defer helpers.MustCloseStorage(t, db)
 
-	row := dbConn.QueryRow("SELECT version FROM migration_info")
+	row := dbConn.QueryRow("SELECT version FROM migration_info;")
 	var version migration.Version
 	err := row.Scan(&version)
 	assert.NoError(t, err, "unable to read version from migration info table")

--- a/migration/actual_migrations_test.go
+++ b/migration/actual_migrations_test.go
@@ -281,7 +281,7 @@ func TestMigration5_TableAlreadyExists(t *testing.T) {
 	db, dbDriver, closer := prepareDBAndInfo(t)
 	defer closer()
 
-	_, err := db.Exec(`CREATE TABLE consumer_error(c INTEGER)`)
+	_, err := db.Exec("CREATE TABLE consumer_error(c INTEGER);")
 	helpers.FailOnError(t, err)
 
 	err = migration.SetDBVersion(db, dbDriver, migration.GetMaxVersion())

--- a/migration/helpers.go
+++ b/migration/helpers.go
@@ -50,7 +50,7 @@ func upgradeTable(tx *sql.Tx, tableName, newTableDefinition string) error {
 
 	// disable "G202 (CWE-89): SQL string concatenation"
 	// #nosec G202
-	_, err = tx.Exec(`INSERT INTO ` + tableName + ` SELECT * FROM tmp;`)
+	_, err = tx.Exec("INSERT INTO " + tableName + " SELECT * FROM tmp;")
 	if err != nil {
 		return err
 	}
@@ -85,12 +85,12 @@ func downgradeTable(tx *sql.Tx, tableName, oldTableDefinition string, columns []
 
 	// disable "G202 (CWE-89): SQL string concatenation"
 	// #nosec G202
-	_, err = tx.Exec(`INSERT INTO ` + tableName + ` SELECT ` + columnsStr + ` FROM tmp;`)
+	_, err = tx.Exec("INSERT INTO " + tableName + " SELECT " + columnsStr + " FROM tmp;")
 	if err != nil {
 		return err
 	}
 
-	_, err = tx.Exec(`DROP TABLE tmp;`)
+	_, err = tx.Exec("DROP TABLE tmp;")
 	if err != nil {
 		return err
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -60,15 +60,13 @@ func InitInfoTable(db *sql.DB) error {
 		}
 
 		// INSERT if there's no rows in the table
-		_, err = tx.Exec(`
-			INSERT INTO migration_info (version) SELECT 0 WHERE NOT EXISTS (SELECT version FROM migration_info);
-		`)
+		_, err = tx.Exec("INSERT INTO migration_info (version) SELECT 0 WHERE NOT EXISTS (SELECT version FROM migration_info);")
 		if err != nil {
 			return err
 		}
 
 		var rowCount uint
-		err = tx.QueryRow("SELECT COUNT(*) FROM migration_info").Scan(&rowCount)
+		err = tx.QueryRow("SELECT COUNT(*) FROM migration_info;").Scan(&rowCount)
 		if err != nil {
 			return err
 		}
@@ -89,7 +87,7 @@ func GetDBVersion(db *sql.DB) (Version, error) {
 	}
 
 	var version Version = 0
-	err = db.QueryRow("SELECT version FROM migration_info").Scan(&version)
+	err = db.QueryRow("SELECT version FROM migration_info;").Scan(&version)
 	err = types.ConvertDBError(err)
 
 	return version, err
@@ -120,7 +118,7 @@ func SetDBVersion(db *sql.DB, dbDriver types.DBDriver, targetVer Version) error 
 // updateVersionInDB updates the migration version number in the migration info table.
 // This function does NOT rollback in case of an error. The calling function is expected to do that.
 func updateVersionInDB(tx *sql.Tx, newVersion Version) error {
-	res, err := tx.Exec("UPDATE migration_info SET version=$1", newVersion)
+	res, err := tx.Exec("UPDATE migration_info SET version=$1;", newVersion)
 	if err != nil {
 		return err
 	}

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -51,7 +51,7 @@ var (
 	}
 	testMigration = migration.Migration{
 		StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
-			_, err := tx.Exec("CREATE TABLE migration_test_table (col INTEGER)")
+			_, err := tx.Exec("CREATE TABLE migration_test_table (col INTEGER);")
 			return err
 		},
 		StepDown: func(tx *sql.Tx, _ types.DBDriver) error {
@@ -148,7 +148,7 @@ func TestMigrationInitNotOneRow(t *testing.T) {
 	db, _, closer := prepareDBAndMigrations(t)
 	defer closer()
 
-	_, err := db.Exec("INSERT INTO migration_info(version) VALUES(10)")
+	_, err := db.Exec("INSERT INTO migration_info(version) VALUES(10);")
 	helpers.FailOnError(t, err)
 
 	const expectedErrStr = "unexpected number of rows in migration info table (expected: 1, reality: 2)"
@@ -180,7 +180,7 @@ func TestMigrationGetVersionMultipleRows(t *testing.T) {
 	db, _, closer := prepareDBAndMigrations(t)
 	defer closer()
 
-	_, err := db.Exec("INSERT INTO migration_info(version) VALUES(10)")
+	_, err := db.Exec("INSERT INTO migration_info(version) VALUES(10);")
 	helpers.FailOnError(t, err)
 
 	_, err = migration.GetDBVersion(db)
@@ -191,7 +191,7 @@ func TestMigrationGetVersionEmptyTable(t *testing.T) {
 	db, _, closer := prepareDBAndMigrations(t)
 	defer closer()
 
-	_, err := db.Exec("DELETE FROM migration_info")
+	_, err := db.Exec("DELETE FROM migration_info;")
 	helpers.FailOnError(t, err)
 
 	_, err = migration.GetDBVersion(db)
@@ -202,10 +202,10 @@ func TestMigrationGetVersionInvalidType(t *testing.T) {
 	db, _, closer := prepareDB(t)
 	defer closer()
 
-	_, err := db.Exec("CREATE TABLE migration_info ( version TEXT )")
+	_, err := db.Exec("CREATE TABLE migration_info ( version TEXT );")
 	helpers.FailOnError(t, err)
 
-	_, err = db.Exec("INSERT INTO migration_info(version) VALUES('hello world')")
+	_, err = db.Exec("INSERT INTO migration_info(version) VALUES('hello world');")
 	helpers.FailOnError(t, err)
 
 	const expectedErrStr = `sql: Scan error on column index 0, name "version": ` +
@@ -320,7 +320,7 @@ func TestMigrationSetVersionCurrentTooHighError(t *testing.T) {
 	db, dbDriver, closer := prepareDBAndMigrations(t)
 	defer closer()
 
-	_, err := db.Exec("UPDATE migration_info SET version=10")
+	_, err := db.Exec("UPDATE migration_info SET version=10;")
 	helpers.FailOnError(t, err)
 
 	const expectedErrStr = "current version (10) is outside of available migration boundaries"

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -209,7 +209,7 @@ func (storage DBStorage) MigrateToLatest() error {
 // tasks necessary for further service operation.
 func (storage DBStorage) Init() error {
 	// Read clusterName:LastChecked dictionary from DB.
-	rows, err := storage.connection.Query("SELECT cluster, last_checked_at FROM report")
+	rows, err := storage.connection.Query("SELECT cluster, last_checked_at FROM report;")
 	if err != nil {
 		return err
 	}
@@ -268,7 +268,7 @@ func closeRows(rows *sql.Rows) {
 func (storage DBStorage) ListOfOrgs() ([]types.OrgID, error) {
 	orgs := make([]types.OrgID, 0)
 
-	rows, err := storage.connection.Query("SELECT DISTINCT org_id FROM report ORDER BY org_id")
+	rows, err := storage.connection.Query("SELECT DISTINCT org_id FROM report ORDER BY org_id;")
 	err = types.ConvertDBError(err)
 	if err != nil {
 		return orgs, err
@@ -292,7 +292,7 @@ func (storage DBStorage) ListOfOrgs() ([]types.OrgID, error) {
 func (storage DBStorage) ListOfClustersForOrg(orgID types.OrgID) ([]types.ClusterName, error) {
 	clusters := make([]types.ClusterName, 0)
 
-	rows, err := storage.connection.Query("SELECT cluster FROM report WHERE org_id = $1 ORDER BY cluster", orgID)
+	rows, err := storage.connection.Query("SELECT cluster FROM report WHERE org_id = $1 ORDER BY cluster;", orgID)
 	err = types.ConvertDBError(err)
 	if err != nil {
 		return clusters, err
@@ -314,7 +314,7 @@ func (storage DBStorage) ListOfClustersForOrg(orgID types.OrgID) ([]types.Cluste
 
 // GetOrgIDByClusterID reads OrgID for specified cluster
 func (storage DBStorage) GetOrgIDByClusterID(cluster types.ClusterName) (types.OrgID, error) {
-	row := storage.connection.QueryRow("SELECT org_id FROM report WHERE cluster = $1 ORDER BY org_id", cluster)
+	row := storage.connection.QueryRow("SELECT org_id FROM report WHERE cluster = $1 ORDER BY org_id;", cluster)
 
 	var orgID uint64
 	err := row.Scan(&orgID)
@@ -333,7 +333,7 @@ func (storage DBStorage) ReadReportForCluster(
 	var lastChecked time.Time
 
 	err := storage.connection.QueryRow(
-		"SELECT report, last_checked_at FROM report WHERE org_id = $1 AND cluster = $2", orgID, clusterName,
+		"SELECT report, last_checked_at FROM report WHERE org_id = $1 AND cluster = $2;", orgID, clusterName,
 	).Scan(&report, &lastChecked)
 	err = types.ConvertDBError(err)
 
@@ -357,7 +357,7 @@ func (storage DBStorage) ReadReportForClusterByClusterName(
 	var lastChecked time.Time
 
 	err := storage.connection.QueryRow(
-		"SELECT report, last_checked_at FROM report WHERE cluster = $1", clusterName,
+		"SELECT report, last_checked_at FROM report WHERE cluster = $1;", clusterName,
 	).Scan(&report, &lastChecked)
 
 	switch {
@@ -375,7 +375,7 @@ func (storage DBStorage) ReadReportForClusterByClusterName(
 // GetLatestKafkaOffset returns latest kafka offset from report table
 func (storage DBStorage) GetLatestKafkaOffset() (types.KafkaOffset, error) {
 	var offset types.KafkaOffset
-	err := storage.connection.QueryRow(`SELECT COALESCE(MAX(kafka_offset), 0) FROM report`).Scan(&offset)
+	err := storage.connection.QueryRow("SELECT COALESCE(MAX(kafka_offset), 0) FROM report;").Scan(&offset)
 	return offset, err
 }
 
@@ -537,7 +537,7 @@ func (storage DBStorage) WriteReportForCluster(
 
 	// Check if there is a more recent report for the cluster already in the database.
 	rows, err := tx.Query(
-		`SELECT last_checked_at FROM report WHERE org_id = $1 AND cluster = $2 AND last_checked_at > $3`,
+		"SELECT last_checked_at FROM report WHERE org_id = $1 AND cluster = $2 AND last_checked_at > $3;",
 		orgID, clusterName, lastCheckedTime)
 	err = types.ConvertDBError(err)
 	if err != nil {
@@ -572,7 +572,7 @@ func (storage DBStorage) WriteReportForCluster(
 // ReportsCount reads number of all records stored in database
 func (storage DBStorage) ReportsCount() (int, error) {
 	count := -1
-	err := storage.connection.QueryRow("SELECT count(*) FROM report").Scan(&count)
+	err := storage.connection.QueryRow("SELECT count(*) FROM report;").Scan(&count)
 	err = types.ConvertDBError(err)
 
 	return count, err
@@ -580,13 +580,13 @@ func (storage DBStorage) ReportsCount() (int, error) {
 
 // DeleteReportsForOrg deletes all reports related to the specified organization from the storage.
 func (storage DBStorage) DeleteReportsForOrg(orgID types.OrgID) error {
-	_, err := storage.connection.Exec("DELETE FROM report WHERE org_id = $1", orgID)
+	_, err := storage.connection.Exec("DELETE FROM report WHERE org_id = $1;", orgID)
 	return err
 }
 
 // DeleteReportsForCluster deletes all reports related to the specified cluster from the storage.
 func (storage DBStorage) DeleteReportsForCluster(clusterName types.ClusterName) error {
-	_, err := storage.connection.Exec("DELETE FROM report WHERE cluster = $1", clusterName)
+	_, err := storage.connection.Exec("DELETE FROM report WHERE cluster = $1;", clusterName)
 	return err
 }
 
@@ -786,7 +786,7 @@ func (storage DBStorage) CreateRuleErrorKey(ruleErrorKey types.RuleErrorKey) err
 // DeleteRuleErrorKey creates rule_error_key with provided data in the DB
 func (storage DBStorage) DeleteRuleErrorKey(ruleID types.RuleID, errorKey types.ErrorKey) error {
 	res, err := storage.connection.Exec(
-		`DELETE FROM rule_error_key WHERE "error_key" = $1 AND "rule_module" = $2`,
+		`DELETE FROM rule_error_key WHERE "error_key" = $1 AND "rule_module" = $2;`,
 		errorKey,
 		ruleID,
 	)

--- a/types/pg_consts.go
+++ b/types/pg_consts.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 const (


### PR DESCRIPTION
# Description

Just a minor refactor to unify the SQL query style (standard double quotes unless multi-line, ending with semicolon just to be sure).

I chose the style that was already used by the majority of the queries. It didn't seem very nice to have every query written slightly differently.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

`make before_commit`