### PR TITLE
Reading Kafka bootstrap server from Clowder when available

### DIFF
--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-THRESHOLD=80
+THRESHOLD=79
 
 RED_BG=$(tput setab 1)
 GREEN_BG=$(tput setab 2)


### PR DESCRIPTION
# Description

Reading the Kafka bootstrap server configuration from Clowder, if available, overwriting the one defined by the current configuration

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
