### PR TITLE
Fix recommendations insertion if no rule hit in report

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -715,11 +715,20 @@ func (storage DBStorage) insertRecommendations(
 	clusterName types.ClusterName,
 	report types.ReportRules,
 ) (inserted int, err error) {
+	if len(report.HitRules) == 0 {
+		log.Info().
+			Int(organizationKey, int(orgID)).
+			Str(clusterKey, string(clusterName)).
+			Msg("No new recommendations to insert.")
+		return 0, nil
+	}
+
 	statement := `INSERT INTO recommendation (org_id, cluster_id, rule_fqdn, error_key) VALUES %s`
 
 	var valuesIdx []string
 	var valuesArg []interface{}
 	inserted = 0
+
 	selectors := make([]string, len(report.HitRules))
 
 	for idx, rule := range report.HitRules {


### PR DESCRIPTION
# Description

When rule hits are empty, it does not make sense to try to insert new records in the recommendation table.

Fixes # 1274 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
