### PR TITLE
Add tags migration

### DIFF
--- a/migration/mig_0006_add_on_delete_cascade.go
+++ b/migration/mig_0006_add_on_delete_cascade.go
@@ -17,7 +17,7 @@ limitations under the License.
 package migration
 
 var mig0006AddOnDeleteCascade = NewUpdateTableMigration(
-	"rule_error_key",
+	ruleErrorKeyTable,
 	`
 		CREATE TABLE rule_error_key (
 			"error_key"     VARCHAR NOT NULL,

--- a/migration/mig_0010_add_tags_on_rule_content.go
+++ b/migration/mig_0010_add_tags_on_rule_content.go
@@ -28,7 +28,7 @@ var mig0010AddTagsFieldToRuleErrorKeyTable = Migration{
 	},
 	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
 		if driver == types.DBDriverSQLite3 {
-			return downgradeTable(tx, "rule_error_key", `
+			return downgradeTable(tx, ruleErrorKeyTable, `
 				CREATE TABLE rule_error_key (
 					"error_key"     VARCHAR NOT NULL,
 					"rule_module"   VARCHAR NOT NULL REFERENCES rule(module) ON DELETE CASCADE,

--- a/migration/mig_0010_add_tags_on_rule_content.go
+++ b/migration/mig_0010_add_tags_on_rule_content.go
@@ -1,0 +1,52 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+var mig0010AddTagsFieldToRuleErrorKeyTable = Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		_, err := tx.Exec(`
+			ALTER TABLE rule_error_key ADD COLUMN tags VARCHAR NOT NULL DEFAULT ""
+		`)
+		return err
+	},
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		if driver == types.DBDriverSQLite3 {
+			return downgradeTable(tx, "rule_error_key", `
+				CREATE TABLE rule_error_key (
+					"error_key"     VARCHAR NOT NULL,
+					"rule_module"   VARCHAR NOT NULL REFERENCES rule(module) ON DELETE CASCADE,
+					"condition"     VARCHAR NOT NULL,
+					"description"   VARCHAR NOT NULL,
+					"impact"        INTEGER NOT NULL,
+					"likelihood"    INTEGER NOT NULL,
+					"publish_date"  TIMESTAMP NOT NULL,
+					"active"        BOOLEAN NOT NULL,
+					"generic"       VARCHAR NOT NULL,
+					PRIMARY KEY("error_key", "rule_module")
+				)
+			`, []string{"error_key", "rule_module", "condition", "description", "impact", "likelihood", "publish_date", "active", "generic"})
+		}
+
+		_, err := tx.Exec(`
+			ALTER TABLE rule_error_key DROP COLUMN tags
+		`)
+		return err
+	},
+}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -42,6 +42,10 @@ type Migration struct {
 	StepDown Step
 }
 
+const (
+	ruleErrorKeyTable = "rule_error_key"
+)
+
 // GetMaxVersion returns the highest available migration version.
 // The DB version cannot be set to a value higher than this.
 // This value is equivalent to the length of the list of available migrations.

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -26,4 +26,5 @@ var migrations = []Migration{
 	mig0007CreateClusterRuleToggle,
 	mig0008AddOffsetFieldToReportTable,
 	mig0009AddIndexOnReportKafkaOffset,
+	mig0010AddTagsFieldToRuleErrorKeyTable,
 }


### PR DESCRIPTION
# Description

Adding "tags" field to rule_error_key table in order to store the tags from the parsed rules content

## Type of change
- New feature (non-breaking change which adds functionality)

## Testing steps
Regular CI