### PR TITLE
update OpenAPI spec with new rule disable/enable endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -915,11 +915,11 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/users/{userId}/disable": {
+    "/clusters/{clusterId}/rules/{ruleId}/disable": {
       "put": {
         "summary": "Disables a rule/health check recommendation for specified cluster",
         "operationId": "disableRule",
-        "description": "Disables a rule (ruleId) for cluster (clusterId) for current organization/user",
+        "description": "Disables a rule (ruleId) for cluster (clusterId)",
         "parameters": [
           {
             "name": "clusterId",
@@ -942,16 +942,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "description": "Numeric ID of the user. An example: `42`",
-            "schema": {
-              "type": "string"
-            },
-            "example": "some.python.module"
           }
         ],
         "responses": {
@@ -1046,11 +1036,11 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/users/{userId}/enable": {
+    "/clusters/{clusterId}/rules/{ruleId}/enable": {
       "put": {
         "summary": "Re-enables a rule/health check recommendation for specified cluster",
         "operationId": "enableRule",
-        "description": "Enables a rule (ruleId) for cluster (clusterId) for current organization/user",
+        "description": "Enables a rule (ruleId) for cluster (clusterId)",
         "parameters": [
           {
             "name": "clusterId",
@@ -1074,15 +1064,6 @@
               "type": "string"
             },
             "example": "some.python.module"
-          },
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "description": "Numeric ID of the user. An example: `42`",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {


### PR DESCRIPTION
# Description

I forgot to update the OpenAPI spec, not sure what it affects (tests maybe?), as the one accessible on https://cloud.redhat.com/api/insights-results-aggregator/v1/openapi.json is the smart-proxy's openapi.json and that one didn't change.

## Type of change

Please delete options that are not relevant.

- Documentation update


