### PR TITLE
Fixed issue #1010

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -105,6 +105,7 @@
     "/organizations/{orgId}/clusters": {
       "get": {
         "summary": "Returns a list of clusters associated with the specified organization ID.",
+        "description": "Returns a list of clusters associated with the specified unique organization ID.",
         "operationId": "getClustersForOrganization",
         "parameters": [
           {


### PR DESCRIPTION
# Description

No description found for endpoint `/organizations/{orgId}/clusters` and method `get` in OpenAPI specification

Fixes #1010

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A