### PR TITLE
Add redirect to content service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ style: fmt vet lint cyclo shellcheck errcheck goconst gosec ineffassign abcgo js
 run: clean build ## Build the project and executes the binary
 	./insights-results-aggregator
 
+automigrate: clean build
+	./insights-results-aggregator migrate latest
+
 test: clean build ## Run the unit tests
 	./unit-tests.sh
 

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -216,6 +216,7 @@ func TestLoadConfigurationFromFile(t *testing.T) {
 		debug = true
 		use_https = false
 		enable_cors = true
+		content_service_url = "http://localhost:8081/api/v1/"
 
 		[storage]
 		db_driver = "sqlite3"
@@ -246,13 +247,14 @@ func TestLoadConfigurationFromFile(t *testing.T) {
 	assert.Equal(t, true, brokerCfg.Enabled)
 
 	assert.Equal(t, server.Configuration{
-		Address:     ":8080",
-		APIPrefix:   "/api/v1/",
-		APISpecFile: "openapi.json",
-		AuthType:    "xrh",
-		Debug:       true,
-		UseHTTPS:    false,
-		EnableCORS:  true,
+		Address:           ":8080",
+		APIPrefix:         "/api/v1/",
+		APISpecFile:       "openapi.json",
+		AuthType:          "xrh",
+		Debug:             true,
+		UseHTTPS:          false,
+		EnableCORS:        true,
+		ContentServiceURL: "http://localhost:8081/api/v1/",
 	}, conf.GetServerConfiguration())
 
 	orgWhiteList := conf.GetOrganizationWhitelist()
@@ -317,13 +319,14 @@ func TestLoadConfigurationFromEnv(t *testing.T) {
 	assert.Equal(t, true, brokerCfg.Enabled)
 
 	assert.Equal(t, server.Configuration{
-		Address:     ":8080",
-		APIPrefix:   "/api/v1/",
-		APISpecFile: "openapi.json",
-		AuthType:    "xrh",
-		Debug:       true,
-		UseHTTPS:    false,
-		EnableCORS:  true,
+		Address:           ":8080",
+		APIPrefix:         "/api/v1/",
+		APISpecFile:       "openapi.json",
+		AuthType:          "xrh",
+		Debug:             true,
+		UseHTTPS:          false,
+		EnableCORS:        true,
+		ContentServiceURL: "http://localhost:8081/api/v1/",
 	}, conf.GetServerConfiguration())
 
 	orgWhiteList := conf.GetOrganizationWhitelist()

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -15,6 +15,7 @@ auth = true
 auth_type = "xrh"
 use_https = false
 enable_cors = true
+content_service_url = "http://localhost:8081/api/v1/"
 
 [processing]
 org_whitelist_file = "org_whitelist.csv"

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,7 @@ auth = true
 auth_type = "xrh"
 use_https = false
 enable_cors = true
+content_service_url = "http://localhost:8081/api/v1/"
 
 [processing]
 org_whitelist_file = "org_whitelist.csv"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/cloudwatch v0.0.0-20200512151223-b0b55757a24b
-	github.com/RedHatInsights/insights-operator-utils v1.0.0
+	github.com/RedHatInsights/insights-operator-utils v1.0.1
 	github.com/Shopify/sarama v1.26.0
 	github.com/aws/aws-sdk-go v1.30.25
 	github.com/bitly/go-simplejson v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/RedHatInsights/insights-operator-utils v0.0.1 h1:o5bIO+WyuApRN6g+JEEi
 github.com/RedHatInsights/insights-operator-utils v0.0.1/go.mod h1:c6ReBK57bYPBl3DCb03lo3Jwr+ORT/9XUdlTwzhKQP8=
 github.com/RedHatInsights/insights-operator-utils v1.0.0 h1:Fwr1Cj9cwBXo/NyZAArtE7av3rKtjQcanMxZ0dez12M=
 github.com/RedHatInsights/insights-operator-utils v1.0.0/go.mod h1:gRzYBMY4csuOXgrxUuC10WUkz6STOm3mqVsQCb+AGOQ=
+github.com/RedHatInsights/insights-operator-utils v1.0.1 h1:uxMsNAMGfhb1ABRXITSHAUnDypceI7eRfLvrwCpq+A4=
+github.com/RedHatInsights/insights-operator-utils v1.0.1/go.mod h1:gRzYBMY4csuOXgrxUuC10WUkz6STOm3mqVsQCb+AGOQ=
 github.com/Shopify/sarama v1.13.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.26.0 h1:C+zFi+/NJdfeJgZWbu+WaLgk4NcsbmqfFTKsoJmR39U=

--- a/openapi.json
+++ b/openapi.json
@@ -63,6 +63,28 @@
         }
       }
     },
+    "/groups": {
+      "get": {
+        "summary": "Get all rule groups and their relevant information",
+        "description": "This simply redirects to an endpoint of the same name of a service called insights-operator-service",
+        "parameters": [],
+        "operationId": "getRuleGroups",
+        "responses": {
+          "302": {
+            "description": "Found redirect: response containing all rule groups",
+            "content": {
+              "text/plain": {}
+            }
+          },
+          "503": {
+            "description": "Content service is unavailable",
+            "content": {
+              "text/plain": {}
+            }
+          }
+        }
+      }
+    },
     "/organizations": {
       "get": {
         "summary": "Returns a list of available organization IDs.",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -18,12 +18,13 @@ package server
 
 // Configuration represents configuration of REST API HTTP server
 type Configuration struct {
-	Address     string `mapstructure:"address" toml:"address"`
-	APIPrefix   string `mapstructure:"api_prefix" toml:"api_prefix"`
-	APISpecFile string `mapstructure:"api_spec_file" toml:"api_spec_file"`
-	Debug       bool   `mapstructure:"debug" toml:"debug"`
-	Auth        bool   `mapstructure:"auth" toml:"auth"`
-	AuthType    string `mapstructure:"auth_type" toml:"auth_type"`
-	UseHTTPS    bool   `mapstructure:"use_https" toml:"use_https"`
-	EnableCORS  bool   `mapstructure:"enable_cors" toml:"enable_cors"`
+	Address           string `mapstructure:"address" toml:"address"`
+	APIPrefix         string `mapstructure:"api_prefix" toml:"api_prefix"`
+	APISpecFile       string `mapstructure:"api_spec_file" toml:"api_spec_file"`
+	Debug             bool   `mapstructure:"debug" toml:"debug"`
+	Auth              bool   `mapstructure:"auth" toml:"auth"`
+	AuthType          string `mapstructure:"auth_type" toml:"auth_type"`
+	UseHTTPS          bool   `mapstructure:"use_https" toml:"use_https"`
+	EnableCORS        bool   `mapstructure:"enable_cors" toml:"enable_cors"`
+	ContentServiceURL string `mapstructure:"content_service_url" toml:"content_service_url"`
 }

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -42,13 +42,14 @@ const (
 	RuleEndpoint = "rules/{rule_id}"
 	// RuleErrorKeyEndpoint is an endpoint to create&delete a rule_error_key. DEBUG only
 	RuleErrorKeyEndpoint = "rules/{rule_id}/error_keys/{error_key}"
+	// RuleGroupsEndpoint is a simple redirect endpoint to the insights-content-service API specified in configruation
+	RuleGroupsEndpoint = "groups"
 	// ClustersForOrganizationEndpoint returns all clusters for {organization}
 	ClustersForOrganizationEndpoint = "organizations/{organization}/clusters"
 	// DisableRuleForClusterEndpoint disables a rule for specified cluster
 	DisableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/disable"
 	// EnableRuleForClusterEndpoint re-enables a rule for specified cluster
 	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/enable"
-
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"
 )

--- a/server/errors.go
+++ b/server/errors.go
@@ -67,6 +67,13 @@ func (*NoBodyError) Error() string {
 	return "client didn't provide request body"
 }
 
+// ContentServiceUnavailableError error meaning that client didn't provide body when it's required
+type ContentServiceUnavailableError struct{}
+
+func (*ContentServiceUnavailableError) Error() string {
+	return "Content service is unreachable"
+}
+
 // handleServerError handles separate server errors and sends appropriate responses
 func handleServerError(writer http.ResponseWriter, err error) {
 	log.Error().Err(err).Msg("handleServerError()")
@@ -82,6 +89,8 @@ func handleServerError(writer http.ResponseWriter, err error) {
 		respErr = responses.SendNotFound(writer, err.Error())
 	case *AuthenticationError:
 		respErr = responses.SendForbidden(writer, err.Error())
+	case *ContentServiceUnavailableError:
+		respErr = responses.SendServiceUnavailable(writer, err.Error())
 	default:
 		respErr = responses.SendInternalServerError(writer, "Internal Server Error")
 	}

--- a/server/errors.go
+++ b/server/errors.go
@@ -67,7 +67,7 @@ func (*NoBodyError) Error() string {
 	return "client didn't provide request body"
 }
 
-// ContentServiceUnavailableError error meaning that client didn't provide body when it's required
+// ContentServiceUnavailableError error is used when the content service cannot be reached
 type ContentServiceUnavailableError struct{}
 
 func (*ContentServiceUnavailableError) Error() string {

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -14,6 +14,7 @@ auth = false
 auth_type = "xrh"
 use_https = false
 enable_cors = true
+content_service_url = "http://localhost:8081/api/v1/"
 
 [processing]
 org_whitelist_file = "org_whitelist.csv"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -15,6 +15,7 @@ auth = true
 auth_type = "xrh"
 use_https = false
 enable_cors = true
+content_service_url = "http://localhost:8081/api/v1/"
 
 [processing]
 org_whitelist_file = "org_whitelist.csv"


### PR DESCRIPTION
# Description
Adds proxy endpoint for content-service. It just redirects to the endpoint - it's just `groups`, because that's how it's currently done in content-service, it can be changed easily.

Also as usual `INSIGHTS_RESULTS_AGGREGATOR__SERVER__CONTENT_SERVICE_URL` works - the URL is parsed and thus needs to be fully qualified URL.

Added automigrate shortcut because I'm lazy
Fixes #707

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit` as usual
ran insights-content-service on the :8081 port and got successfully redirected by aggregator