### PR TITLE
Change produced_messages metric description

### DIFF
--- a/docs/packages/metrics/metrics.html
+++ b/docs/packages/metrics/metrics.html
@@ -150,7 +150,7 @@ and indirectly to Grafana. Currently, the following metrics are exposed:</p>
 
 <p>last<em>checked</em>timestamp<em>lag</em>minutes - shows how slow we get messages from clusters</p>
 
-<p>produced_messages - total number of produced messages</p>
+<p>produced_messages - total number of produced messages sent to Payload Tracker's Kafka topic</p>
 
 <p>written_reports - total number of reports written into the storage (cache)</p>
 
@@ -232,7 +232,7 @@ probably it will be used only in tests</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">var</div> <div class="ident">ProducedMessages</div> <div class="operator">=</div> <div class="ident">promauto</div><div class="operator">.</div><div class="ident">NewCounter</div><div class="operator">(</div><div class="ident">prometheus</div><div class="operator">.</div><div class="ident">CounterOpts</div><div class="operator">{</div>
 	<div class="ident">Name</div><div class="operator">:</div> <div class="literal">&#34;produced_messages&#34;</div><div class="operator">,</div>
-	<div class="ident">Help</div><div class="operator">:</div> <div class="literal">&#34;The total number of produced messages&#34;</div><div class="operator">,</div>
+	<div class="ident">Help</div><div class="operator">:</div> <div class="literal">&#34;The total number of produced messages sent to Payload Tracker&#39;s Kafka topic&#34;</div><div class="operator">,</div>
 <div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
 
 </code></pre></td>
@@ -327,7 +327,7 @@ probably it will be used only in tests</p>
 	<div class="ident">ProducedMessages</div> <div class="operator">=</div> <div class="ident">promauto</div><div class="operator">.</div><div class="ident">NewCounter</div><div class="operator">(</div><div class="ident">prometheus</div><div class="operator">.</div><div class="ident">CounterOpts</div><div class="operator">{</div>
 		<div class="ident">Namespace</div><div class="operator">:</div> <div class="ident">namespace</div><div class="operator">,</div>
 		<div class="ident">Name</div><div class="operator">:</div>      <div class="literal">&#34;produced_messages&#34;</div><div class="operator">,</div>
-		<div class="ident">Help</div><div class="operator">:</div>      <div class="literal">&#34;The total number of produced messages&#34;</div><div class="operator">,</div>
+		<div class="ident">Help</div><div class="operator">:</div>      <div class="literal">&#34;The total number of produced messages sent to Payload Tracker&#39;s Kafka topic&#34;</div><div class="operator">,</div>
 	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">WrittenReports</div> <div class="operator">=</div> <div class="ident">promauto</div><div class="operator">.</div><div class="ident">NewCounter</div><div class="operator">(</div><div class="ident">prometheus</div><div class="operator">.</div><div class="ident">CounterOpts</div><div class="operator">{</div>
 		<div class="ident">Namespace</div><div class="operator">:</div> <div class="ident">namespace</div><div class="operator">,</div>

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -13,7 +13,7 @@ Currently, the following metrics are exposed:
 1. `successful_messages_processing_time` the time to process successfully message
 1. `failed_messages_processing_time` the time to process message fail
 1. `last_checked_timestamp_lag_minutes` shows how slow we get messages from clusters
-1. `produced_messages` the total number of produced messages
+1. `produced_messages` the total number of produced messages sent to Payload Tracker's Kafka topic
 1. `written_reports` the total number of reports written to the storage
 1. `feedback_on_rules` the total number of left feedback
 1. `sql_queries_counter` the total number of SQL queries

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,7 +27,7 @@ limitations under the License.
 //
 // last_checked_timestamp_lag_minutes - shows how slow we get messages from clusters
 //
-// produced_messages - total number of produced messages
+// produced_messages - total number of produced messages sent to Payload Tracker's Kafka topic
 //
 // written_reports - total number of reports written into the storage (cache)
 //
@@ -78,7 +78,7 @@ var LastCheckedTimestampLagMinutes = promauto.NewHistogram(prometheus.HistogramO
 // probably it will be used only in tests
 var ProducedMessages = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "produced_messages",
-	Help: "The total number of produced messages",
+	Help: "The total number of produced messages sent to Payload Tracker's Kafka topic",
 })
 
 // WrittenReports shows number of reports written into the database
@@ -148,7 +148,7 @@ func AddMetricsWithNamespace(namespace string) {
 	ProducedMessages = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "produced_messages",
-		Help:      "The total number of produced messages",
+		Help:      "The total number of produced messages sent to Payload Tracker's Kafka topic",
 	})
 	WrittenReports = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,


### PR DESCRIPTION
# Description

In order to avoid misunderstandings of the meaning of the `produced_messages` metric, update docs, comments and current code.

Fixes #923 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Regular CI