### PR TITLE
 Ability to retrieve and return list of disabled rules for given account

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1107,6 +1107,68 @@
         ]
       }
     },
+    "rules/{userId}/disabled": {
+      "get": {
+        "summary": "Returns a list of rules disabled from current account",
+        "operationId": "ListOfDisabledRules",
+        "description": "Returns a list of rules disabled from current account",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "description": "Numeric ID of the user. An example: `42`",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of disabled rules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "report": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "component": {
+                                "type": "string",
+                                "description": "The rule identifier for the hit rule.",
+                                "example": "some.python.module"
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "The erroy key triggered for this rule in the cluster.",
+                                "example": "SOME_ERROR_KEY"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "prod"
+        ]
+      }
+    },
     "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/{userId}/enable": {
       "put": {
         "summary": "Re-enables a rule/health check recommendation for specified cluster",

--- a/openapi.json
+++ b/openapi.json
@@ -1107,7 +1107,7 @@
         ]
       }
     },
-    "rules/{userId}/disabled": {
+    "/rules/{userId}/disabled": {
       "get": {
         "summary": "Returns a list of rules disabled from current account",
         "operationId": "ListOfDisabledRules",

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2020, 2021  Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,6 +59,8 @@ const (
 	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/{user_id}/enable"
 	// DisableRuleFeedbackEndpoint accepts a feedback from user when (s)he disables a rule
 	DisableRuleFeedbackEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disable_feedback"
+	// ListOfDisabledRules returns a list of rules disabled from current account
+	ListOfDisabledRules = "rules/{user_id}/disabled"
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"
 )
@@ -97,6 +99,7 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	router.HandleFunc(apiPrefix+DisableRuleFeedbackEndpoint, server.saveDisableFeedback).Methods(http.MethodPost)
 	router.HandleFunc(apiPrefix+ReportForListOfClustersEndpoint, server.reportForListOfClusters).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+ReportForListOfClustersPayloadEndpoint, server.reportForListOfClustersPayload).Methods(http.MethodPost)
+	router.HandleFunc(apiPrefix+ListOfDisabledRules, server.listOfDisabledRules).Methods(http.MethodGet)
 
 	// Prometheus metrics
 	router.Handle(apiPrefix+MetricsEndpoint, promhttp.Handler()).Methods(http.MethodGet)

--- a/server/rules.go
+++ b/server/rules.go
@@ -68,6 +68,35 @@ func (server *HTTPServer) toggleRuleForCluster(writer http.ResponseWriter, reque
 	}
 }
 
+// listOfDisabledRules returns list of rules disabled from an account
+func (server HTTPServer) listOfDisabledRules(writer http.ResponseWriter, request *http.Request) {
+	log.Info().Msg("Lisf of disabled rules")
+
+	// retrieve account (user) ID
+	userID, succesful := readUserID(writer, request)
+	if !succesful {
+		// everything has been handled already
+		return
+	}
+	log.Info().Str("account", string(userID)).Msg("disabled rules for account")
+
+	// try to read list of disabled rules by an account/user from database
+	disabledRules, err := server.Storage.ListOfDisabledRules(userID)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to read list of disabled rules")
+		handleServerError(writer, err)
+		return
+	}
+	log.Info().Int("disabled rules", len(disabledRules)).Msg("list of disabled rules")
+
+	// try to send JSON payload to the client in a HTTP response
+	err = responses.SendOK(writer,
+		responses.BuildOkResponseWithData("rules", disabledRules))
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}
+
 // getFeedbackAndTogglesOnRules
 func (server HTTPServer) getFeedbackAndTogglesOnRules(
 	clusterName types.ClusterName,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -801,3 +801,17 @@ func TestHTTPServer_SaveDisableFeedback_Error_DBError(t *testing.T) {
 		Body:       `{"status": "Internal Server Error"}`,
 	})
 }
+
+func TestListDisabledRules(t *testing.T) {
+	mockStorage, closer := helpers.MustGetMockStorage(t, true)
+	defer closer()
+
+	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     server.ListOfDisabledRules,
+		EndpointArgs: []interface{}{testdata.UserID},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Body:       `{"rules":[],"status":"ok"}`,
+	})
+}

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -237,3 +237,9 @@ func (*NoopStorage) ReadOrgIDsForClusters(clusterNames []types.ClusterName) ([]t
 func (*NoopStorage) ReadReportsForClusters(clusterNames []types.ClusterName) (map[types.ClusterName]types.ClusterReport, error) {
 	return nil, nil
 }
+
+// ListOfDisabledRules function returns list of all rules disabled from a
+// specified account (noop).
+func (*NoopStorage) ListOfDisabledRules(userID types.UserID) ([]DisabledRule, error) {
+	return nil, nil
+}

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
+// Don't decrease code coverage by non-functional and not covered code.
+
 func TestNoopStorage_Methods(t *testing.T) {
 	noopStorage := storage.NoopStorage{}
 
@@ -67,4 +69,6 @@ func TestNoopStorage_Methods_Cont(t *testing.T) {
 	_, _ = noopStorage.ReadSingleRuleTemplateData(0, "", "", "")
 	_, _ = noopStorage.GetUserDisableFeedbackOnRules("", []types.RuleOnReport{}, "")
 	_, _ = noopStorage.DoesClusterExist("")
+	_, _ = noopStorage.ListOfDisabledRules("")
+	_ = noopStorage.WriteRecommendationsForCluster(0, "", "")
 }

--- a/storage/rule_list.go
+++ b/storage/rule_list.go
@@ -1,0 +1,81 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"database/sql"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+// DisabledRule represents a record from rule_cluster_toggle
+type DisabledRule struct {
+	ClusterID  types.ClusterName
+	RuleID     types.RuleID
+	ErrorKey   types.ErrorKey
+	Disabled   RuleToggle
+	DisabledAt sql.NullTime
+	EnabledAt  sql.NullTime
+	UpdatedAt  sql.NullTime
+}
+
+// ListOfDisabledRules function returns list of all rules disabled from a
+// specified account.
+func (storage DBStorage) ListOfDisabledRules(userID types.UserID) ([]DisabledRule, error) {
+	disabledRules := make([]DisabledRule, 0)
+	query := `SELECT
+                         cluster_id,
+			 rule_id,
+			 error_key,
+			 disabled_at,
+			 updated_at
+	FROM
+		cluster_rule_toggle
+	WHERE
+		user_id = $1 and
+		disabled = $2
+	`
+
+	// run the query against database
+	rows, err := storage.connection.Query(query, userID, RuleToggleDisable)
+
+	// return empty list in case of any error
+	if err != nil {
+		return nil, err
+	}
+	defer closeRows(rows)
+
+	for rows.Next() {
+		var disabledRule DisabledRule
+
+		err = rows.Scan(&disabledRule.ClusterID,
+			&disabledRule.RuleID,
+			&disabledRule.ErrorKey,
+			&disabledRule.DisabledAt,
+			&disabledRule.UpdatedAt)
+
+		if err != nil {
+			log.Error().Err(err).Msg("ReadListOfDisabledRules")
+			return nil, err
+		}
+
+		// append disabled rule read from database to a slice
+		disabledRules = append(disabledRules, disabledRule)
+	}
+
+	return disabledRules, nil
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -148,6 +148,7 @@ type Storage interface {
 		userID types.UserID,
 	) (map[types.RuleID]UserFeedbackOnRule, error)
 	DoesClusterExist(clusterID types.ClusterName) (bool, error)
+	ListOfDisabledRules(userID types.UserID) ([]DisabledRule, error)
 }
 
 // DBStorage is an implementation of Storage interface that use selected SQL like database

--- a/tests/rest/rest.go
+++ b/tests/rest/rest.go
@@ -40,6 +40,7 @@ func ServerTests() {
 	MultipleReportsTests()
 	MultipleReportsTestsUsingPostMethod()
 	VoteTests()
+	DisableRuleTests()
 
 	// tests for OpenAPI specification that is accessible via its endpoint as well
 	// implementation of these tests is stored in openapi.go
@@ -164,4 +165,10 @@ func VoteTests() {
 	checkGetUserVoteAfterUnvote()
 	checkGetUserVoteAfterDoubleVote()
 	checkGetUserVoteAfterDoubleUnvote()
+}
+
+// DisableRuleTests impements tests for REST API endpoinds for disabling etc.
+// rules
+func DisableRuleTests() {
+	checkListOfDisabledRules()
 }

--- a/tests/rest/rule_vote.go
+++ b/tests/rest/rule_vote.go
@@ -377,3 +377,26 @@ func checkGetUserVoteAfterDoubleUnvote() {
 	resetVoteForRule(cluster, rule, errorKey)
 	checkVoteForClusterAndRule(cluster, rule, errorKey, 0)
 }
+
+func checkListOfDisabledRules() {
+	url := httputils.MakeURLToEndpoint(apiURL, server.ListOfDisabledRules, testdata.UserID)
+
+	f := frisby.Create("Read list of disabled rules").Get(url)
+	r := RuleVoteResponse{}
+	setAuthHeader(f)
+	f.Send()
+	f.ExpectStatus(200)
+
+	text, err := f.Resp.Content()
+	if err != nil {
+		f.AddError(err.Error())
+		return
+	}
+
+	err = json.Unmarshal(text, &r)
+	if err != nil {
+		f.AddError(err.Error())
+		return
+	}
+
+}


### PR DESCRIPTION
# Description

Ability to retrieve and return list of disabled rules for given account

Fixes #1247

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Unit tests (no changes in the code)
- REST API tests
- Documentation update

## Testing steps

Can be tested locally by using `curl`:

```
curl localhost:8080/api/v1/rules/1/disabled 
```

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
