### PR TITLE
properly return disable feedback for disabled rules

### DIFF
--- a/bonfire-config-devel.yaml
+++ b/bonfire-config-devel.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Bonfire deployment configuration
 # Defines where to fetch the file that defines application configs
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
-	github.com/RedHatInsights/insights-operator-utils v1.10.0
-	github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023
+	github.com/RedHatInsights/insights-operator-utils v1.12.0
+	github.com/RedHatInsights/insights-results-aggregator-data v1.1.0
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/RedHatInsights/insights-operator-utils v1.8.2/go.mod h1:L6alrkNSM+uBz
 github.com/RedHatInsights/insights-operator-utils v1.8.3/go.mod h1:L6alrkNSM+uBzlQdIihhGnwTpdw+bD8i8Fdh/OE9rdo=
 github.com/RedHatInsights/insights-operator-utils v1.10.0 h1:AqbWfO4Hx/Mu8+taqwEXfuGV3JIvDAzD7ZX0S52DgEo=
 github.com/RedHatInsights/insights-operator-utils v1.10.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.12.0 h1:cQVdkkRRlQ23QVGFgXLNpvv/FcnH3ZB2tKszNQ6iL0c=
+github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
@@ -50,6 +52,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
 github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023 h1:Ot6Rk8utrv02RMVTrGU/+QLSp+m5341pvq8auwlbDls=
 github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023/go.mod h1:SDeBuNY8AIwkD4JB5/I54ArWG7qngP5/Ydn7xbu2iZo=
+github.com/RedHatInsights/insights-results-aggregator-data v1.1.0 h1:Xl6e52pP1C8KDxBiotS4pBfVcjtdil+NgpmFUlik0Fk=
+github.com/RedHatInsights/insights-results-aggregator-data v1.1.0/go.mod h1:rbiccYJ8whbpLLvNGMiaFzyMPs1A/2/Jh0P2U9DXF+4=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/server/rules.go
+++ b/server/rules.go
@@ -163,13 +163,21 @@ func (server HTTPServer) getFeedbackAndTogglesOnRule(
 		rule.DisabledAt = types.Timestamp(ruleToggle.DisabledAt.Time.UTC().Format(time.RFC3339))
 	}
 
-	feedback, err := server.Storage.GetUserFeedbackOnRule(clusterName, rule.Module, rule.ErrorKey, userID)
+	disableFeedback, err := server.Storage.GetUserFeedbackOnRuleDisable(clusterName, rule.Module, rule.ErrorKey, userID)
 	if err != nil {
 		log.Error().Err(err).Msg("Feedback for rule was not found")
+		rule.DisableFeedback = ""
+	} else {
+		log.Info().Msgf("feedback Message: '%v'", disableFeedback.Message)
+		rule.DisableFeedback = disableFeedback.Message
+	}
+
+	userVote, err := server.Storage.GetUserFeedbackOnRule(clusterName, rule.Module, rule.ErrorKey, userID)
+	if err != nil {
+		log.Error().Err(err).Msg("User vote for rule was not found")
 		rule.UserVote = types.UserVoteNone
 	} else {
-		rule.UserVote = feedback.UserVote
-		rule.DisableFeedback = feedback.Message
+		rule.UserVote = userVote.UserVote
 	}
 
 	return rule

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -711,7 +711,7 @@ func TestHTTPServer_SaveDisableFeedback(t *testing.T) {
 		Body:       `{"message":"user's feedback", "status":"ok"}`,
 	})
 
-	feedback, err := mockStorage.GetUserFeedbackOnRuleDisable(testdata.ClusterName, testdata.Rule1ID, testdata.UserID)
+	feedback, err := mockStorage.GetUserFeedbackOnRuleDisable(testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID)
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, expectedFeedback, feedback.Message)

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -108,7 +108,7 @@ func (*NoopStorage) AddFeedbackOnRuleDisable(
 
 // GetUserFeedbackOnRuleDisable noop
 func (*NoopStorage) GetUserFeedbackOnRuleDisable(
-	types.ClusterName, types.RuleID, types.UserID,
+	types.ClusterName, types.RuleID, types.ErrorKey, types.UserID,
 ) (*UserFeedbackOnRule, error) {
 	return nil, nil
 }

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -39,7 +39,7 @@ func TestNoopStorage_Methods(t *testing.T) {
 	_ = noopStorage.VoteOnRule("", "", "", "", 0, "")
 	_ = noopStorage.AddOrUpdateFeedbackOnRule("", "", "", "", "")
 	_ = noopStorage.AddFeedbackOnRuleDisable("", "", "", "", "")
-	_, _ = noopStorage.GetUserFeedbackOnRuleDisable("", "", "")
+	_, _ = noopStorage.GetUserFeedbackOnRuleDisable("", "", "", "")
 	_, _ = noopStorage.GetUserFeedbackOnRule("", "", "", "")
 	_ = noopStorage.DeleteReportsForOrg(0)
 	_ = noopStorage.DeleteReportsForCluster("")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -109,7 +109,10 @@ type Storage interface {
 		userID types.UserID,
 	) (*UserFeedbackOnRule, error)
 	GetUserFeedbackOnRuleDisable(
-		clusterID types.ClusterName, ruleID types.RuleID, userID types.UserID,
+		clusterID types.ClusterName,
+		ruleID types.RuleID,
+		errorKey types.ErrorKey,
+		userID types.UserID,
 	) (*UserFeedbackOnRule, error)
 	DeleteReportsForOrg(orgID types.OrgID) error
 	DeleteReportsForCluster(clusterName types.ClusterName) error

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -533,7 +533,7 @@ func TestDBStorageTextDisableFeedback(t *testing.T) {
 	))
 
 	feedback, err := mockStorage.GetUserFeedbackOnRuleDisable(
-		testdata.ClusterName, testdata.Rule1ID, testdata.UserID,
+		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID,
 	)
 	helpers.FailOnError(t, err)
 
@@ -560,7 +560,7 @@ func TestDBStorageDisableFeedbackChangeMessage(t *testing.T) {
 	))
 
 	feedback, err := mockStorage.GetUserFeedbackOnRuleDisable(
-		testdata.ClusterName, testdata.Rule1ID, testdata.UserID,
+		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID,
 	)
 	helpers.FailOnError(t, err)
 
@@ -576,7 +576,7 @@ func TestDBStorageDisableFeedbackErrorItemNotFound(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	_, err := mockStorage.GetUserFeedbackOnRuleDisable(testdata.ClusterName, testdata.Rule1ID, testdata.UserID)
+	_, err := mockStorage.GetUserFeedbackOnRuleDisable(testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID)
 	if _, ok := err.(*types.ItemNotFoundError); err == nil || !ok {
 		t.Fatalf("expected ItemNotFoundError, got %T, %+v", err, err)
 	}
@@ -586,6 +586,6 @@ func TestDBStorageDisableFeedbackErrorDBError(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
 	closer()
 
-	_, err := mockStorage.GetUserFeedbackOnRuleDisable(testdata.ClusterName, testdata.Rule1ID, testdata.UserID)
+	_, err := mockStorage.GetUserFeedbackOnRuleDisable(testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID)
 	assert.EqualError(t, err, "sql: database is closed")
 }


### PR DESCRIPTION
# Description
A couple of retrieving functions were missed in one of the merge requests adding error keys to tables. It wasn't caught during reviews or by unit tests (the functions werent modified, so it passed OK). 

This adds the error key to the retrieval of the disabled feedback too.

Fixes 5290

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
