### PR TITLE
Add org_id to the recommendation table

### DIFF
--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -131,6 +131,7 @@ func writeRecommendations(
 	consumer *KafkaConsumer, msg *sarama.ConsumerMessage, message incomingMessage, reportAsBytes []byte) (
 	time.Time, error) {
 	err := consumer.Storage.WriteRecommendationsForCluster(
+		*message.Organization,
 		*message.ClusterName,
 		types.ClusterReport(reportAsBytes),
 	)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -154,7 +154,7 @@ func TestWrittenRecommendationsMetricCorrectUpdate(t *testing.T) {
 	initialDeletes := testutil.CollectAndCount(metrics.SQLRecommendationsDeletes)
 	initialInserts := testutil.CollectAndCount(metrics.SQLRecommendationsInserts)
 
-	err := mockStorage.WriteRecommendationsForCluster(testdata.ClusterName, testdata.Report3Rules)
+	err := mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report3Rules)
 	helpers.FailOnError(t, err)
 
 	//We expect one new metric in each histogramVect, one for deleted rows and one for inserted rows

--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -25,7 +25,7 @@ var mig0016AddRecommendationsTable = Migration{
 			_, err := tx.Exec(`
 			CREATE TABLE recommendation
 				AS SELECT
-				        org_id,
+					org_id,
 					cluster_id,
 					rule_fqdn,
 					error_key

--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -25,6 +25,7 @@ var mig0016AddRecommendationsTable = Migration{
 			_, err := tx.Exec(`
 			CREATE TABLE recommendation
 				AS SELECT
+				        org_id,
 					cluster_id,
 					rule_fqdn,
 					error_key
@@ -40,6 +41,7 @@ var mig0016AddRecommendationsTable = Migration{
 		_, err := tx.Exec(`
 			CREATE TABLE recommendation
 				AS SELECT
+					org_id,
 					cluster_id,
 					REGEXP_REPLACE(rule_fqdn, 'report$', error_key) AS rule_fqdn,
 					error_key

--- a/storage/consts.go
+++ b/storage/consts.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+const (
+	// key for organization ID used in structured log messages
+	organizationKey = "organization"
+	// key for cluster ID used in structured log messages
+	clusterKey = "cluster"
+	// Key for number of issues found for a cluster
+	issuesCountKey = "issues found"
+	// key for recommendations selectors used in structured log messages
+	selectorsKey = "selectors"
+)

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -56,12 +56,12 @@ func SetClustersLastChecked(storage *DBStorage, cluster types.ClusterName, lastC
 	storage.clustersLastChecked[cluster] = lastChecked
 }
 
-func InsertRecommendations(storage *DBStorage, clusterName types.ClusterName, report types.ReportRules) error {
+func InsertRecommendations(storage *DBStorage, orgID types.OrgID, clusterName types.ClusterName, report types.ReportRules) error {
 	tx, err := storage.connection.Begin()
 	if err != nil {
 		return err
 	}
-	_, err = storage.insertRecommendations(tx, clusterName, report)
+	_, err = storage.insertRecommendations(tx, orgID, clusterName, report)
 	if err != nil {
 		_ = tx.Rollback()
 		return err

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -77,7 +77,7 @@ func (*NoopStorage) WriteReportForCluster(
 
 // WriteRecommendationsForCluster noop
 func (*NoopStorage) WriteRecommendationsForCluster(
-	types.ClusterName, types.ClusterReport,
+	types.OrgID, types.ClusterName, types.ClusterReport,
 ) error {
 	return nil
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1014,6 +1014,7 @@ func TestDBStorageWriteRecommendationsForClusterClosedStorage(t *testing.T) {
 	// we need to close storage right now
 	closer()
 	err := mockStorage.WriteRecommendationsForCluster(
+		testdata.OrgID,
 		testdata.ClusterName,
 		testdata.ClusterReportEmpty,
 	)
@@ -1024,6 +1025,7 @@ func TestDBStorageWriteRecommendationsForClusterClosedStorage(t *testing.T) {
 func TestDBStorageWriteRecommendationForClusterUnsupportedDriverError(t *testing.T) {
 	fakeStorage := storage.NewFromConnection(nil, -1)
 	err := fakeStorage.WriteRecommendationsForCluster(
+		testdata.OrgID,
 		testdata.ClusterName,
 		testdata.ClusterReportEmpty,
 	)
@@ -1045,7 +1047,7 @@ func TestDBStorageWriteRecommendationForClusterNoConflict(t *testing.T) {
 	expects.ExpectCommit()
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.ClusterName, testdata.Report3Rules,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 	)
 
 	helpers.FailOnError(t, err)
@@ -1059,8 +1061,8 @@ func TestDBStorageInsertRecommendations(t *testing.T) {
 
 	expects.ExpectBegin()
 
-	expects.ExpectExec("INSERT INTO recommendation \\(cluster_id, rule_fqdn, error_key\\) " +
-		"VALUES \\(\\$1, \\$2, \\$3\\),\\(\\$4, \\$5, \\$6\\),\\(\\$7, \\$8, \\$9\\)").
+	expects.ExpectExec("INSERT INTO recommendation \\(org_id, cluster_id, rule_fqdn, error_key\\) " +
+		"VALUES \\(\\$1, \\$2, \\$3\\, \\$4\\),\\(\\$5, \\$6, \\$7\\, \\$8\\),\\(\\$9, \\$10, \\$11\\, \\$12\\)").
 		WillReturnResult(driver.ResultNoRows)
 
 	expects.ExpectCommit()
@@ -1071,7 +1073,7 @@ func TestDBStorageInsertRecommendations(t *testing.T) {
 		PassedRules:  testdata.RuleOnReportResponses,
 		TotalCount:   3 * len(testdata.RuleOnReportResponses),
 	}
-	err := storage.InsertRecommendations(mockStorage.(*storage.DBStorage), testdata.ClusterName, report)
+	err := storage.InsertRecommendations(mockStorage.(*storage.DBStorage), testdata.OrgID, testdata.ClusterName, report)
 
 	helpers.FailOnError(t, err)
 }
@@ -1089,7 +1091,7 @@ func TestDBStorageWriteRecommendationForClusterAlreadyStored(t *testing.T) {
 	expects.ExpectCommit()
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.ClusterName, testdata.Report3Rules,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1099,7 +1101,7 @@ func TestDBStorageWriteRecommendationForClusterAlreadyStored(t *testing.T) {
 	expects.ExpectRollback()
 
 	err = mockStorage.WriteRecommendationsForCluster(
-		testdata.ClusterName, testdata.Report3Rules,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 	)
 
 	assert.Error(t, err, "")
@@ -1119,7 +1121,7 @@ func TestDBStorageWriteRecommendationForClusterAlreadyStoredAndDeleted(t *testin
 	expects.ExpectCommit()
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.ClusterName, testdata.Report3Rules,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 	)
 
 	helpers.FailOnError(t, err)
@@ -1136,7 +1138,7 @@ func TestDBStorageWriteRecommendationForClusterAlreadyStoredAndDeleted(t *testin
 	expects.ExpectCommit()
 
 	err = mockStorage.WriteRecommendationsForCluster(
-		testdata.ClusterName, testdata.Report3Rules,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 	)
 
 	helpers.FailOnError(t, err)

--- a/storage/storage_write_recommendations_benchmark_test.go
+++ b/storage/storage_write_recommendations_benchmark_test.go
@@ -309,7 +309,7 @@ func mustPrepareRecommendationsBenchmark(b *testing.B) (storage.Storage, *sql.DB
 	_, err := conn.Exec("DROP TABLE IF EXISTS recommendation;")
 	helpers.FailOnError(b, err)
 
-	_, err = conn.Exec("CREATE TABLE recommendation (cluster_id VARCHAR NOT NULL, rule_fqdn VARCHAR NOT NULL, error_key VARCHAR NOT NULL, PRIMARY KEY(cluster_id, rule_fqdn, error_key));")
+	_, err = conn.Exec("CREATE TABLE recommendation (org_id INTEGER NOT NULL, cluster_id VARCHAR NOT NULL, rule_fqdn VARCHAR NOT NULL, error_key VARCHAR NOT NULL, PRIMARY KEY(cluster_id, rule_fqdn, error_key));")
 	helpers.FailOnError(b, err)
 
 	return mockStorage, conn, closer
@@ -350,7 +350,7 @@ func mustPrepareReportAndRecommendationsBenchmark(b *testing.B) (storage.Storage
 	_, err = conn.Exec("DROP TABLE IF EXISTS rule_hit;")
 	helpers.FailOnError(b, err)
 
-	_, err = conn.Exec("CREATE TABLE recommendation (cluster_id VARCHAR NOT NULL, rule_fqdn VARCHAR NOT NULL, error_key VARCHAR NOT NULL, PRIMARY KEY(cluster_id, rule_fqdn, error_key));")
+	_, err = conn.Exec("CREATE TABLE recommendation (org_id INTEGER NOT NULL, cluster_id VARCHAR NOT NULL, rule_fqdn VARCHAR NOT NULL, error_key VARCHAR NOT NULL, PRIMARY KEY(cluster_id, rule_fqdn, error_key));")
 	helpers.FailOnError(b, err)
 	_, err = conn.Exec("CREATE TABLE report (org_id INTEGER NOT NULL, cluster VARCHAR NOT NULL UNIQUE, report VARCHAR NOT NULL, reported_at TIMESTAMP, last_checked_at TIMESTAMP, kafka_offset BIGINT NOT NULL DEFAULT 0, PRIMARY KEY(org_id, cluster));")
 	helpers.FailOnError(b, err)
@@ -395,7 +395,7 @@ func BenchmarkNewRecommendationsWithoutConflict(b *testing.B) {
 
 	for benchIter := 0; benchIter < b.N; benchIter++ {
 		for id := range clusterIDSet.content {
-			err := storage.WriteRecommendationsForCluster(types.ClusterName(id), testdata.Report3Rules)
+			err := storage.WriteRecommendationsForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report3Rules)
 			helpers.FailOnError(b, err)
 		}
 	}
@@ -433,7 +433,7 @@ func BenchmarkNewRecommendationsExistingClusterConflict(b *testing.B) {
 
 	for benchIter := 0; benchIter < b.N; benchIter++ {
 		for _, id := range clusterIds {
-			err := mockStorage.WriteRecommendationsForCluster(types.ClusterName(id), testdata.Report2Rules)
+			err := mockStorage.WriteRecommendationsForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report2Rules)
 			helpers.FailOnError(b, err)
 		}
 	}
@@ -463,7 +463,7 @@ func BenchmarkNewRecommendations2000initialEntries(b *testing.B) {
 
 	for benchIter := 0; benchIter < b.N; benchIter++ {
 		for id := range clusterIDSet.content {
-			err := mockStorage.WriteRecommendationsForCluster(types.ClusterName(id), Report20Rules)
+			err := mockStorage.WriteRecommendationsForCluster(types.OrgID(1), types.ClusterName(id), Report20Rules)
 			helpers.FailOnError(b, err)
 		}
 	}
@@ -514,7 +514,7 @@ func BenchmarkWriteReportAndRecommendationsNoConflict(b *testing.B) {
 		for id := range clusterIDSet.content {
 			err := storage.WriteReportForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report2Rules, testdata.Report2RulesParsed, time.Now(), types.KafkaOffset(0))
 			helpers.FailOnError(b, err)
-			err = storage.WriteRecommendationsForCluster(types.ClusterName(id), Report20Rules)
+			err = storage.WriteRecommendationsForCluster(types.OrgID(1), types.ClusterName(id), Report20Rules)
 			helpers.FailOnError(b, err)
 		}
 	}


### PR DESCRIPTION
# Description

Recommendation table is now created with the following columns: organisation ID, cluster ID, rule FQDN and error key.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

- tested locally with `./insights-results-aggregator migration 15` to downgrade DB version and `./insights-results-aggregator migration 16` to test this migration
- `make test`, `make test-postures` and `make integration_tests` pass
- 
## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
