### PR TITLE
Add org ID to recommendation table's composite key

### DIFF
--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -56,7 +56,7 @@ var mig0016AddRecommendationsTable = Migration{
 		_, err = tx.Exec(`
 			ALTER TABLE recommendation
 				ADD CONSTRAINT recommendation_pk
-					PRIMARY KEY (cluster_id, rule_fqdn, error_key);`)
+					PRIMARY KEY (org_id, cluster_id, rule_fqdn, error_key);`)
 		return err
 	},
 	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {


### PR DESCRIPTION
# Description

In production environment, the current primary key cannot be created as there might be some old duplicated cluster IDs. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Local test

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
