### PR TITLE
Fixed issue #1009

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10,6 +10,7 @@
     "/openapi.json": {
       "get": {
         "summary": "Returns the OpenAPI specification JSON.",
+        "description": "The OpenAPI specification of this REST API service that is represented in formatted and human-readable JSON is available under this endpoint.",
         "operationId": "getOpenApi",
         "responses": {
           "200": {


### PR DESCRIPTION
# Description

No description found for endpoint `/openapi.json` and method `get` in OpenAPI specification 

Fixes #1009

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A