### PR TITLE
fix typo OK response in capital letters instead of 'ok'

### DIFF
--- a/server/reports.go
+++ b/server/reports.go
@@ -128,7 +128,7 @@ func fillInGeneratedReports(clusterNames []types.ClusterName, reports map[types.
 	}
 
 	// it must be ok now
-	generatedReports.Status = "OK"
+	generatedReports.Status = "ok"
 
 	return generatedReports
 }

--- a/server/reports.go
+++ b/server/reports.go
@@ -31,7 +31,12 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
-const includeTimestamp = false
+const (
+	includeTimestamp = false
+
+	// OkStatusPayload is the text returned as body payload when an OK Status request is sent
+	OkStatusPayload = "ok"
+)
 
 // validateClusterID function checks if the cluster ID is a valid UUID.
 func validateClusterID(clusterID string) error {
@@ -128,7 +133,7 @@ func fillInGeneratedReports(clusterNames []types.ClusterName, reports map[types.
 	}
 
 	// it must be ok now
-	generatedReports.Status = "ok"
+	generatedReports.Status = OkStatusPayload
 
 	return generatedReports
 }

--- a/server/reports_test.go
+++ b/server/reports_test.go
@@ -153,7 +153,7 @@ func TestReadReportsForClustersKnownCluster(t *testing.T) {
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body: `{
-			"clusters": null,"errors": ["84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc"],"reports": {},"generated_at": "","status": "OK"
+			"clusters": null,"errors": ["84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc"],"reports": {},"generated_at": "","status": "ok"
 		}`,
 	})
 }
@@ -168,7 +168,7 @@ func TestReadReportsForClustersTwoClusters(t *testing.T) {
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body: `{
-			"clusters": null,"errors": ["84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc","84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc"],"reports": {},"generated_at": "","status": "OK"
+			"clusters": null,"errors": ["84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc","84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc"],"reports": {},"generated_at": "","status": "ok"
 		}`,
 	})
 }

--- a/tests/rest/common.go
+++ b/tests/rest/common.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 
 	"github.com/verdverm/frisby"
+
+	server "github.com/RedHatInsights/insights-results-aggregator/server"
 )
 
 // common constants used by REST API tests
@@ -124,14 +126,14 @@ func checkGetEndpointByOtherMethods(endpoint string, includingOptions bool) {
 
 // checkOkStatusResponse tests whether the response (JSON) contains status attribute set to 'ok'
 func checkOkStatusResponse(f *frisby.Frisby, response ClustersResponse) {
-	if response.Status != "ok" {
+	if response.Status != server.OkStatusPayload {
 		f.AddError(fmt.Sprintf("Expected status is 'ok', but got '%s' instead", response.Status))
 	}
 }
 
 // checkErrorStatusResponse tests whether the response (JSON) contains status attribute not set to 'ok'
 func checkErrorStatusResponse(f *frisby.Frisby, response StatusOnlyResponse) {
-	if response.Status == "ok" {
+	if response.Status == server.OkStatusPayload {
 		f.AddError(fmt.Sprintf("Expected error status, but got '%s' instead", response.Status))
 	}
 }

--- a/tests/rest/metrics.go
+++ b/tests/rest/metrics.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/verdverm/frisby"
 )
 
@@ -33,7 +34,7 @@ func checkPrometheusMetrics() {
 	f.Expect(func(F *frisby.Frisby) (bool, string) {
 		header := F.Resp.Header.Get(contentTypeHeader)
 		if strings.HasPrefix(header, "text/plain") {
-			return true, "ok"
+			return true, server.OkStatusPayload
 		}
 		return false, fmt.Sprintf("Expected Header %q to be %q, but got %q", contentTypeHeader, "text/plain", header)
 	})

--- a/tests/rest/multiple_reports.go
+++ b/tests/rest/multiple_reports.go
@@ -127,8 +127,8 @@ func expectNumberOfReports(f *frisby.Frisby, response MultipleReportsResponse, e
 
 // expectOkStatus tests whether the response (JSON) contains status attribute set to 'ok'
 func expectOkStatus(f *frisby.Frisby, response MultipleReportsResponse) {
-	if response.Status == "ok" {
-		f.AddError(fmt.Sprintf("Expected error status, but got '%s' instead", response.Status))
+	if response.Status != "ok" {
+		f.AddError(fmt.Sprintf("Expected ok status, but got '%s' instead", response.Status))
 	}
 }
 

--- a/tests/rest/multiple_reports.go
+++ b/tests/rest/multiple_reports.go
@@ -127,7 +127,7 @@ func expectNumberOfReports(f *frisby.Frisby, response MultipleReportsResponse, e
 
 // expectOkStatus tests whether the response (JSON) contains status attribute set to 'ok'
 func expectOkStatus(f *frisby.Frisby, response MultipleReportsResponse) {
-	if response.Status != "ok" {
+	if response.Status != server.OkStatusPayload {
 		f.AddError(fmt.Sprintf("Expected ok status, but got '%s' instead", response.Status))
 	}
 }

--- a/tests/rest/organizations.go
+++ b/tests/rest/organizations.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/verdverm/frisby"
 )
 
@@ -50,7 +51,7 @@ func readOrganizationsFromResponse(f *frisby.Frisby) OrganizationsResponse {
 func contentSizeForOrganizationResponse(orgIDs ...int) int {
 	r := OrganizationsResponse{
 		Organizations: orgIDs,
-		Status:        "ok",
+		Status:        server.OkStatusPayload,
 	}
 	m, err := json.Marshal(r)
 
@@ -73,7 +74,7 @@ func checkOrganizationsEndpointWithPostfix(postfix string) {
 	f.ExpectHeader(contentLengthHeader, strconv.Itoa(contentSizeForOrganizationResponse(1, 2, 3, 4)))
 
 	organizationsResponse := readOrganizationsFromResponse(f)
-	if organizationsResponse.Status != "ok" {
+	if organizationsResponse.Status != server.OkStatusPayload {
 		f.AddError(fmt.Sprintf("Expected status is 'ok', but got '%s' instead", organizationsResponse.Status))
 	}
 

--- a/tests/rest/rule_vote.go
+++ b/tests/rest/rule_vote.go
@@ -98,7 +98,7 @@ func checkOkStatus(f *frisby.Frisby) {
 	f.ExpectStatus(200)
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 	statusResponse := readStatusFromResponse(f)
-	if statusResponse.Status != "ok" {
+	if statusResponse.Status != server.OkStatusPayload {
 		f.AddError(fmt.Sprintf("Expected ok status, but got '%s' instead", statusResponse.Status))
 	}
 }
@@ -120,7 +120,7 @@ func checkInvalidUUIDFormat(f *frisby.Frisby) {
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 
 	statusResponse := readStatusFromResponse(f)
-	if statusResponse.Status == "ok" {
+	if statusResponse.Status == server.OkStatusPayload {
 		f.AddError(fmt.Sprintf(unexpectedErrorStatusMessage, statusResponse.Status))
 	}
 	if !strings.Contains(statusResponse.Status, "Error: 'invalid UUID ") {
@@ -147,7 +147,7 @@ func checkItemNotFound(f *frisby.Frisby) {
 	f.ExpectHeader(contentTypeHeader, ContentTypeJSON)
 
 	statusResponse := readStatusFromResponse(f)
-	if statusResponse.Status == "ok" {
+	if statusResponse.Status == server.OkStatusPayload {
 		f.AddError(fmt.Sprintf(unexpectedErrorStatusMessage, statusResponse.Status))
 	}
 	if !strings.Contains(statusResponse.Status, "was not found in the storage") {


### PR DESCRIPTION
# Description

Fix typo where some payloads includes an "OK" response in capital letters instead of "ok".

Fixes [#1200](https://github.com/RedHatInsights/insights-results-aggregator/issues/1200)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)

## Testing steps

Run `sh test.sh`.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
