### PR TITLE
Save tags to db

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -273,6 +273,13 @@
                                   4
                                 ]
                               },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "List of tags that the rule contains, forming rule groups"
+                              },
                               "user_vote": {
                                 "type": "integer",
                                 "description": "User vote - value of user voting. -1 is dislike vote, 0 is no vote, 1 is like vote.",

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -56,6 +56,7 @@ var (
 							Likelihood:  1,
 							PublishDate: "1970-01-01 00:00:00",
 							Status:      "active",
+							Tags:        []string{"tag1", "tag2"},
 						},
 					},
 				},
@@ -80,6 +81,7 @@ var (
 							Likelihood:  1,
 							PublishDate: "1970-01-01 00:00:00",
 							Status:      "inactive",
+							Tags:        []string{"tag1", "tag2"},
 						},
 					},
 				},
@@ -104,6 +106,7 @@ var (
 							Likelihood:  1,
 							PublishDate: "1970-01-01 00:00:00",
 							Status:      "bad",
+							Tags:        []string{"tag1", "tag2"},
 						},
 					},
 				},
@@ -140,6 +143,7 @@ var (
 							Likelihood:  1,
 							PublishDate: "1970-01-01 00:00:00",
 							Status:      "active",
+							Tags:        []string{"tag1", "tag2"},
 						},
 					},
 				},
@@ -191,6 +195,7 @@ func TestDBStorageLoadRuleContentInsertIntoRuleErrorKeyError(t *testing.T) {
 			"publish_date"  TIMESTAMP NOT NULL,
 			"active"        BOOLEAN NOT NULL,
 			"generic"       VARCHAR NOT NULL,
+			"tags"          VARCHAR NOT NULL DEFAULT "",
 
 			PRIMARY KEY("error_key", "rule_module")
 		)
@@ -209,6 +214,7 @@ func TestDBStorageLoadRuleContentInsertIntoRuleErrorKeyError(t *testing.T) {
 				"publish_date"  TIMESTAMP NOT NULL,
 				"active"        BOOLEAN NOT NULL,
 				"generic"       VARCHAR NOT NULL,
+				"tags"          VARCHAR NOT NULL DEFAULT "",
 
 				PRIMARY KEY("error_key", "rule_module")
 			)
@@ -328,6 +334,7 @@ func TestDBStorageGetContentForRulesOK(t *testing.T) {
 			TotalRisk:    1,
 			RiskOfChange: 0,
 			TemplateData: nil,
+			Tags:         []string{"tag1", "tag2"},
 			Disabled:     false,
 		},
 	}, res)
@@ -376,6 +383,7 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 			TotalRisk:    3,
 			RiskOfChange: 0,
 			TemplateData: nil,
+			Tags:         []string{"tag1", "tag2"},
 			Disabled:     false,
 		},
 		{
@@ -389,6 +397,7 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 			TotalRisk:    4,
 			RiskOfChange: 0,
 			TemplateData: nil,
+			Tags:         []string{"tag1", "tag2"},
 			Disabled:     false,
 		},
 		{
@@ -402,6 +411,7 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 			TotalRisk:    2,
 			RiskOfChange: 0,
 			TemplateData: nil,
+			Tags:         []string{"tag1", "tag2"},
 			Disabled:     false,
 		},
 	}, res)
@@ -424,6 +434,7 @@ func TestDBStorageGetContentForRulesScanError(t *testing.T) {
 		"publish_date",
 		"impact",
 		"likelihood",
+		"tags",
 		"disabled",
 	}
 

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -114,6 +114,7 @@ var (
 							Likelihood:  4,
 							PublishDate: Rule1CreatedAt,
 							Status:      "active",
+							Tags:        []string{"tag1", "tag2"},
 						},
 					},
 				},
@@ -139,6 +140,7 @@ var (
 							Likelihood:  2,
 							PublishDate: Rule2CreatedAt,
 							Status:      "active",
+							Tags:        []string{"tag1", "tag2"},
 						},
 					},
 				},
@@ -164,6 +166,7 @@ var (
 							Likelihood:  2,
 							PublishDate: Rule3CreatedAt,
 							Status:      "active",
+							Tags:        []string{"tag1", "tag2"},
 						},
 					},
 				},
@@ -236,6 +239,10 @@ var (
 				"total_risk": 4,
 				"risk_of_change": 0,
 				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
 				"disabled": false
 			},
 			{
@@ -248,6 +255,10 @@ var (
 				"total_risk": 3,
 				"risk_of_change": 0,
 				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
 				"disabled": true
 			}
 		]
@@ -274,6 +285,10 @@ var (
 				"total_risk": 3,
 				"risk_of_change": 0,
 				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
 				"disabled": false
 			},
 			{
@@ -286,6 +301,10 @@ var (
 				"total_risk": 4,
 				"risk_of_change": 0,
 				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
 				"disabled": false
 			}
 		]
@@ -338,6 +357,10 @@ var (
 				"total_risk": 3,
 				"risk_of_change": 0,
 				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
 				"disabled": false
 			},
 			{
@@ -350,6 +373,10 @@ var (
 				"total_risk": 4,
 				"risk_of_change": 0,
 				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
 				"disabled": false
 			},
 			{
@@ -362,6 +389,10 @@ var (
 				"total_risk": 2,
 				"risk_of_change": 0,
 				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
 				"disabled": false
 			}
 		]

--- a/types/types.go
+++ b/types/types.go
@@ -75,6 +75,7 @@ type RuleContentResponse struct {
 	RiskOfChange int         `json:"risk_of_change"`
 	RuleModule   string      `json:"rule_id"`
 	TemplateData interface{} `json:"extra_data"`
+	Tags         []string    `json:"tags"`
 	UserVote     UserVote    `json:"user_vote"`
 	Disabled     bool        `json:"disabled"`
 }


### PR DESCRIPTION
# Description
This adds a (non-optimal) solution to saving rule tags into the database and retrieving them for the API.

Fixes #790 

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit` finished with some weird timeout, let's see here
