### PR TITLE
Remove address as argument for Initialize

### DIFF
--- a/server/report_benchmarks_test.go
+++ b/server/report_benchmarks_test.go
@@ -104,7 +104,7 @@ func benchmarkHTTPServerReadReportForCluster(
 			req, err := http.NewRequest(http.MethodGet, url, nil)
 			helpers.FailOnError(b, err)
 
-			response := helpers.ExecuteRequest(testServer, req, &helpers.DefaultServerConfig).Result()
+			response := helpers.ExecuteRequest(testServer, req).Result()
 			respBody, err := ioutil.ReadAll(response.Body)
 			helpers.FailOnError(b, err)
 

--- a/server/server.go
+++ b/server/server.go
@@ -318,8 +318,8 @@ func (server *HTTPServer) handleOptionsMethod(nextHandler http.Handler) http.Han
 }
 
 // Initialize perform the server initialization
-func (server *HTTPServer) Initialize(address string) http.Handler {
-	log.Info().Msgf("Initializing HTTP server at '%s'", address)
+func (server *HTTPServer) Initialize() http.Handler {
+	log.Info().Msgf("Initializing HTTP server at '%s'", server.Config.Address)
 
 	router := mux.NewRouter().StrictSlash(true)
 	router.Use(server.LogRequest)
@@ -358,7 +358,7 @@ func (server *HTTPServer) Initialize(address string) http.Handler {
 func (server *HTTPServer) Start() error {
 	address := server.Config.Address
 	log.Info().Msgf("Starting HTTP server at '%s'", address)
-	router := server.Initialize(address)
+	router := server.Initialize()
 	server.Serv = &http.Server{Addr: address, Handler: router}
 	var err error
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -244,7 +244,7 @@ func TestServerStart(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, config.APIPrefix, nil)
 			helpers.FailOnError(t, err)
 
-			response := helpers.ExecuteRequest(s, req, &config).Result()
+			response := helpers.ExecuteRequest(s, req).Result()
 			checkResponseCode(t, http.StatusForbidden, response.StatusCode)
 
 			// stopping the server
@@ -553,7 +553,7 @@ func TestRuleFeedbackErrorBadUserID(t *testing.T) {
 	identity := "wrong type"
 	req = req.WithContext(context.WithValue(req.Context(), server.ContextKeyUser, identity))
 
-	response := helpers.ExecuteRequest(testServer, req, &config).Result()
+	response := helpers.ExecuteRequest(testServer, req).Result()
 
 	assert.Equal(t, http.StatusInternalServerError, response.StatusCode, "Expected different status code")
 	helpers.CheckResponseBodyJSON(t, `{"status": "Internal Server Error"}`, response.Body)

--- a/server/vote_endpoints_benchmarks_test.go
+++ b/server/vote_endpoints_benchmarks_test.go
@@ -119,7 +119,7 @@ func benchmarkHTTPServerVoteEndpointsWithStorage(b *testing.B, mockStorage stora
 					}
 					req = req.WithContext(context.WithValue(req.Context(), server.ContextKeyUser, identity))
 
-					response := helpers.ExecuteRequest(testServer, req, &helpers.DefaultServerConfig).Result()
+					response := helpers.ExecuteRequest(testServer, req).Result()
 
 					assert.Equal(b, http.StatusOK, response.StatusCode)
 				}

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -99,7 +99,7 @@ func AssertAPIRequest(
 
 	req := makeRequest(t, request, url)
 
-	response := ExecuteRequest(testServer, req, serverConfig).Result()
+	response := ExecuteRequest(testServer, req).Result()
 
 	if len(expectedResponse.Headers) != 0 {
 		checkResponseHeaders(t, expectedResponse.Headers, response.Header)
@@ -141,8 +141,8 @@ func makeRequest(t testing.TB, request *APIRequest, url string) *http.Request {
 }
 
 // ExecuteRequest executes http request on a testServer
-func ExecuteRequest(testServer *server.HTTPServer, req *http.Request, config *server.Configuration) *httptest.ResponseRecorder {
-	router := testServer.Initialize(config.Address)
+func ExecuteRequest(testServer *server.HTTPServer, req *http.Request) *httptest.ResponseRecorder {
+	router := testServer.Initialize()
 
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)


### PR DESCRIPTION
# Description

Small fix for removing an unneeded argument from `server.Initialize` method

Fixes #847 

## Type of change
- Refactor (refactoring code, removing useless files)

## Testing steps
Regular CI