### PR TITLE
Fixed issue #931: Description needs to be provided for all items in  /clusters/{clusterId}/rules/{ruleId}/users/{userId}/like

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -276,6 +276,7 @@
             "name": "clusterId",
             "in": "path",
             "required": true,
+            "description": "ID of the cluster which must conform to UUID format. An example: `34c3ecc5-624a-49a5-bab8-4fdc5e51a266`",
             "schema": {
               "type": "string",
               "minLength": 36,
@@ -287,6 +288,7 @@
             "name": "ruleId",
             "in": "path",
             "required": true,
+            "description": "ID of a rule. An example: `some.python.module`",
             "schema": {
               "type": "string"
             }
@@ -295,6 +297,7 @@
             "name": "userId",
             "in": "path",
             "required": true,
+            "description": "Numeric ID of the user. An example: `42`",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
# Description

Description needs to be provided for all items in `parameters` for "/clusters/{clusterId}/rules/{ruleId}/users/{userId}/like"

Fixes #931

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

N/A