### PR TITLE
changed db name

### DIFF
--- a/deploy/irdb_clowdapp.yaml
+++ b/deploy/irdb_clowdapp.yaml
@@ -129,7 +129,7 @@ objects:
               cpu: 200m
               memory: 300Mi
     database:
-      name: results-db
+      name: ccx-data-pipeline-db
       version: 12
     kafkaTopics:
       - replicas: 3


### PR DESCRIPTION
# Description

the deployment has an error `MountVolume.SetUp failed for volume "config-secret" : secret "insights-results-db" not found`

we need to use the same name that was set up [here](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/ccx-data-pipeline/namespaces/stage-ccx-data-pipeline-stage.yml#L62) as the secret is automatically created with the name specified in app-interface.

References:
https://gitlab.cee.redhat.com/service/app-interface/#manage-rds-databases-via-app-interface-openshiftnamespace-1yml


Fixes CCXDEV-4927

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


