### PR TITLE
Minor Makefile improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,13 @@ docs/packages/%.html: %.go
 	docgo -outdir $(dir $@) $^
 	addlicense -c "Red Hat, Inc" -l "apache" -v $@
 
+godoc: export GO111MODULE=off
 godoc: install_docgo install_addlicense ${DOCFILES}
 
+install_docgo: export GO111MODULE=off
 install_docgo:
-	[[ `command -v docgo` ]] || GO111MODULE=off go get -u github.com/dhconnelly/docgo
+	[[ `command -v docgo` ]] || go get -u github.com/dhconnelly/docgo
 
+install_addlicense: export GO111MODULE=off
 install_addlicense:
 	[[ `command -v addlicense` ]] || GO111MODULE=off go get -u github.com/google/addlicense

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo json-check openapi-check style run test test-postgres cover integration_tests rest_api_tests sqlite_db license before_commit help godoc
+.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo json-check openapi-check style run test test-postgres cover integration_tests rest_api_tests sqlite_db license before_commit help godoc install_docgo install_addlicense
 
 SOURCES:=$(shell find . -name '*.go')
 BINARY:=insights-results-aggregator
@@ -91,9 +91,8 @@ sqlite_db:
 	mv aggregator.db aggragator.db.backup
 	local_storage/create_database_sqlite.sh
 
-license:
-	GO111MODULE=off go get -u github.com/google/addlicense && \
-		addlicense -c "Red Hat, Inc" -l "apache" -v ./
+license: install_addlicense
+	addlicense -c "Red Hat, Inc" -l "apache" -v ./
 
 before_commit: style test test-postgres integration_tests openapi-check license ## Checks done before commit
 	./check_coverage.sh
@@ -110,5 +109,12 @@ help: ## Show this help screen
 docs/packages/%.html: %.go
 	mkdir -p $(dir $@)
 	docgo -outdir $(dir $@) $^
+	addlicense -c "Red Hat, Inc" -l "apache" -v $@
 
-godoc: ${DOCFILES}
+godoc: install_docgo install_addlicense ${DOCFILES}
+
+install_docgo:
+	[[ `command -v docgo` ]] || GO111MODULE=off go get -u github.com/dhconnelly/docgo
+
+install_addlicense:
+	[[ `command -v addlicense` ]] || GO111MODULE=off go get -u github.com/google/addlicense

--- a/docs/packages/logger/logger.html
+++ b/docs/packages/logger/logger.html
@@ -138,7 +138,7 @@ limitations under the License.
       
       <tr class="section">
 	<td class="doc"><p>Package logger contains the configuration structures needed to configure
-the access to CloudWatch server to sending the log messages there</p>
+the access to CloudWatch server to sending the log messages there.</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">package</div> <div class="ident">logger</div><div class="operator"></div>
 

--- a/docs/packages/producer/producer.html
+++ b/docs/packages/producer/producer.html
@@ -137,8 +137,8 @@ limitations under the License.
       </tr>
       
       <tr class="section">
-	<td class="doc"><p>Package producer contains functions that can be used to produce (i.e. send)
-messages to properly configured Kafka broker.</p>
+	<td class="doc"><p>Package producer contains functions that can be used to produce (that is
+send) messages to properly configured Kafka broker.</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">package</div> <div class="ident">producer</div><div class="operator"></div>
 


### PR DESCRIPTION
# Description

This PR adds 2 minor improvements to Makefile:
* The `docgo` generated files now will have the license without the needs of running `make license` adter generating them
* Added phony rules to install `docgo` and `addlicense` command only if needed, avoiding modifications on `go.mod` and `go.sum` files. Using `make license` or `make godoc` will make use of this phony rules

## Type of change
- Refactor (refactoring code, removing useless files)
