### PR TITLE
Recommendations table and processing of report

### DIFF
--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -49,6 +49,8 @@ const (
 
 	// message to be checked
 	organizationIDNotInAllowList = "organization ID is not in allow list"
+
+	testReport = `{"fingerprints": [], "info": [], "skips": [], "system": {}, "analysis_metadata":{"metadata":"some metadata"},"reports":[{"rule_id":"rule_4|RULE_4","component":"ccx_rules_ocp.external.rules.rule_1.report","type":"rule","key":"RULE_4","details":"some details"},{"rule_id":"rule_4|RULE_4","component":"ccx_rules_ocp.external.rules.rule_2.report","type":"rule","key":"RULE_2","details":"some details"},{"rule_id":"rule_5|RULE_5","component":"ccx_rules_ocp.external.rules.rule_5.report","type":"rule","key":"RULE_3","details":"some details"}]}`
 )
 
 var (
@@ -58,6 +60,12 @@ var (
 		Topic:   "topic",
 		Group:   "group",
 	}
+	messageReportWithRuleHits = `{
+		"OrgID": ` + fmt.Sprint(testdata.OrgID) + `,
+		"ClusterName": "` + string(testdata.ClusterName) + `",
+		"Report":` + testReport + `,
+		"LastChecked": "` + testdata.LastCheckedAt.UTC().Format(time.RFC3339) + `"
+	}`
 )
 
 func init() {
@@ -255,12 +263,13 @@ func TestProcessEmptyMessage(t *testing.T) {
 
 func TestProcessCorrectMessage(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
+
 	defer closer()
 
 	c := dummyConsumer(mockStorage, true)
 
 	message := sarama.ConsumerMessage{}
-	message.Value = []byte(testdata.ConsumerMessage)
+	message.Value = []byte(messageReportWithRuleHits)
 	// message is correct -> one record should be written into storage
 	_, err := c.ProcessMessage(&message)
 	helpers.FailOnError(t, err)
@@ -309,7 +318,7 @@ func TestKafkaConsumerMockOK(t *testing.T) {
 			t,
 			testTopicName,
 			testOrgAllowlist,
-			[]string{testdata.ConsumerMessage},
+			[]string{messageReportWithRuleHits},
 		)
 
 		go mockConsumer.Serve()
@@ -418,7 +427,7 @@ func TestKafkaConsumer_ProcessMessage_OrganizationAllowlistDisabled(t *testing.T
 
 	mockConsumer := dummyConsumer(mockStorage, false)
 
-	err := consumerProcessMessage(mockConsumer, testdata.ConsumerMessage)
+	err := consumerProcessMessage(mockConsumer, messageReportWithRuleHits)
 	helpers.FailOnError(t, err)
 }
 
@@ -477,7 +486,7 @@ func TestKafkaConsumer_ProcessMessage_MessageFromTheFuture(t *testing.T) {
 	message := `{
 		"OrgID": ` + fmt.Sprint(testdata.OrgID) + `,
 		"ClusterName": "` + string(testdata.ClusterName) + `",
-		"Report":` + testdata.ConsumerReport + `,
+		"Report":` + testReport + `,
 		"LastChecked": "` + time.Now().Add(24*time.Hour).Format(time.RFC3339) + `"
 	}`
 
@@ -502,7 +511,7 @@ func TestKafkaConsumer_ProcessMessage_MoreRecentReportAlreadyExists(t *testing.T
 	message := `{
 		"OrgID": ` + fmt.Sprint(testdata.OrgID) + `,
 		"ClusterName": "` + string(testdata.ClusterName) + `",
-		"Report":` + testdata.ConsumerReport + `,
+		"Report":` + testReport + `,
 		"LastChecked": "` + time.Now().Format(time.RFC3339) + `"
 	}`
 
@@ -534,7 +543,7 @@ func TestKafkaConsumer_ProcessMessage_MessageWithUnexpectedSchemaVersion(t *test
 		Storage:       mockStorage,
 	}
 
-	err := consumerProcessMessage(mockConsumer, testdata.ConsumerMessage)
+	err := consumerProcessMessage(mockConsumer, messageReportWithRuleHits)
 	helpers.FailOnError(t, err)
 	assert.Contains(t, buf.String(), "\"level\":\"warn\"")
 	assert.Contains(t, buf.String(), "Received data with unexpected version")
@@ -555,7 +564,7 @@ func TestKafkaConsumer_ProcessMessage_MessageWithExpectedSchemaVersion(t *testin
 	message := `{
 		"OrgID": ` + fmt.Sprint(testdata.OrgID) + `,
 		"ClusterName": "` + string(testdata.ClusterName) + `",
-		"Report":` + testdata.ConsumerReport + `,
+		"Report":` + testReport + `,
 		"LastChecked": "` + time.Now().Add(-24*time.Hour).Format(time.RFC3339) + `",
 		"Version": ` + fmt.Sprintf("%d", consumer.CurrentSchemaVersion) + `
 	}`

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -127,6 +127,22 @@ func checkMessageOrgInAllowList(consumer *KafkaConsumer, message *incomingMessag
 	return true, ""
 }
 
+func writeRecommendations(
+	consumer *KafkaConsumer, msg *sarama.ConsumerMessage, message incomingMessage, reportAsBytes []byte) (
+	time.Time, error) {
+	err := consumer.Storage.WriteRecommendationsForCluster(
+		*message.ClusterName,
+		types.ClusterReport(reportAsBytes),
+	)
+	if err != nil {
+		logMessageError(consumer, msg, message, "Error writing recommendations to database", err)
+		return time.Time{}, err
+	}
+	tStored := time.Now()
+	logMessageInfo(consumer, msg, message, "Stored recommendations")
+	return tStored, nil
+}
+
 // ProcessMessage processes an incoming message
 func (consumer *KafkaConsumer) ProcessMessage(msg *sarama.ConsumerMessage) (types.RequestID, error) {
 	tStart := time.Now()
@@ -192,15 +208,21 @@ func (consumer *KafkaConsumer) ProcessMessage(msg *sarama.ConsumerMessage) (type
 		logMessageError(consumer, msg, message, "Error writing report to database", err)
 		return message.RequestID, err
 	}
-	logMessageInfo(consumer, msg, message, "Stored")
+	logMessageInfo(consumer, msg, message, "Stored report")
 	tStored := time.Now()
+
+	tRecommendationsStored, err := writeRecommendations(consumer, msg, message, reportAsBytes)
+	if err != nil {
+		return message.RequestID, err
+	}
 
 	// log durations for every message consumption steps
 	logDuration(tStart, tRead, msg.Offset, "read")
 	logDuration(tRead, tAllowlisted, msg.Offset, "org_filtering")
 	logDuration(tAllowlisted, tMarshalled, msg.Offset, "marshalling")
 	logDuration(tMarshalled, tTimeCheck, msg.Offset, "time_check")
-	logDuration(tTimeCheck, tStored, msg.Offset, "db_store")
+	logDuration(tTimeCheck, tStored, msg.Offset, "db_store_report")
+	logDuration(tStored, tRecommendationsStored, msg.Offset, "db_store_recommendations")
 
 	// message has been parsed and stored into storage
 	return message.RequestID, nil

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -36,6 +36,8 @@ limitations under the License.
 // sql_queries_counter - total number of SQL queries
 //
 // sql_queries_durations - SQL queries durations
+//
+// sql_recommendations_updates - number of insert and deletes in recommendations table
 package metrics
 
 import (
@@ -105,6 +107,18 @@ var SQLQueriesDurations = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help: "SQL queries durations",
 }, []string{"query"})
 
+// SQLRecommendationsDeletes shows deleted entries in recommendations table.
+var SQLRecommendationsDeletes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name: "sql_recommendations_deletes",
+	Help: "Number of rows removed from the SQL Recommendations table when new report is processed",
+}, []string{"cluster"})
+
+// SQLRecommendationsInserts shows inserted entries in recommendations table.
+var SQLRecommendationsInserts = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name: "sql_recommendations_inserts",
+	Help: "Number of rows added to the SQL Recommendations table when new report is processed",
+}, []string{"cluster"})
+
 // AddMetricsWithNamespace register the desired metrics using a given namespace
 func AddMetricsWithNamespace(namespace string) {
 	metrics.AddAPIMetricsWithNamespace(namespace)
@@ -119,6 +133,8 @@ func AddMetricsWithNamespace(namespace string) {
 	prometheus.Unregister(FeedbackOnRules)
 	prometheus.Unregister(SQLQueriesCounter)
 	prometheus.Unregister(SQLQueriesDurations)
+	prometheus.Unregister(SQLRecommendationsDeletes)
+	prometheus.Unregister(SQLRecommendationsInserts)
 
 	ConsumedMessages = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
@@ -170,4 +186,14 @@ func AddMetricsWithNamespace(namespace string) {
 		Name:      "sql_queries_durations",
 		Help:      "SQL queries durations",
 	}, []string{"query"})
+	SQLRecommendationsDeletes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "sql_recommendations_deletes",
+		Help:      "Number of rows removed from the SQL recommendation table when new report is processed",
+	}, []string{"cluster", "deleted_rows"})
+	SQLRecommendationsInserts = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "sql_recommendations_inserts",
+		Help:      "Number of rows added to the SQL recommendation table when new report is processed",
+	}, []string{"cluster", "inserted_rows"})
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Shopify/sarama/mocks"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	prommodels "github.com/prometheus/client_model/go"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -141,6 +142,27 @@ func TestWrittenReportsMetric(t *testing.T) {
 
 	assertCounterValue(t, 100, metrics.WrittenReports, initValue)
 }
+
+// TestWrittenRecommendationsMetricCorrectUpdate verifies that every time
+// WriteRecommendationsForCluster is called, two entries are added to the
+// metrics.SQLRecommendationsUpdates HistogramVect. One entry for number
+// of deleted rows, and one for number of inserted rows.
+func TestWrittenRecommendationsMetricCorrectUpdate(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
+	defer closer()
+
+	initialDeletes := testutil.CollectAndCount(metrics.SQLRecommendationsDeletes)
+	initialInserts := testutil.CollectAndCount(metrics.SQLRecommendationsInserts)
+
+	err := mockStorage.WriteRecommendationsForCluster(testdata.ClusterName, testdata.Report3Rules)
+	helpers.FailOnError(t, err)
+
+	//We expect one new metric in each histogramVect, one for deleted rows and one for inserted rows
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.SQLRecommendationsDeletes)-initialDeletes)
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.SQLRecommendationsInserts)-initialInserts)
+}
+
+// TODO: More tests for recommendations metrics, but in another PR
 
 // TODO: write tests for sql queries metrics
 // - SQLQueriesCounter

--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"database/sql"
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+var mig0016AddRecommendationsTable = Migration{
+	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
+		// Create recommendation table using currently stored rule hits
+		_, err := tx.Exec(`
+			CREATE TABLE recommendation
+				AS SELECT
+					cluster_id,
+					rule_fqdn,
+					error_key
+				FROM rule_hit;
+		`)
+
+		if err != nil {
+			return err
+		}
+
+		if driver != types.DBDriverPostgres {
+			// stop here if sqLite
+			return nil
+		}
+
+		//Add the primary_key to the new table
+		_, err = tx.Exec(`
+			ALTER TABLE recommendation
+				ADD CONSTRAINT recommendation_pk
+					PRIMARY KEY (cluster_id, rule_fqdn, error_key);`)
+		return err
+	},
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		_, err := tx.Exec(`
+			DROP TABLE recommendation
+		`)
+		return err
+	},
+}

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -32,4 +32,5 @@ var migrations = []Migration{
 	mig0013AddRuleHitTable,
 	mig0014ModifyClusterRuleToggle,
 	mig0015ModifyFeedbackTables,
+	mig0016AddRecommendationsTable,
 }

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -51,3 +51,21 @@ func GetConnection(storage *DBStorage) *sql.DB {
 func GetClustersLastChecked(storage *DBStorage) map[types.ClusterName]time.Time {
 	return storage.clustersLastChecked
 }
+
+func SetClustersLastChecked(storage *DBStorage, cluster types.ClusterName, lastChecked time.Time) {
+	storage.clustersLastChecked[cluster] = lastChecked
+}
+
+func InsertRecommendations(storage *DBStorage, clusterName types.ClusterName, report types.ReportRules) error {
+	tx, err := storage.connection.Begin()
+	if err != nil {
+		return err
+	}
+	_, err = storage.insertRecommendations(tx, clusterName, report)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	_ = tx.Commit()
+	return nil
+}

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -75,6 +75,13 @@ func (*NoopStorage) WriteReportForCluster(
 	return nil
 }
 
+// WriteRecommendationsForCluster noop
+func (*NoopStorage) WriteRecommendationsForCluster(
+	types.ClusterName, types.ClusterReport,
+) error {
+	return nil
+}
+
 // ReportsCount noop
 func (*NoopStorage) ReportsCount() (int, error) {
 	return 0, nil

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1007,3 +1007,137 @@ func TestDBStorageReadOrgIDsForClusters3(t *testing.T) {
 	// error is expected in this case
 	assert.NotNil(t, err)
 }
+
+// TestDBStorageWriteRecommendationsForClusterClosedStorage check the behaviour of method WriteRecommendationsForCluster
+func TestDBStorageWriteRecommendationsForClusterClosedStorage(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetMockStorage(t, false)
+	// we need to close storage right now
+	closer()
+	err := mockStorage.WriteRecommendationsForCluster(
+		testdata.ClusterName,
+		testdata.ClusterReportEmpty,
+	)
+	assert.EqualError(t, err, "sql: database is closed")
+}
+
+// TestDBStorageWriteReportForClusterClosedStorage check the behaviour of method WriteReportForCluster
+func TestDBStorageWriteRecommendationForClusterUnsupportedDriverError(t *testing.T) {
+	fakeStorage := storage.NewFromConnection(nil, -1)
+	err := fakeStorage.WriteRecommendationsForCluster(
+		testdata.ClusterName,
+		testdata.ClusterReportEmpty,
+	)
+	assert.EqualError(t, err, "writing recommendations with DB -1 is not supported")
+}
+
+// TestDBStorageWriteRecommendationForClusterNoConflict checks that
+// recommendation is inserted correctly if there is not a more recent
+// one stored.
+func TestDBStorageWriteRecommendationForClusterNoConflict(t *testing.T) {
+	mockStorage, expects := ira_helpers.MustGetMockStorageWithExpectsForDriver(t, types.DBDriverPostgres)
+	defer ira_helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
+
+	expects.ExpectBegin()
+
+	expects.ExpectExec("INSERT INTO recommendation").
+		WillReturnResult(driver.ResultNoRows)
+
+	expects.ExpectCommit()
+
+	err := mockStorage.WriteRecommendationsForCluster(
+		testdata.ClusterName, testdata.Report3Rules,
+	)
+
+	helpers.FailOnError(t, err)
+}
+
+// TestDBStorageInsertRecommendations checks that only hitting rules in the report
+// are inserted in the recommendation table
+func TestDBStorageInsertRecommendations(t *testing.T) {
+	mockStorage, expects := ira_helpers.MustGetMockStorageWithExpectsForDriver(t, types.DBDriverSQLite3)
+	defer ira_helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
+
+	expects.ExpectBegin()
+
+	expects.ExpectExec("INSERT INTO recommendation \\(cluster_id, rule_fqdn, error_key\\) " +
+		"VALUES \\(\\$1, \\$2, \\$3\\),\\(\\$4, \\$5, \\$6\\),\\(\\$7, \\$8, \\$9\\)").
+		WillReturnResult(driver.ResultNoRows)
+
+	expects.ExpectCommit()
+
+	report := types.ReportRules{
+		HitRules:     testdata.RuleOnReportResponses,
+		SkippedRules: testdata.RuleOnReportResponses,
+		PassedRules:  testdata.RuleOnReportResponses,
+		TotalCount:   3 * len(testdata.RuleOnReportResponses),
+	}
+	err := storage.InsertRecommendations(mockStorage.(*storage.DBStorage), testdata.ClusterName, report)
+
+	helpers.FailOnError(t, err)
+}
+
+// TestDBStorageWriteRecommendationForClusterAlreadyStored checks that
+// recommendation is not inserted if there is already one
+// recommendation stored with the same values
+func TestDBStorageWriteRecommendationForClusterAlreadyStored(t *testing.T) {
+	mockStorage, expects := ira_helpers.MustGetMockStorageWithExpectsForDriver(t, types.DBDriverPostgres)
+	defer ira_helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
+
+	expects.ExpectBegin()
+	expects.ExpectExec("INSERT INTO recommendation").
+		WillReturnResult(driver.ResultNoRows)
+	expects.ExpectCommit()
+
+	err := mockStorage.WriteRecommendationsForCluster(
+		testdata.ClusterName, testdata.Report3Rules,
+	)
+	helpers.FailOnError(t, err)
+
+	expects.ExpectBegin()
+	expects.ExpectExec("INSERT INTO recommendation").
+		WillReturnError(fmt.Errorf("Unable to insert the recommendation for cluster: " + string(testdata.ClusterName)))
+	expects.ExpectRollback()
+
+	err = mockStorage.WriteRecommendationsForCluster(
+		testdata.ClusterName, testdata.Report3Rules,
+	)
+
+	assert.Error(t, err, "")
+}
+
+// TestDBStorageWriteRecommendationForClusterAlreadyStoredAndDeleted checks that
+// recommendation is inserted correctly if there is already one
+// recommendation stored with the same values, and existing recommendation
+// is not deleted
+func TestDBStorageWriteRecommendationForClusterAlreadyStoredAndDeleted(t *testing.T) {
+	mockStorage, expects := ira_helpers.MustGetMockStorageWithExpectsForDriver(t, types.DBDriverPostgres)
+	defer ira_helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
+
+	expects.ExpectBegin()
+	expects.ExpectExec("INSERT INTO recommendation").
+		WillReturnResult(driver.ResultNoRows)
+	expects.ExpectCommit()
+
+	err := mockStorage.WriteRecommendationsForCluster(
+		testdata.ClusterName, testdata.Report3Rules,
+	)
+
+	helpers.FailOnError(t, err)
+
+	//Need to update clustersLastChecked as would be done on init and in writeReportForClusters
+	dbStorage := mockStorage.(*storage.DBStorage)
+	storage.SetClustersLastChecked(dbStorage, testdata.ClusterName, time.Now())
+
+	expects.ExpectBegin()
+	expects.ExpectExec("DELETE FROM recommendation").
+		WillReturnResult(driver.RowsAffected(3))
+	expects.ExpectExec("INSERT INTO recommendation").
+		WillReturnResult(driver.ResultNoRows)
+	expects.ExpectCommit()
+
+	err = mockStorage.WriteRecommendationsForCluster(
+		testdata.ClusterName, testdata.Report3Rules,
+	)
+
+	helpers.FailOnError(t, err)
+}

--- a/storage/storage_write_recommendations_benchmark_test.go
+++ b/storage/storage_write_recommendations_benchmark_test.go
@@ -1,0 +1,527 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage_test
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/insights-results-aggregator/storage"
+	ira_helpers "github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
+)
+
+var Report20Rules = types.ClusterReport(`
+{
+	"system": {
+		"metadata": {},
+		"hostname": null
+	},
+	"reports": [
+		{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "` + testdata.ErrorKey1 + `",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "` + testdata.ErrorKey2 + `",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek3",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek4",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek5",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek6",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek7",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek8",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek9",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek10",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek11",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek12",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek13",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek14",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek15",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek16",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek17",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek18",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek19",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek20",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek200",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek21",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek22",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek23",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek24",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek25",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek26",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek27",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek28",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		},
+{
+			"component": "` + string(testdata.Rule1ID) + `",
+			"key": "ek29",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule1ExtraData) + `
+		},
+		{
+			"component": "` + string(testdata.Rule2ID) + `",
+			"key": "ek30",
+			"user_vote": 0,
+			"disabled": false,
+			"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+		}
+	],
+	"fingerprints": [],
+	"skips": [],
+	"info": []
+}
+`)
+
+var exists = struct{}{}
+
+type set struct {
+	content map[string]struct{}
+}
+
+// newSet function allows us to make sure there is no duplicated cluster name
+// in the entries we use for testing.
+func newSet() *set {
+	s := &set{}
+	s.content = make(map[string]struct{})
+	return s
+}
+
+func (s *set) add(value string) {
+	s.content[value] = exists
+}
+
+func (s *set) remove(value string) {
+	delete(s.content, value)
+}
+
+func (s *set) contains(value string) bool {
+	_, c := s.content[value]
+	return c
+}
+
+func resetTimerForBenchmark(b *testing.B) {
+	b.ResetTimer()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	b.StartTimer()
+}
+
+func stopBenchmarkTimer(b *testing.B) {
+	b.StopTimer()
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+}
+
+// Only create recommendation table in the test DB
+func mustPrepareRecommendationsBenchmark(b *testing.B) (storage.Storage, *sql.DB, func()) {
+	// Postgres queries are very verbose at DEBUG log level, so it's better
+	// to silence them this way to make benchmark results easier to find.
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	mockStorage, closer := ira_helpers.MustGetPostgresStorage(b, false)
+	conn := storage.GetConnection(mockStorage.(*storage.DBStorage))
+
+	_, err := conn.Exec("DROP TABLE IF EXISTS recommendation;")
+	helpers.FailOnError(b, err)
+
+	_, err = conn.Exec("CREATE TABLE recommendation (cluster_id VARCHAR NOT NULL, rule_fqdn VARCHAR NOT NULL, error_key VARCHAR NOT NULL, PRIMARY KEY(cluster_id, rule_fqdn, error_key));")
+	helpers.FailOnError(b, err)
+
+	return mockStorage, conn, closer
+}
+
+// Only create recommendation table in the test DB, and insert numRows entries
+// in the table before the benchmarking timers are reset
+func mustPrepareRecommendationsBenchmarkWithEntries(b *testing.B, numRows int) (storage.Storage, *sql.DB, func()) {
+	mockStorage, conn, closer := mustPrepareReportAndRecommendationsBenchmark(b)
+
+	for i := 0; i < numRows; i++ {
+		cluster := uuid.New().String()
+		_, err := conn.Exec(`
+			INSERT INTO recommendation (
+				cluster_id, rule_fqdn, error_key
+			) VALUES ($1, $2, $3)
+		`, cluster, "a rule module", "an error key")
+		helpers.FailOnError(b, err)
+		storage.SetClustersLastChecked(mockStorage.(*storage.DBStorage), types.ClusterName(cluster), time.Now())
+	}
+
+	return mockStorage, conn, closer
+
+}
+
+func mustPrepareReportAndRecommendationsBenchmark(b *testing.B) (storage.Storage, *sql.DB, func()) {
+	// Postgres queries are very verbose at DEBUG log level, so it's better
+	// to silence them this way to make benchmark results easier to find.
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	mockStorage, closer := ira_helpers.MustGetPostgresStorage(b, false)
+
+	conn := storage.GetConnection(mockStorage.(*storage.DBStorage))
+
+	_, err := conn.Exec("DROP TABLE IF EXISTS recommendation;")
+	helpers.FailOnError(b, err)
+	_, err = conn.Exec("DROP TABLE IF EXISTS report;")
+	helpers.FailOnError(b, err)
+	_, err = conn.Exec("DROP TABLE IF EXISTS rule_hit;")
+	helpers.FailOnError(b, err)
+
+	_, err = conn.Exec("CREATE TABLE recommendation (cluster_id VARCHAR NOT NULL, rule_fqdn VARCHAR NOT NULL, error_key VARCHAR NOT NULL, PRIMARY KEY(cluster_id, rule_fqdn, error_key));")
+	helpers.FailOnError(b, err)
+	_, err = conn.Exec("CREATE TABLE report (org_id INTEGER NOT NULL, cluster VARCHAR NOT NULL UNIQUE, report VARCHAR NOT NULL, reported_at TIMESTAMP, last_checked_at TIMESTAMP, kafka_offset BIGINT NOT NULL DEFAULT 0, PRIMARY KEY(org_id, cluster));")
+	helpers.FailOnError(b, err)
+	_, err = conn.Exec("CREATE TABLE rule_hit (org_id INTEGER NOT NULL, cluster_id VARCHAR NOT NULL, rule_fqdn VARCHAR NOT NULL, error_key VARCHAR NOT NULL, template_data VARCHAR NOT NULL, PRIMARY KEY(cluster_id, org_id, rule_fqdn, error_key));")
+	helpers.FailOnError(b, err)
+
+	return mockStorage, conn, closer
+}
+
+func mustCleanupAfterRecommendationsBenchmark(b *testing.B, conn *sql.DB, closer func()) {
+	_, err := conn.Exec("DROP TABLE recommendation;")
+	helpers.FailOnError(b, err)
+
+	closer()
+}
+
+func mustCleanupAfterReportAndRecommendationsBenchmark(b *testing.B, conn *sql.DB, closer func()) {
+	_, err := conn.Exec("DROP TABLE recommendation;")
+	helpers.FailOnError(b, err)
+	_, err = conn.Exec("DROP TABLE report;")
+	helpers.FailOnError(b, err)
+	_, err = conn.Exec("DROP TABLE rule_hit;")
+	helpers.FailOnError(b, err)
+
+	closer()
+}
+
+// BenchmarkNewRecommendationsWithoutConflict inserts many non-conflicting
+// rows into the benchmark table using storage.WriteRecommendationsForCluster.
+func BenchmarkNewRecommendationsWithoutConflict(b *testing.B) {
+	storage, conn, closer := mustPrepareRecommendationsBenchmark(b)
+
+	clusterIDSet := newSet()
+	for i := 0; i < 1; i++ {
+		id := uuid.New().String()
+		if !clusterIDSet.contains(id) {
+			clusterIDSet.add(id)
+		}
+	}
+
+	resetTimerForBenchmark(b)
+
+	for benchIter := 0; benchIter < b.N; benchIter++ {
+		for id := range clusterIDSet.content {
+			err := storage.WriteRecommendationsForCluster(types.ClusterName(id), testdata.Report3Rules)
+			helpers.FailOnError(b, err)
+		}
+	}
+
+	stopBenchmarkTimer(b)
+	mustCleanupAfterRecommendationsBenchmark(b, conn, closer)
+}
+
+// BenchmarkNewRecommendationsExistingClusterConflict inserts 2 conflicting
+// rows into the benchmark table, forcing deletion of existing rows first
+func BenchmarkNewRecommendationsExistingClusterConflict(b *testing.B) {
+	mockStorage, conn, closer := mustPrepareRecommendationsBenchmark(b)
+
+	clusterIDSet := newSet()
+	for i := 0; i < 1; i++ {
+		id := uuid.New().String()
+		if !clusterIDSet.contains(id) {
+			clusterIDSet.add(id)
+			storage.SetClustersLastChecked(mockStorage.(*storage.DBStorage), types.ClusterName(id), time.Now())
+		}
+	}
+	clusterIds := make([]string, 2*len(clusterIDSet.content))
+	idx := 0
+	for id := range clusterIDSet.content {
+		clusterIds[idx] = id
+		idx++
+	}
+	//Now, we duplicate them
+	for id := range clusterIDSet.content {
+		clusterIds[idx] = id
+		idx++
+	}
+
+	resetTimerForBenchmark(b)
+
+	for benchIter := 0; benchIter < b.N; benchIter++ {
+		for _, id := range clusterIds {
+			err := mockStorage.WriteRecommendationsForCluster(types.ClusterName(id), testdata.Report2Rules)
+			helpers.FailOnError(b, err)
+		}
+	}
+
+	stopBenchmarkTimer(b)
+	mustCleanupAfterRecommendationsBenchmark(b, conn, closer)
+}
+
+// BenchmarkNewRecommendations2000initialEntries benchmarks the insertion of
+// 20 entries in the recommendation table which has been previously filled
+// with 2000 entries. The inserted entries do not conflict with the existing
+// ones. This allows to benchmark the WriteRecommendationsForCluster method
+// when the table already has a lot of rows.
+func BenchmarkNewRecommendations2000initialEntries(b *testing.B) {
+	mockStorage, conn, closer := mustPrepareRecommendationsBenchmarkWithEntries(b, 2000)
+
+	clusterIDSet := newSet()
+	for i := 0; i < 2; i++ {
+		id := uuid.New().String()
+		if !clusterIDSet.contains(id) {
+			clusterIDSet.add(id)
+			storage.SetClustersLastChecked(mockStorage.(*storage.DBStorage), types.ClusterName(id), time.Now())
+		}
+	}
+
+	resetTimerForBenchmark(b)
+
+	for benchIter := 0; benchIter < b.N; benchIter++ {
+		for id := range clusterIDSet.content {
+			err := mockStorage.WriteRecommendationsForCluster(types.ClusterName(id), Report20Rules)
+			helpers.FailOnError(b, err)
+		}
+	}
+
+	stopBenchmarkTimer(b)
+	mustCleanupAfterRecommendationsBenchmark(b, conn, closer)
+}
+
+// BenchmarkWriteReportAndRecommendationsNoConflict inserts reports and the
+// corresponding recommendation so we can compare insertion times
+func BenchmarkWriteReportAndRecommendationsNoConflict(b *testing.B) {
+	storage, conn, closer := mustPrepareReportAndRecommendationsBenchmark(b)
+
+	clusterIDSet := newSet()
+	for i := 0; i < 1; i++ {
+		id := uuid.New().String()
+		if !clusterIDSet.contains(id) {
+			clusterIDSet.add(id)
+		}
+	}
+
+	resetTimerForBenchmark(b)
+
+	/*
+		for benchIter := 0; benchIter < b.N; benchIter++ {
+			for id := range clusterIDSet.content {
+				err := storage.WriteReportForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report0Rules, testdata.ReportEmptyRulesParsed, time.Now(), types.KafkaOffset(0))
+				helpers.FailOnError(b, err)
+			}
+		}
+
+		b.ResetTimer()
+		b.StartTimer()
+
+		for benchIter := 0; benchIter < b.N; benchIter++ {
+			for id := range clusterIDSet.content {
+				err := storage.WriteRecommendationsForCluster(types.ClusterName(id), testdata.Report0Rules)
+				helpers.FailOnError(b, err)
+			}
+		}
+
+		b.ResetTimer()
+		b.StartTimer()*/
+
+	tStart := time.Now()
+
+	for benchIter := 0; benchIter < b.N; benchIter++ {
+		for id := range clusterIDSet.content {
+			err := storage.WriteReportForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report2Rules, testdata.Report2RulesParsed, time.Now(), types.KafkaOffset(0))
+			helpers.FailOnError(b, err)
+			err = storage.WriteRecommendationsForCluster(types.ClusterName(id), Report20Rules)
+			helpers.FailOnError(b, err)
+		}
+	}
+
+	tEnd := time.Now()
+	duration := tEnd.Sub(tStart)
+	fmt.Printf("Test Duration: %v microsecs\n", duration.Microseconds())
+	stopBenchmarkTimer(b)
+	mustCleanupAfterReportAndRecommendationsBenchmark(b, conn, closer)
+}


### PR DESCRIPTION
# Description

This is a second attempt at merging the changes for the recommendations view PoC, with an optimisation of the migration step. The only file changed is [migration/mig_0016_add_recommendations_table.go](https://github.com/RedHatInsights/insights-results-aggregator/pull/1219/files#diff-825f24ca9f5ff19de4ded3a434ceca851833887a044bb44be18056f0c74bb08f).

The [original PR](https://github.com/RedHatInsights/insights-results-aggregator/pull/1196), was reverted as it created issues in the QA environment during the database migration.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Unit tests (no changes in the code)
- Benchmarks (no changes in the code)

## Testing steps

New UTs + benchmark + some heavy local testing 

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
