### PR TITLE
Create recommendation table without REGEXP_REPLACE in sqlite

### DIFF
--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -21,6 +21,22 @@ import (
 var mig0016AddRecommendationsTable = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
 		// Create recommendation table using currently stored rule hits
+		if driver != types.DBDriverPostgres {
+			_, err := tx.Exec(`
+			CREATE TABLE recommendation
+				AS SELECT
+					cluster_id,
+					rule_fqdn,
+					error_key
+				FROM rule_hit;
+			`)
+			if err != nil {
+				return err
+			}
+			// stop here if sqLite
+			return nil
+		}
+
 		_, err := tx.Exec(`
 			CREATE TABLE recommendation
 				AS SELECT
@@ -32,11 +48,6 @@ var mig0016AddRecommendationsTable = Migration{
 
 		if err != nil {
 			return err
-		}
-
-		if driver != types.DBDriverPostgres {
-			// stop here if sqLite
-			return nil
 		}
 
 		//Add the primary_key to the new table


### PR DESCRIPTION
# Description

Integration tests step is failing due to the REGEXP_REPLACE function, which is available in real postgres database but not in sqlite.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

`make test` and `make test-postgres` are now passing

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
