### PR TITLE
Fixed link to architecture diagram, minor fixes in README and other docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ REST API endpoints.
 ## Documentation
 
 Documentation is hosted on Github Pages <https://redhatinsights.github.io/insights-results-aggregator/>.
-Sources are located in `[docs](https://github.com/RedHatInsights/insights-results-aggregator/tree/master/docs)`.
+Sources are located in [docs](https://github.com/RedHatInsights/insights-results-aggregator/tree/master/docs).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: Insights Results Aggregator
 description: Aggregator service for Openshist insights results
-baseurl: ""
-url: "https://redhatinsights.github.io/insights-results-aggregator"
+baseurl: "/insights-results-aggregator"
+url: "https://redhatinsights.github.io"
 
 heading_anchors: true
 search_enabled: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ fully supported, but more SQL databases might be added later.
 
 ## Whole data flow
 
-![data_flow](assets/customer-facing-services-architecture.png)
+![data_flow]({{ "assets/customer-facing-services-architecture.png" | relative_url}})
 
 1. Event about new data from insights operator is consumed from Kafka. That event contains (among
 other things) URL to S3 Bucket

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,7 +7,7 @@ nav_order: 6
 Authentication is working through `x-rh-identity` token which is provided by 3scale. `x-rh-identity`
  is base64 encoded JSON, that includes data about user and organization, like:
 
-```JSON
+```json
 {
   "identity": {
     "account_number": "0369233",


### PR DESCRIPTION
# Description
Various fixes after merging #778 

Fixes #780 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

Tested locally with jekyll. Relative link is `/insights-results-aggregator/assets/customer-facing-services-architecture.png` which should be correct now.