### PR TITLE
Description needs to be provided for all items in `parameters` for "/clusters/{clusterId}/rules/{ruleId}/users/{userId}/reset_vote"

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -398,6 +398,7 @@
             "name": "clusterId",
             "in": "path",
             "required": true,
+            "description": "ID of the cluster which must conform to UUID format. An example: `34c3ecc5-624a-49a5-bab8-4fdc5e51a266`",
             "schema": {
               "type": "string",
               "minLength": 36,
@@ -409,6 +410,7 @@
             "name": "ruleId",
             "in": "path",
             "required": true,
+            "description": "ID of a rule. An example: `some.python.module`",
             "schema": {
               "type": "string"
             }
@@ -417,6 +419,7 @@
             "name": "userId",
             "in": "path",
             "required": true,
+            "description": "Numeric ID of the user. An example: `42`",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
# Description

Description needs to be provided for all items in `parameters` for "/clusters/{clusterId}/rules/{ruleId}/users/{userId}/reset_vote"

Fixes #933

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A