### PR TITLE
change-sarama-logging-level-to-error-if-string-starts-with-kafka-error

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -169,6 +169,8 @@ func setGlobalLogLevel(configuration LoggingConfiguration) {
 	}
 }
 
+const kafkaErrorPrefix = "kafka: error"
+
 // SaramaZerologger is a wrapper to make sarama log to zerolog
 // those logs can be filtered by key "package" with value "sarama"
 type SaramaZerologger struct{ zerologger zerolog.Logger }
@@ -197,7 +199,7 @@ func (logger *SaramaZerologger) logMessage(format string, params ...interface{})
 	var event *zerolog.Event
 	messageStr := fmt.Sprintf(format, params...)
 
-	if strings.HasPrefix(messageStr, "kafka: error") {
+	if strings.HasPrefix(messageStr, kafkaErrorPrefix) {
 		event = logger.zerologger.Error()
 	} else {
 		event = logger.zerologger.Info()

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestSaramaZerologger(t *testing.T) {
-	const expectedErrStrInfoLevel = "some random error message"
+	const expectedErrStrInfoLevel = "some random message"
 	const expectedErrStrErrorLevel = "kafka: error test error"
 
 	buf := new(bytes.Buffer)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestSaramaZerologger(t *testing.T) {
-	const expectedErrStrInfoLevel = "some random message"
+	const expectedStrInfoLevel = "some random message"
 	const expectedErrStrErrorLevel = "kafka: error test error"
 
 	buf := new(bytes.Buffer)
@@ -48,10 +48,10 @@ func TestSaramaZerologger(t *testing.T) {
 	t.Run("InfoLevel", func(t *testing.T) {
 		buf.Reset()
 
-		sarama.Logger.Printf(expectedErrStrInfoLevel)
+		sarama.Logger.Printf(expectedStrInfoLevel)
 
 		assert.Contains(t, buf.String(), `\"level\":\"info\"`)
-		assert.Contains(t, buf.String(), expectedErrStrInfoLevel)
+		assert.Contains(t, buf.String(), expectedStrInfoLevel)
 	})
 
 	t.Run("ErrorLevel", func(t *testing.T) {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,133 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RedHatInsights/insights-results-aggregator/logger"
+	"github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
+)
+
+func TestSaramaZerologger(t *testing.T) {
+	const expectedErrStrInfoLevel = "some random error message"
+	const expectedErrStrErrorLevel = "kafka: error test error"
+
+	buf := new(bytes.Buffer)
+
+	err := logger.InitZerolog(
+		logger.LoggingConfiguration{
+			Debug:                      false,
+			LogLevel:                   "debug",
+			LoggingToCloudWatchEnabled: false,
+		},
+		logger.CloudWatchConfiguration{},
+		zerolog.New(buf),
+	)
+	helpers.FailOnError(t, err)
+
+	t.Run("InfoLevel", func(t *testing.T) {
+		buf.Reset()
+
+		sarama.Logger.Printf(expectedErrStrInfoLevel)
+
+		assert.Contains(t, buf.String(), `\"level\":\"info\"`)
+		assert.Contains(t, buf.String(), expectedErrStrInfoLevel)
+	})
+
+	t.Run("ErrorLevel", func(t *testing.T) {
+		buf.Reset()
+
+		sarama.Logger.Print(expectedErrStrErrorLevel)
+
+		assert.Contains(t, buf.String(), `\"level\":\"error\"`)
+		assert.Contains(t, buf.String(), expectedErrStrErrorLevel)
+	})
+}
+
+func TestLoggerSetLogLevel(t *testing.T) {
+	logLevels := []string{"debug", "info", "warning", "error"}
+	for logLevelIndex, logLevel := range logLevels {
+		t.Run(logLevel, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+
+			err := logger.InitZerolog(
+				logger.LoggingConfiguration{
+					Debug:                      false,
+					LogLevel:                   logLevel,
+					LoggingToCloudWatchEnabled: false,
+				},
+				logger.CloudWatchConfiguration{},
+				zerolog.New(buf),
+			)
+			helpers.FailOnError(t, err)
+
+			log.Debug().Msg("debug level")
+			log.Info().Msg("info level")
+			log.Warn().Msg("warning level")
+			log.Error().Msg("error level")
+
+			for i := 0; i < len(logLevels); i++ {
+				if i < logLevelIndex {
+					assert.NotContains(t, buf.String(), logLevels[i]+" level")
+				} else {
+					assert.Contains(t, buf.String(), logLevels[i]+" level")
+				}
+			}
+		})
+	}
+}
+
+func TestUnJSONWriter_Write(t *testing.T) {
+	for _, testCase := range []struct {
+		Name        string
+		StrToWrite  string
+		ExpectedStr string
+	}{
+		{"NotJSON", "some expected string", "some expected string"},
+		{"JSON", `{"level": "error", "is_something": true}`, "LEVEL=error; IS_SOMETHING=true;"},
+	} {
+		t.Run(testCase.Name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			unJSONWriter := logger.UnJSONWriter{Writer: buf}
+
+			writtenBytes, err := unJSONWriter.Write([]byte(testCase.StrToWrite))
+			helpers.FailOnError(t, err)
+
+			assert.Equal(t, writtenBytes, len(testCase.StrToWrite))
+			assert.Equal(t, testCase.ExpectedStr, strings.TrimSpace(buf.String()))
+		})
+	}
+}
+
+func TestInitZerolog_LogToCloudWatch(t *testing.T) {
+	// TODO: mock logging to cloud watch and do actual testing
+	err := logger.InitZerolog(
+		logger.LoggingConfiguration{
+			Debug:                      false,
+			LogLevel:                   "debug",
+			LoggingToCloudWatchEnabled: true,
+		},
+		logger.CloudWatchConfiguration{},
+	)
+	helpers.FailOnError(t, err)
+}


### PR DESCRIPTION
# Description

Fixes #718

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

`make before_commit`