### PR TITLE
Make rule toggle Actually per cluster/user

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -129,6 +129,8 @@ func getTotalRuleCount(reportRules types.ReportRules) int {
 func (server *HTTPServer) getContentForRules(
 	writer http.ResponseWriter,
 	report types.ClusterReport,
+	userID types.UserID,
+	clusterName types.ClusterName,
 ) ([]types.RuleContentResponse, int, error) {
 	var reportRules types.ReportRules
 
@@ -141,7 +143,7 @@ func (server *HTTPServer) getContentForRules(
 
 	totalRules := getTotalRuleCount(reportRules)
 
-	hitRules, err := server.Storage.GetContentForRules(reportRules)
+	hitRules, err := server.Storage.GetContentForRules(reportRules, userID, clusterName)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to retrieve rules content from database")
 		handleServerError(writer, err)
@@ -192,7 +194,7 @@ func (server *HTTPServer) readReportForCluster(writer http.ResponseWriter, reque
 		return
 	}
 
-	rulesContent, rulesCount, err := server.getContentForRules(writer, report)
+	rulesContent, rulesCount, err := server.getContentForRules(writer, report, userID, clusterName)
 	if err != nil {
 		// everything has been handled already
 		return

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -96,7 +96,7 @@ func (*NoopStorage) GetUserFeedbackOnRule(
 }
 
 // GetContentForRules noop
-func (*NoopStorage) GetContentForRules(_ types.ReportRules) ([]types.RuleContentResponse, error) {
+func (*NoopStorage) GetContentForRules(_ types.ReportRules, _ types.UserID, _ types.ClusterName) ([]types.RuleContentResponse, error) {
 	return nil, nil
 }
 

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -280,12 +280,16 @@ func TestDBStorageGetContentForRulesEmpty(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	res, err := mockStorage.GetContentForRules(types.ReportRules{
-		HitRules:     nil,
-		SkippedRules: nil,
-		PassedRules:  nil,
-		TotalCount:   0,
-	})
+	res, err := mockStorage.GetContentForRules(
+		types.ReportRules{
+			HitRules:     nil,
+			SkippedRules: nil,
+			PassedRules:  nil,
+			TotalCount:   0,
+		},
+		testdata.UserID,
+		testdata.ClusterName,
+	)
 	helpers.FailOnError(t, err)
 
 	assert.Empty(t, res)
@@ -295,12 +299,16 @@ func TestDBStorageGetContentForRulesDBError(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	closer()
 
-	_, err := mockStorage.GetContentForRules(types.ReportRules{
-		HitRules:     nil,
-		SkippedRules: nil,
-		PassedRules:  nil,
-		TotalCount:   0,
-	})
+	_, err := mockStorage.GetContentForRules(
+		types.ReportRules{
+			HitRules:     nil,
+			SkippedRules: nil,
+			PassedRules:  nil,
+			TotalCount:   0,
+		},
+		testdata.UserID,
+		testdata.ClusterName,
+	)
 	assert.EqualError(t, err, "sql: database is closed")
 }
 
@@ -311,15 +319,20 @@ func TestDBStorageGetContentForRulesOK(t *testing.T) {
 	err := mockStorage.LoadRuleContent(ruleContentExample1)
 	helpers.FailOnError(t, err)
 
-	res, err := mockStorage.GetContentForRules(types.ReportRules{
-		HitRules: []types.RuleOnReport{
-			{
-				Module:   string(testRuleID),
-				ErrorKey: "ek",
+	res, err := mockStorage.GetContentForRules(
+		types.ReportRules{
+			HitRules: []types.RuleOnReport{
+				{
+					Module:   string(testRuleID),
+					ErrorKey: "ek",
+				},
 			},
+			TotalCount: 1,
 		},
-		TotalCount: 1,
-	})
+		testdata.UserID,
+		testdata.ClusterName,
+	)
+
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, []types.RuleContentResponse{
@@ -347,23 +360,28 @@ func TestDBStorageGetContentForMultipleRulesOK(t *testing.T) {
 	err := mockStorage.LoadRuleContent(testdata.RuleContent3Rules)
 	helpers.FailOnError(t, err)
 
-	res, err := mockStorage.GetContentForRules(types.ReportRules{
-		HitRules: []types.RuleOnReport{
-			{
-				Module:   "test.rule1.report",
-				ErrorKey: "ek1",
+	res, err := mockStorage.GetContentForRules(
+		types.ReportRules{
+			HitRules: []types.RuleOnReport{
+				{
+					Module:   "test.rule1.report",
+					ErrorKey: "ek1",
+				},
+				{
+					Module:   "test.rule2.report",
+					ErrorKey: "ek2",
+				},
+				{
+					Module:   "test.rule3.report",
+					ErrorKey: "ek3",
+				},
 			},
-			{
-				Module:   "test.rule2.report",
-				ErrorKey: "ek2",
-			},
-			{
-				Module:   "test.rule3.report",
-				ErrorKey: "ek3",
-			},
+			TotalCount: 3,
 		},
-		TotalCount: 3,
-	})
+		testdata.UserID,
+		testdata.ClusterName,
+	)
+
 	helpers.FailOnError(t, err)
 
 	assert.Len(t, res, 3)
@@ -448,15 +466,20 @@ func TestDBStorageGetContentForRulesScanError(t *testing.T) {
 		sqlmock.NewRows(columns).AddRow(values...),
 	)
 
-	_, err := mockStorage.GetContentForRules(types.ReportRules{
-		HitRules: []types.RuleOnReport{
-			{
-				Module:   "rule_module",
-				ErrorKey: "error_key",
+	_, err := mockStorage.GetContentForRules(
+		types.ReportRules{
+			HitRules: []types.RuleOnReport{
+				{
+					Module:   "rule_module",
+					ErrorKey: "error_key",
+				},
 			},
+			TotalCount: 1,
 		},
-		TotalCount: 1,
-	})
+		testdata.UserID,
+		testdata.ClusterName,
+	)
+
 	helpers.FailOnError(t, err)
 
 	assert.Regexp(t, "converting driver.Value type .+ to .*", buf.String())
@@ -492,15 +515,20 @@ func TestDBStorageGetContentForRulesRowsError(t *testing.T) {
 		sqlmock.NewRows(columns).AddRow(values...).RowError(0, fmt.Errorf(rowErr)),
 	)
 
-	_, err := mockStorage.GetContentForRules(types.ReportRules{
-		HitRules: []types.RuleOnReport{
-			{
-				Module:   "rule_module",
-				ErrorKey: "error_key",
+	_, err := mockStorage.GetContentForRules(
+		types.ReportRules{
+			HitRules: []types.RuleOnReport{
+				{
+					Module:   "rule_module",
+					ErrorKey: "error_key",
+				},
 			},
+			TotalCount: 1,
 		},
-		TotalCount: 1,
-	})
+		testdata.UserID,
+		testdata.ClusterName,
+	)
+
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), rowErr)
 	assert.Contains(t, buf.String(), "SQL rows error while retrieving content for rules")

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -29,6 +29,7 @@ const (
 	OrgID            = types.OrgID(1)
 	ClusterName      = types.ClusterName("84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc")
 	UserID           = types.UserID("1")
+	User2ID          = types.UserID("2")
 	BadClusterName   = types.ClusterName("aaaa")
 	Rule1ID          = types.RuleID("test.rule1")
 	BadRuleID        = types.RuleID("rule id with spaces")
@@ -268,7 +269,53 @@ var (
 }
 `
 
-	Report2RulesEnabledRule1ExpectedResponse = `
+	Report2RulesDisabledExpectedResponse = `
+{
+	"report": {
+		"meta": {
+			"count": 2,
+			"last_checked_at": "` + LastCheckedAt.Format(time.RFC3339) + `"
+		},
+		"data": [
+			{
+				"rule_id": "` + string(Rule1ID) + `",
+				"description": "` + Rule1Description + `",
+				"details": "` + Rule1Details + `",
+				"reason": "` + Rule1Reason + `",
+				"resolution": "` + Rule1Resolution + `",
+				"created_at": "` + Rule1CreatedAt + `",
+				"total_risk": 3,
+				"risk_of_change": 0,
+				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
+				"disabled": true
+			},
+			{
+				"rule_id": "` + string(Rule2ID) + `",
+				"description": "` + Rule2Description + `",
+				"details": "` + Rule2Details + `",
+				"reason": "` + Rule2Reason + `",
+				"resolution": "` + Rule2Resolution + `",
+				"created_at": "` + Rule2CreatedAt + `",
+				"total_risk": 4,
+				"risk_of_change": 0,
+				"extra_data": null,
+				"tags": [
+					"tag1",
+					"tag2"
+				],
+				"disabled": true
+			}
+		]
+	},
+	"status": "ok"
+}
+`
+
+	Report2RulesEnabledRulesExpectedResponse = `
 {
 	"report": {
 		"meta": {


### PR DESCRIPTION
# Description
I can't believe I didn't realize it at the time... Pls let me know if you have an idea of a better test for this.
This will have to be done differently for smart proxy / content service, but this blocked stable updates.

Fixes #811 , might also #814 depending on the decision

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit` + ran with several hardcoded user ids + ran against dumped DB from QA env, thanks @Sergey1011010 @quarckster 