### PR TITLE
added-option-to-create-stream-if-it-does-not-exist

### DIFF
--- a/config-devel.toml
+++ b/config-devel.toml
@@ -47,3 +47,4 @@ aws_region = "us-east-1"
 log_group = "platform-dev"
 stream_name = "insights-results-aggregator"
 debug = false
+create_stream_if_not_exists = true

--- a/config.toml
+++ b/config.toml
@@ -42,3 +42,4 @@ aws_region = "us-east-1"
 log_group = "platform-dev"
 stream_name = "insights-results-aggregator"
 debug = false
+create_stream_if_not_exists = false

--- a/logger/configuration.go
+++ b/logger/configuration.go
@@ -38,12 +38,13 @@ type LoggingConfiguration struct {
 
 // CloudWatchConfiguration represents configuration of CloudWatch logger
 type CloudWatchConfiguration struct {
-	AWSAccessID     string `mapstructure:"aws_access_id" toml:"aws_access_id"`
-	AWSSecretKey    string `mapstructure:"aws_secret_key" toml:"aws_secret_key"`
-	AWSSessionToken string `mapstructure:"aws_session_token" toml:"aws_session_token"`
-	AWSRegion       string `mapstructure:"aws_region" toml:"aws_region"`
-	LogGroup        string `mapstructure:"log_group" toml:"log_group"`
-	StreamName      string `mapstructure:"stream_name" toml:"stream_name"`
+	AWSAccessID             string `mapstructure:"aws_access_id" toml:"aws_access_id"`
+	AWSSecretKey            string `mapstructure:"aws_secret_key" toml:"aws_secret_key"`
+	AWSSessionToken         string `mapstructure:"aws_session_token" toml:"aws_session_token"`
+	AWSRegion               string `mapstructure:"aws_region" toml:"aws_region"`
+	LogGroup                string `mapstructure:"log_group" toml:"log_group"`
+	StreamName              string `mapstructure:"stream_name" toml:"stream_name"`
+	CreateStreamIfNotExists bool   `mapstructure:"create_stream_if_not_exists" toml:"create_stream_if_not_exists"`
 
 	// enable debug logs for debugging aws client itself
 	Debug bool `mapstructure:"debug" toml:"debug"`


### PR DESCRIPTION
# Description

Created new option `create_stream_if_not_exists` which is set to false by default

Fixes #835

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps

`make before_commit` & test that it's not trying to create a stream with option set to `false`