### PR TITLE
Bumped-up `utils` to 1.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
-	github.com/RedHatInsights/insights-operator-utils v1.16.0
+	github.com/RedHatInsights/insights-operator-utils v1.17.0
 	github.com/RedHatInsights/insights-results-aggregator-data v1.1.0
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,9 @@ github.com/RedHatInsights/insights-operator-utils v1.14.0 h1:bROfP6PaOnxuFBiYDVs
 github.com/RedHatInsights/insights-operator-utils v1.14.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.15.0 h1:EQr79jONoR+x32eltxFN+tTHy52lXDrcoyNgvpyz9KI=
 github.com/RedHatInsights/insights-operator-utils v1.15.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.16.0 h1:viE9oEDX40JkkRwaO75u2h8R67+kNi9I7CnpfgZNr/0=
+github.com/RedHatInsights/insights-operator-utils v1.16.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.17.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=


### PR DESCRIPTION
# Description

Bumped-up `utils` to 1.17.0

Fixes #1276

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Done on CI side.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
