### PR TITLE
Unit test to get votes without rules

### DIFF
--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -1045,6 +1045,18 @@ func TestDBStorage_DeleteRuleErrorKey_DBError(t *testing.T) {
 	assert.EqualError(t, err, "sql: database is closed")
 }
 
+func TestDBStorageGetVotesForNoRules(t *testing.T) {
+	mockStorage, closer := helpers.MustGetMockStorage(t, true)
+	defer closer()
+
+	feedbacks, err := mockStorage.GetUserFeedbackOnRules(
+		testdata.ClusterName, testdata.RuleContentResponses, testdata.UserID,
+	)
+	helpers.FailOnError(t, err)
+
+	assert.Len(t, feedbacks, 0)
+}
+
 func TestDBStorageGetVotes(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -1075,6 +1075,8 @@ func TestDBStorageGetVotes(t *testing.T) {
 	)
 	helpers.FailOnError(t, err)
 
+	assert.Len(t, feedbacks, 2)
+
 	assert.Equal(t, types.UserVoteLike, feedbacks[testdata.Rule1ID])
 	assert.Equal(t, types.UserVoteDislike, feedbacks[testdata.Rule2ID])
 	assert.Equal(t, types.UserVoteNone, feedbacks[testdata.Rule3ID])


### PR DESCRIPTION
# Description

Unit test to get votes without rules.

I was worried a bit to have `in ()` clause in code, but it seems that at least SQLite handle it correctly. OTOH it is problematic in MariaDB/MySQL.

## Type of change

- Unit tests (no changes in the code)
