### PR TITLE
Report endpoint doesn't return static content

### DIFF
--- a/server/rules.go
+++ b/server/rules.go
@@ -215,79 +215,37 @@ func (server *HTTPServer) deleteRuleErrorKey(writer http.ResponseWriter, request
 	}
 }
 
-// deleteRuleForClusterToggle is debug endpoint for deleting the record in the rule_cluster_toggle table
-func (server *HTTPServer) deleteFromRuleClusterToggle(writer http.ResponseWriter, request *http.Request) {
-	clusterID, ruleID, userID, err := server.readClusterRuleUserParams(writer, request)
-	if err != nil {
-		// everything has been handled already
-		return
-	}
-
-	err = server.checkUserClusterPermissions(writer, request, clusterID)
-	if err != nil {
-		// everything has been handled already
-		return
-	}
-
-	err = server.Storage.DeleteFromRuleClusterToggle(clusterID, ruleID, userID)
-	if err != nil {
-		log.Error().Err(err).Msg("Unable to delete from rule_cluster_toggle")
-		handleServerError(writer, err)
-		return
-	}
-
-	err = responses.SendOK(writer, responses.BuildOkResponse())
-	if err != nil {
-		log.Error().Err(err).Msg(responseDataError)
-	}
-}
-
-func getTotalRuleCount(reportRules types.ReportRules) int {
-	totalCount := len(reportRules.HitRules) +
-		len(reportRules.SkippedRules) +
-		len(reportRules.PassedRules)
-	return totalCount
-}
-
-// getContentForRules returns the hit rules from the report, as well as total count of all rules (skipped, ..)
-func (server *HTTPServer) getContentForRules(
-	writer http.ResponseWriter,
-	report types.ClusterReport,
-	userID types.UserID,
+// getFeedbackAndTogglesOnRules
+func (server HTTPServer) getFeedbackAndTogglesOnRules(
 	clusterName types.ClusterName,
-) ([]types.RuleContentResponse, int, error) {
-	var reportRules types.ReportRules
-
-	err := json.Unmarshal([]byte(report), &reportRules)
+	userID types.UserID,
+	rules []types.RuleOnReport,
+) ([]types.RuleOnReport, error) {
+	togglesRules, err := server.Storage.GetTogglesForRules(clusterName, rules, userID)
 	if err != nil {
-		log.Error().Err(err).Msg("Unable to parse cluster report")
-		handleServerError(writer, err)
-		return nil, 0, err
+		log.Error().Err(err).Msg("Unable to retrieve disabled status from database")
+		return nil, err
 	}
 
-	totalRules := getTotalRuleCount(reportRules)
-
-	hitRules, err := server.Storage.GetContentForRules(reportRules, userID, clusterName)
+	feedbacks, err := server.Storage.GetUserFeedbackOnRules(clusterName, rules, userID)
 	if err != nil {
-		log.Error().Err(err).Msg("Unable to retrieve rules content from database")
-		handleServerError(writer, err)
-		return nil, 0, err
+		log.Error().Err(err).Msg("Unable to retrieve feedback results from database")
+		return nil, err
 	}
 
-	return hitRules, totalRules, nil
-}
-
-// getUserVoteForRules returns user votes for defined list of report's IDs
-func (server *HTTPServer) getUserVoteForRules(
-	feedbacks map[types.RuleID]types.UserVote,
-	rulesContent []types.RuleContentResponse,
-) []types.RuleContentResponse {
-	for i := range rulesContent {
-		if vote, found := feedbacks[types.RuleID(rulesContent[i].RuleModule)]; found {
-			rulesContent[i].UserVote = vote
+	for i := range rules {
+		ruleID := types.RuleID(rules[i].Module)
+		if vote, found := feedbacks[ruleID]; found {
+			rules[i].UserVote = vote
 		} else {
-			rulesContent[i].UserVote = types.UserVoteNone
+			rules[i].UserVote = types.UserVoteNone
+		}
+
+		if disabled, found := togglesRules[ruleID]; found {
+			rules[i].Disabled = disabled
+		} else {
+			rules[i].Disabled = false
 		}
 	}
-	return rulesContent
+	return rules, nil
 }

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -95,11 +95,6 @@ func (*NoopStorage) GetUserFeedbackOnRule(
 	return nil, nil
 }
 
-// GetContentForRules noop
-func (*NoopStorage) GetContentForRules(types.ReportRules, types.UserID, types.ClusterName) ([]types.RuleContentResponse, error) {
-	return nil, nil
-}
-
 // DeleteReportsForOrg noop
 func (*NoopStorage) DeleteReportsForOrg(types.OrgID) error {
 	return nil
@@ -178,10 +173,19 @@ func (*NoopStorage) GetFromClusterRuleToggle(
 	return nil, nil
 }
 
+// GetTogglesForRules noop
+func (*NoopStorage) GetTogglesForRules(
+	types.ClusterName,
+	[]types.RuleOnReport,
+	types.UserID,
+) (map[types.RuleID]bool, error) {
+	return nil, nil
+}
+
 // GetUserFeedbackOnRules noop
 func (*NoopStorage) GetUserFeedbackOnRules(
 	types.ClusterName,
-	[]types.RuleContentResponse,
+	[]types.RuleOnReport,
 	types.UserID,
 ) (map[types.RuleID]types.UserVote, error) {
 	return nil, nil

--- a/storage/rule_feedback.go
+++ b/storage/rule_feedback.go
@@ -179,11 +179,11 @@ func (storage DBStorage) GetUserFeedbackOnRule(
 
 // GetUserFeedbackOnRules gets user feedbacks for defined array of rule IDs from DB
 func (storage DBStorage) GetUserFeedbackOnRules(
-	clusterID types.ClusterName, rulesContent []types.RuleContentResponse, userID types.UserID,
+	clusterID types.ClusterName, rulesReport []types.RuleOnReport, userID types.UserID,
 ) (map[types.RuleID]types.UserVote, error) {
 	ruleIDs := make([]string, 0)
-	for _, v := range rulesContent {
-		ruleIDs = append(ruleIDs, v.RuleModule)
+	for _, v := range rulesReport {
+		ruleIDs = append(ruleIDs, v.Module)
 	}
 
 	feedbacks := make(map[types.RuleID]types.UserVote)

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -250,6 +250,18 @@ var (
 		},
 	}
 
+	RuleOnReportResponses = []types.RuleOnReport{
+		types.RuleOnReport{
+			Module: string(Rule1ID),
+		},
+		types.RuleOnReport{
+			Module: string(Rule2ID),
+		},
+		types.RuleOnReport{
+			Module: string(Rule3ID),
+		},
+	}
+
 	Report0Rules = types.ClusterReport(`
 {
 	"system": {
@@ -271,11 +283,11 @@ var (
 	},
 	"reports": [
 		{
-			"component": "` + string(Rule1ID) + `.report",
+			"component": "` + string(Rule1ID) + `",
 			"key": "` + ErrorKey1 + `"
 		},
 		{
-			"component": "` + string(Rule2ID) + `.report",
+			"component": "` + string(Rule2ID) + `",
 			"key": "` + ErrorKey2 + `"
 		}
 	],
@@ -292,37 +304,17 @@ var (
 			"count": 2,
 			"last_checked_at": "` + LastCheckedAt.Format(time.RFC3339) + `"
 		},
-		"data": [
+		"reports": [
 			{
-				"rule_id": "` + string(Rule2ID) + `",
-				"description": "` + Rule2Description + `",
-				"details": "` + Rule2Details + `",
-				"reason": "` + Rule2Reason + `",
-				"resolution": "` + Rule2Resolution + `",
-				"created_at": "` + Rule2CreatedAt + `",
-				"total_risk": 4,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+				"component": "` + string(Rule2ID) + `",
+				"key": "` + ErrorKey2 + `",
+				"user_vote": 0,
 				"disabled": false
 			},
 			{
-				"rule_id": "` + string(Rule1ID) + `",
-				"description": "` + Rule1Description + `",
-				"details": "` + Rule1Details + `",
-				"reason": "` + Rule1Reason + `",
-				"resolution": "` + Rule1Resolution + `",
-				"created_at": "` + Rule1CreatedAt + `",
-				"total_risk": 3,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+				"component": "` + string(Rule1ID) + `",
+				"key": "` + ErrorKey1 + `",
+				"user_vote": 0,
 				"disabled": true
 			}
 		]
@@ -338,37 +330,17 @@ var (
 			"count": 2,
 			"last_checked_at": "` + LastCheckedAt.Format(time.RFC3339) + `"
 		},
-		"data": [
+		"reports": [
 			{
-				"rule_id": "` + string(Rule1ID) + `",
-				"description": "` + Rule1Description + `",
-				"details": "` + Rule1Details + `",
-				"reason": "` + Rule1Reason + `",
-				"resolution": "` + Rule1Resolution + `",
-				"created_at": "` + Rule1CreatedAt + `",
-				"total_risk": 3,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+				"component": "` + string(Rule1ID) + `",
+				"key": "` + ErrorKey1 + `",
+				"user_vote": 0,
 				"disabled": true
 			},
 			{
-				"rule_id": "` + string(Rule2ID) + `",
-				"description": "` + Rule2Description + `",
-				"details": "` + Rule2Details + `",
-				"reason": "` + Rule2Reason + `",
-				"resolution": "` + Rule2Resolution + `",
-				"created_at": "` + Rule2CreatedAt + `",
-				"total_risk": 4,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+				"component": "` + string(Rule2ID) + `",
+				"key": "` + ErrorKey2 + `",
+				"user_vote": 0,
 				"disabled": true
 			}
 		]
@@ -384,37 +356,17 @@ var (
 			"count": 2,
 			"last_checked_at": "` + LastCheckedAt.Format(time.RFC3339) + `"
 		},
-		"data": [
+		"reports": [
 			{
-				"rule_id": "` + string(Rule1ID) + `",
-				"description": "` + Rule1Description + `",
-				"details": "` + Rule1Details + `",
-				"reason": "` + Rule1Reason + `",
-				"resolution": "` + Rule1Resolution + `",
-				"created_at": "` + Rule1CreatedAt + `",
-				"total_risk": 3,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+				"component": "` + string(Rule1ID) + `",
+				"key": "` + ErrorKey1 + `",
+				"user_vote": 0,
 				"disabled": false
 			},
 			{
-				"rule_id": "` + string(Rule2ID) + `",
-				"description": "` + Rule2Description + `",
-				"details": "` + Rule2Details + `",
-				"reason": "` + Rule2Reason + `",
-				"resolution": "` + Rule2Resolution + `",
-				"created_at": "` + Rule2CreatedAt + `",
-				"total_risk": 4,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+				"component": "` + string(Rule2ID) + `",
+				"key": "` + ErrorKey2 + `",
+				"user_vote": 0,
 				"disabled": false
 			}
 		]
@@ -431,15 +383,15 @@ var (
 	},
 	"reports": [
 		{
-			"component": "` + string(Rule1ID) + `.report",
+			"component": "` + string(Rule1ID) + `",
 			"key": "` + ErrorKey1 + `"
 		},
 		{
-			"component": "` + string(Rule2ID) + `.report",
+			"component": "` + string(Rule2ID) + `",
 			"key": "` + ErrorKey2 + `"
 		},
 		{
-			"component": "` + string(Rule3ID) + `.report",
+			"component": "` + string(Rule3ID) + `",
 			"key": "` + ErrorKey3 + `"
 		}
 	],
@@ -452,61 +404,31 @@ var (
 	Report3RulesExpectedResponse = `
 {
 	"report": {
-		"meta": {
-			"count": 3,
-			"last_checked_at": "` + LastCheckedAt.Format(time.RFC3339) + `"
-		},
-		"data": [
-			{
-				"rule_id": "` + string(Rule1ID) + `",
-				"description": "` + Rule1Description + `",
-				"details": "` + Rule1Details + `",
-				"reason": "` + Rule1Reason + `",
-				"resolution": "` + Rule1Resolution + `",
-				"created_at": "` + Rule1CreatedAt + `",
-				"total_risk": 3,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+        "meta": {
+            "count": 3,
+            "last_checked_at": "` + LastCheckedAt.Format(time.RFC3339) + `"
+        },
+        "reports": [
+            {
+				"component": "` + string(Rule1ID) + `",
+				"key": "` + ErrorKey1 + `",
+				"user_vote": 0,
+				"disabled": false
+			},
+            {
+				"component": "` + string(Rule2ID) + `",
+                "key": "` + ErrorKey2 + `",
+                "user_vote": 0,
 				"disabled": false
 			},
 			{
-				"rule_id": "` + string(Rule2ID) + `",
-				"description": "` + Rule2Description + `",
-				"details": "` + Rule2Details + `",
-				"reason": "` + Rule2Reason + `",
-				"resolution": "` + Rule2Resolution + `",
-				"created_at": "` + Rule2CreatedAt + `",
-				"total_risk": 4,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
-				"disabled": false
-			},
-			{
-				"rule_id": "` + string(Rule3ID) + `",
-				"description": "` + Rule3Description + `",
-				"details": "` + Rule3Details + `",
-				"reason": "` + Rule3Reason + `",
-				"resolution": "` + Rule3Resolution + `",
-				"created_at": "` + Rule3CreatedAt + `",
-				"total_risk": 2,
-				"risk_of_change": 0,
-				"extra_data": null,
-				"tags": [
-					"tag1",
-					"tag2"
-				],
+				"component": "` + string(Rule3ID) + `",
+                "key": "` + ErrorKey3 + `",
+				"user_vote": 0,
 				"disabled": false
 			}
-		]
-	},
+        ]
+    },
 	"status": "ok"
 }
 `

--- a/types/types.go
+++ b/types/types.go
@@ -42,9 +42,10 @@ type RequestID string
 
 // RuleOnReport represents a single (hit) rule of the string encoded report
 type RuleOnReport struct {
-	Module   string      `json:"component"`
-	ErrorKey string      `json:"key"`
-	Details  interface{} `json:"details"`
+	Module   string   `json:"component"`
+	ErrorKey string   `json:"key"`
+	UserVote UserVote `json:"user_vote"`
+	Disabled bool     `json:"disabled"`
 }
 
 // ReportRules is a helper struct for easy JSON unmarshalling of string encoded report
@@ -57,8 +58,8 @@ type ReportRules struct {
 
 // ReportResponse represents the response of /report endpoint
 type ReportResponse struct {
-	Meta  ReportResponseMeta    `json:"meta"`
-	Rules []RuleContentResponse `json:"data"`
+	Meta   ReportResponseMeta `json:"meta"`
+	Report []RuleOnReport     `json:"reports"`
 }
 
 // ReportResponseMeta contains metadata about the report


### PR DESCRIPTION
# Description

Remove the static content from the "report" endpoint response. New response includes only the report, user feedback (votes) and if some rule is disabled by the user,

Fixes [insights-results-smart-proxy#6](https://github.com/RedHatInsights/insights-results-smart-proxy/issues/6)

## Type of change
- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
Regular CI, new UTs included