### PR TITLE
Bump-up utils to 1.16.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
-	github.com/RedHatInsights/insights-operator-utils v1.15.0
+	github.com/RedHatInsights/insights-operator-utils v1.16.0
 	github.com/RedHatInsights/insights-results-aggregator-data v1.1.0
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1


### PR DESCRIPTION
# Description

Bump-up `utils` to 1.16.0 in `go.mod`

Fixes #1272 

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
