### PR TITLE
fix upsert query which wasn't ready for a cluster transferring to different org

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,3 +1,17 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Build and deploy Jekyll site to GitHub Pages
 
 on:

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -exv
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # --------------------------------------------
 # Options that must be configured by app owner

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -595,8 +595,8 @@ func (storage DBStorage) getReportUpsertQuery() string {
 	return `
 		INSERT INTO report(org_id, cluster, report, reported_at, last_checked_at, kafka_offset)
 		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (org_id, cluster)
-		DO UPDATE SET report = $3, reported_at = $4, last_checked_at = $5, kafka_offset = $6
+		ON CONFLICT (cluster)
+		DO UPDATE SET org_id = $1, report = $3, reported_at = $4, last_checked_at = $5, kafka_offset = $6
 	`
 }
 
@@ -644,7 +644,9 @@ func (storage DBStorage) updateReport(
 	for _, rule := range rules {
 		_, err = tx.Exec(ruleUpsertQuery, orgID, clusterName, rule.Module, rule.ErrorKey, string(rule.TemplateData))
 		if err != nil {
-			log.Err(err).Msgf("Unable to upsert the cluster report (org: %v, cluster: %v)", orgID, clusterName)
+			log.Err(err).Msgf("Unable to upsert the cluster report rules (org: %v, cluster: %v, rule: %v|%v)",
+				orgID, clusterName, rule.Module, rule.ErrorKey,
+			)
 			return err
 		}
 	}


### PR DESCRIPTION
# Description
When a cluster got transferred to a different org (e.g. via OCM), our pipeline was basically not ready for it, only expecting a `org_id` + `cluster_id` ON CONFLICT. However when we received a cluster report that had the same cluster_id but a different org_id, the ON CONFLICT was not triggered, the db-writer tried to perform a simple INSERT and failed because of the enforced `org_id` + `cluster_id` uniqueness.

This PR changes the ON CONFLICT behaviour so that when the service receives a report with a new org_id, it's able to handle it.

No other changes to SELECT queries are IMO necessary because the constraint is handled on DB side, so a unique cluster ID always = 1 org. **This means we're now relying on cluster IDs (UUIDs) being unique, which I think is probably safe to do**. And if we experience a cluster_id duplicate, I'll be damned :) 

Fixes https://issues.redhat.com/browse/CCXDEV-5142

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
tried the behaviour locally by modifying a report's org_id in the database and trying to upload the archive again (which now wouldn't trigger the ON CONFLICT) and it works as expected = the cluster gets transferred to the new org, which is now able to retrieve the report and the old org is not able to access to report

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
