### PR TITLE
Fixed broken doc on godoc.org

### DIFF
--- a/producer/producer.go
+++ b/producer/producer.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package producer contains functions that can be used to produce (i.e. send)
-// messages to properly configured Kafka broker.
+// Package producer contains functions that can be used to produce (that is
+// send) messages to properly configured Kafka broker.
 package producer
 
 import (


### PR DESCRIPTION
# Description

Fixed broken doc on godoc.org - the documentation generator thinks that the "main description" is separated from the rest of text by dot (.). But the first dot was placed in "i.e." which in results means, that the generated documentation for the package overview was wrong.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

Can be rechecked on https://godoc.org/github.com/RedHatInsights/insights-results-aggregator later