### PR TITLE
Modify recommendation table

### DIFF
--- a/docs/db_structure.md
+++ b/docs/db_structure.md
@@ -20,7 +20,7 @@ for more details about tables, indexes, and keys.
 ## List of tables
 
 ```
- Schema |                Name                | Type 
+ Schema |                Name                | Type
 --------+------------------------------------+------
  public | cluster_rule_toggle                | table
  public | cluster_rule_user_feedback         | table
@@ -144,6 +144,8 @@ CREATE TABLE recommendations (
     cluster_id  VARCHAR NOT NULL,
     rule_fqdn   VARCHAR NOT NULL,
     error_key   VARCHAR NOT NULL,
+    rule_id     VARCHAR NOT NULL,
+    created_at  TIMESTAMP WITHOUT TIME ZONE,
 
     PRIMARY KEY(org_id, cluster_id, rule_fqdn, error_key)
 )

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Shopify/sarama/mocks"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	prommodels "github.com/prometheus/client_model/go"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -142,27 +141,6 @@ func TestWrittenReportsMetric(t *testing.T) {
 
 	assertCounterValue(t, 100, metrics.WrittenReports, initValue)
 }
-
-// TestWrittenRecommendationsMetricCorrectUpdate verifies that every time
-// WriteRecommendationsForCluster is called, two entries are added to the
-// metrics.SQLRecommendationsUpdates HistogramVect. One entry for number
-// of deleted rows, and one for number of inserted rows.
-func TestWrittenRecommendationsMetricCorrectUpdate(t *testing.T) {
-	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
-	defer closer()
-
-	initialDeletes := testutil.CollectAndCount(metrics.SQLRecommendationsDeletes)
-	initialInserts := testutil.CollectAndCount(metrics.SQLRecommendationsInserts)
-
-	err := mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report3Rules)
-	helpers.FailOnError(t, err)
-
-	//We expect one new metric in each histogramVect, one for deleted rows and one for inserted rows
-	assert.Equal(t, 1, testutil.CollectAndCount(metrics.SQLRecommendationsDeletes)-initialDeletes)
-	assert.Equal(t, 1, testutil.CollectAndCount(metrics.SQLRecommendationsInserts)-initialInserts)
-}
-
-// TODO: More tests for recommendations metrics, but in another PR
 
 // TODO: write tests for sql queries metrics
 // - SQLQueriesCounter

--- a/migration/actual_migrations_test.go
+++ b/migration/actual_migrations_test.go
@@ -419,7 +419,7 @@ func TestMigration19(t *testing.T) {
 	err := migration.SetDBVersion(db, dbDriver, 18)
 	helpers.FailOnError(t, err)
 
-	correctRuleFQDN := testdata.Rule1ID + "|" + testdata.ErrorKey1
+	correctRuleID := testdata.Rule1ID + "|" + testdata.ErrorKey1
 	incorrectRuleFQDN := testdata.Rule1ID + "." + testdata.ErrorKey1
 
 	expectedRuleAfterMigration := string(testdata.Rule1ID)
@@ -441,7 +441,7 @@ func TestMigration19(t *testing.T) {
 		`,
 		testdata.Org2ID,
 		testdata.ClusterName,
-		correctRuleFQDN,
+		correctRuleID,
 		testdata.ErrorKey1,
 	)
 	helpers.FailOnError(t, err)
@@ -449,36 +449,40 @@ func TestMigration19(t *testing.T) {
 	err = migration.SetDBVersion(db, dbDriver, 19)
 	helpers.FailOnError(t, err)
 
-	var ruleFQDN string
+	var (
+		ruleFQDN string
+		ruleID   string
+	)
 
 	err = db.QueryRow(`
 			SELECT
-				rule_fqdn
+				rule_fqdn, rule_id
 			FROM
 				recommendation
 			WHERE
 			    org_id = $1`,
 		testdata.OrgID,
 	).Scan(
-		&ruleFQDN,
+		&ruleFQDN, &ruleID,
 	)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, expectedRuleAfterMigration, ruleFQDN)
+	assert.Equal(t, string(correctRuleID), ruleID)
 
 	err = db.QueryRow(`
 			SELECT
-				rule_fqdn
+				rule_fqdn, rule_id
 			FROM
 				recommendation
 			WHERE
 			    org_id = $1`,
 		testdata.Org2ID,
 	).Scan(
-		&ruleFQDN,
+		&ruleFQDN, &ruleID,
 	)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, expectedRuleAfterMigration, ruleFQDN)
-
+	assert.Equal(t, string(correctRuleID), ruleID)
 	var timestamp time.Time
 
 	err = db.QueryRow(`

--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -38,13 +38,14 @@ var mig0016AddRecommendationsTable = Migration{
 			return nil
 		}
 
+		// Create recommendation table using records from rule_hit table
 		_, err := tx.Exec(`
 			CREATE TABLE recommendation
 				AS SELECT
 					org_id,
 					cluster_id,
-					REGEXP_REPLACE(rule_fqdn, '.report$', CONCAT('|', error_key)) AS rule_fqdn,
-					error_key,
+					REGEXP_REPLACE(rule_fqdn, '.report$', '') AS rule_fqdn,
+					error_key
 				FROM rule_hit;
 		`)
 

--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -31,11 +31,9 @@ var mig0016AddRecommendationsTable = Migration{
 					error_key
 				FROM rule_hit;
 			`)
-			if err != nil {
-				return err
-			}
-			// stop here if sqLite
-			return nil
+
+			// stop here if not working with postgres
+			return err
 		}
 
 		// Create recommendation table using records from rule_hit table
@@ -62,7 +60,7 @@ var mig0016AddRecommendationsTable = Migration{
 	},
 	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
 		_, err := tx.Exec(`
-			DROP TABLE recommendation
+			DROP TABLE recommendation;
 		`)
 		return err
 	},

--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -42,7 +42,7 @@ var mig0016AddRecommendationsTable = Migration{
 				AS SELECT
 					org_id,
 					cluster_id,
-					REGEXP_REPLACE(rule_fqdn, '.report$', '') AS rule_fqdn,
+					REGEXP_REPLACE(rule_fqdn, 'report$', error_key) AS rule_fqdn,
 					error_key
 				FROM rule_hit;
 		`)

--- a/migration/mig_0016_add_recommendations_table.go
+++ b/migration/mig_0016_add_recommendations_table.go
@@ -41,7 +41,11 @@ var mig0016AddRecommendationsTable = Migration{
 		_, err := tx.Exec(`
 			CREATE TABLE recommendation
 				AS SELECT
-					org_id, cluster_id, REGEXP_REPLACE(rule_fqdn, '.report$', CONCAT('|', error_key)) AS rule_fqdn, error_key, FROM rule_hit;
+					org_id,
+					cluster_id,
+					REGEXP_REPLACE(rule_fqdn, '.report$', CONCAT('|', error_key)) AS rule_fqdn,
+					error_key,
+				FROM rule_hit;
 		`)
 
 		if err != nil {

--- a/migration/mig_0017_add_system_wide_rule_disable_table.go
+++ b/migration/mig_0017_add_system_wide_rule_disable_table.go
@@ -21,7 +21,7 @@ import (
 
 var mig0017AddSystemWideRuleDisableTable = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
-		// Create recommendation table using currently stored rule hits
+		// Create rule_disable table
 		_, err := tx.Exec(`
                     CREATE TABLE rule_disable (
                         org_id        VARCHAR NOT NULL,

--- a/migration/mig_0018_add_ratings_table.go
+++ b/migration/mig_0018_add_ratings_table.go
@@ -21,7 +21,7 @@ import (
 
 var mig0018AddRatingsTable = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
-		// Create recommendation table using currently stored rule hits
+		// Create advisor_ratings
 		_, err := tx.Exec(`
 		CREATE TABLE advisor_ratings (
 		    user_id VARCHAR NOT NULL,

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -18,7 +18,7 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
-var mig0019ModifyRecommendationRuleFQDN = Migration{
+var mig0019ModifyRecommendationTable = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
 		if driver != types.DBDriverPostgres {
 			// Add rule_id column

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -18,16 +18,21 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
-var mig0019ModifyRecommendationTable = Migration{
+var mig0019ModifyRecommendationRuleFQDN = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
 		if driver != types.DBDriverPostgres {
 			return nil
 		}
 
-		// Fix rule_fqdn value for records created in migration 16
+		// Recreate table to fix rule_fqdn value for records created in migration 16
+		// The regex expression has two parts separated by a logical or `|`:
+		// (\.(?!.*\|)(?!.*\.|\|).*) finds the last dot and all the characters that follows it
+		// (\|.*) finds the '|' and all the characters that follow it
+		// Both patterns are replaced by an empty string, so we are left with only the rule's
+		// component ID in the `rule_fqdn` column
 		_, err := tx.Exec(`
 			UPDATE recommendation
-				SET rule_fqdn = REGEXP_REPLACE(rule_fqdn, '\.(?!.*\|)(?!.*\.)', '|');
+				SET rule_fqdn = REGEXP_REPLACE(rule_fqdn, '(\.(?!.*\|)(?!.*\.|\|).*)|(\|.*)', '');
 		`)
 
 		return err

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -21,7 +21,12 @@ import (
 var mig0019ModifyRecommendationRuleFQDN = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
 		if driver != types.DBDriverPostgres {
-			return nil
+			//Add the created_at column
+			_, err := tx.Exec(`
+			ALTER TABLE recommendation
+				ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE;
+			`)
+			return err
 		}
 
 		// Recreate table to fix rule_fqdn value for records created in migration 16
@@ -33,7 +38,7 @@ var mig0019ModifyRecommendationRuleFQDN = Migration{
 		_, err := tx.Exec(`
 			UPDATE recommendation
 				SET rule_fqdn = REGEXP_REPLACE(rule_fqdn, '(\.(?!.*\|)(?!.*\.|\|).*)|(\|.*)', '');
-		`)
+			`)
 
 		if err != nil {
 			return err
@@ -42,12 +47,20 @@ var mig0019ModifyRecommendationRuleFQDN = Migration{
 		//Add the created_at column with current UTC time as value
 		_, err = tx.Exec(`
 			ALTER TABLE recommendation
-				ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'utc')
+				ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'utc');
 		`)
 
 		return err
 	},
 	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		if driver == types.DBDriverPostgres {
+			//Remove the created_at column with current UTC time as value
+			_, err := tx.Exec(`
+			ALTER TABLE recommendation DROP COLUMN IF EXISTS created_at;
+			`)
+
+			return err
+		}
 		return nil
 	},
 }

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -35,6 +35,16 @@ var mig0019ModifyRecommendationRuleFQDN = Migration{
 				SET rule_fqdn = REGEXP_REPLACE(rule_fqdn, '(\.(?!.*\|)(?!.*\.|\|).*)|(\|.*)', '');
 		`)
 
+		if err != nil {
+			return err
+		}
+
+		//Add the created_at column with current UTC time as value
+		_, err = tx.Exec(`
+			ALTER TABLE recommendation
+				ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'utc')
+		`)
+
 		return err
 	},
 	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -24,7 +24,7 @@ var mig0019ModifyRecommendationRuleFQDN = Migration{
 			// Add rule_id column
 			_, err := tx.Exec(`
 				ALTER TABLE recommendation ADD COLUMN rule_id VARCHAR NOT NULL DEFAULT '.';
-				UPDATE recommendation SET rule_id = CONCAT(rule_fqdn, '|', error_key);
+				UPDATE recommendation SET rule_id = rule_fqdn + '|' + error_key;
 			`)
 			if err != nil {
 				return err

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -37,10 +37,11 @@ var mig0019ModifyRecommendationTable = Migration{
 			return err
 		}
 
-		// Recreate table to fix rule_fqdn value for records created in migration 16
+		// Fix rule_fqdn value for records created in migration 16
 		// The regex expression has two parts separated by a logical or `|`:
-		// (\.(?!.*\|)(?!.*\.|\|).*) finds the last dot and all the characters that follows it
-		// (\|.*) finds the '|' and all the characters that follow it
+		// - (\.(?!.*\|)(?!.*\.|\|).*) finds the last dot and all the characters that follow it,
+		// if and only if there is no '|' in the whole string
+		// - (\|.*) finds the '|' and all the characters that follow it
 		// Both patterns are replaced by an empty string, so we are left with only the rule's
 		// component ID in the `rule_fqdn` column
 		_, err := tx.Exec(`

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -76,7 +76,8 @@ var mig0019ModifyRecommendationRuleFQDN = Migration{
 		if driver == types.DBDriverPostgres {
 			//Remove the created_at column
 			_, err := tx.Exec(`
-			ALTER TABLE recommendation DROP COLUMN IF EXISTS created_at;
+				ALTER TABLE recommendation DROP COLUMN IF EXISTS created_at;
+				ALTER TABLE recommendation DROP COLUMN IF EXISTS rule_id;
 			`)
 
 			return err

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -30,15 +30,6 @@ var mig0019ModifyRecommendationTable = Migration{
 				SET rule_fqdn = REGEXP_REPLACE(rule_fqdn, '\.(?!.*\|)(?!.*\.)', '|');
 		`)
 
-		if err != nil {
-			return err
-		}
-
-		//Add the created_at column with current time as value
-		_, err = tx.Exec(`
-			ALTER TABLE recommendation
-				ADD COLUMN created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP.
-		`)
 		return err
 	},
 	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -35,4 +35,5 @@ var migrations = []Migration{
 	mig0016AddRecommendationsTable,
 	mig0017AddSystemWideRuleDisableTable,
 	mig0018AddRatingsTable,
+	mig0019ModifyRecommendationRuleFQDN,
 }

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -35,5 +35,5 @@ var migrations = []Migration{
 	mig0016AddRecommendationsTable,
 	mig0017AddSystemWideRuleDisableTable,
 	mig0018AddRatingsTable,
-	mig0019ModifyRecommendationRuleFQDN,
+	mig0019ModifyRecommendationTable,
 }

--- a/storage/consts.go
+++ b/storage/consts.go
@@ -23,6 +23,8 @@ const (
 	issuesCountKey = "issues found"
 	// key for recommendations selectors used in structured log messages
 	selectorsKey = "selectors"
+	// key for recommendations' creation time
+	createdAtKey = "created_at"
 
 	// closeStatementError error string
 	closeStatementError = "Unable to close statement"

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -56,12 +56,12 @@ func SetClustersLastChecked(storage *DBStorage, cluster types.ClusterName, lastC
 	storage.clustersLastChecked[cluster] = lastChecked
 }
 
-func InsertRecommendations(storage *DBStorage, orgID types.OrgID, clusterName types.ClusterName, report types.ReportRules) (int, error) {
+func InsertRecommendations(storage *DBStorage, orgID types.OrgID, clusterName types.ClusterName, report types.ReportRules) (inserted int, err error) {
 	tx, err := storage.connection.Begin()
 	if err != nil {
 		return 0, err
 	}
-	inserted, err := storage.insertRecommendations(tx, orgID, clusterName, report)
+	inserted, err = storage.insertRecommendations(tx, orgID, clusterName, report)
 	if err != nil {
 		_ = tx.Rollback()
 		return 0, err

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -56,16 +56,16 @@ func SetClustersLastChecked(storage *DBStorage, cluster types.ClusterName, lastC
 	storage.clustersLastChecked[cluster] = lastChecked
 }
 
-func InsertRecommendations(storage *DBStorage, orgID types.OrgID, clusterName types.ClusterName, report types.ReportRules) error {
+func InsertRecommendations(storage *DBStorage, orgID types.OrgID, clusterName types.ClusterName, report types.ReportRules) (int, error) {
 	tx, err := storage.connection.Begin()
 	if err != nil {
-		return err
+		return 0, err
 	}
-	_, err = storage.insertRecommendations(tx, orgID, clusterName, report)
+	inserted, err := storage.insertRecommendations(tx, orgID, clusterName, report)
 	if err != nil {
 		_ = tx.Rollback()
-		return err
+		return 0, err
 	}
 	_ = tx.Commit()
-	return nil
+	return inserted, nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -723,7 +723,7 @@ func (storage DBStorage) insertRecommendations(
 	selectors := make([]string, len(report.HitRules))
 
 	for idx, rule := range report.HitRules {
-		ruleFqdn := strings.TrimSuffix(string(rule.Module), ".report") + "|" + string(rule.ErrorKey)
+		ruleFqdn := strings.TrimSuffix(string(rule.Module), ".report")
 		selectors[idx] = ruleFqdn
 		valuesArg = append(valuesArg, orgID, clusterName, ruleFqdn, rule.ErrorKey)
 		inserted = len(valuesArg)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -759,7 +759,7 @@ func (storage DBStorage) insertRecommendations(
 		Int(issuesCountKey, inserted).
 		Time(createdAtKey, creationtime).
 		Strs(selectorsKey, selectors).
-		Msg("Recommendations statementIdx successfully")
+		Msg("Recommendations inserted successfully")
 
 	return
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -723,7 +723,7 @@ func (storage DBStorage) insertRecommendations(
 			Msg("No new recommendation to insert")
 		return 0, nil
 	}
-	statement := `INSERT INTO recommendation (org_id, cluster_id, rule_fqdn, error_key, created_at) VALUES %s`
+	statement := `INSERT INTO recommendation (org_id, cluster_id, rule_fqdn, error_key, rule_id, created_at) VALUES %s`
 
 	var valuesIdx []string
 	var valuesArg []interface{}
@@ -732,10 +732,11 @@ func (storage DBStorage) insertRecommendations(
 	creationtime := time.Now().UTC()
 	for idx, rule := range report.HitRules {
 		ruleFqdn := strings.TrimSuffix(string(rule.Module), ".report")
-		selectors[idx] = ruleFqdn
-		valuesArg = append(valuesArg, orgID, clusterName, ruleFqdn, rule.ErrorKey, creationtime)
+		ruleId := ruleFqdn + "|" + string(rule.ErrorKey)
+		selectors[idx] = ruleId
+		valuesArg = append(valuesArg, orgID, clusterName, ruleFqdn, rule.ErrorKey, ruleId, creationtime)
 		statementIdx = len(valuesArg)
-		valuesIdx = append(valuesIdx, "($"+fmt.Sprint(statementIdx-4)+", $"+fmt.Sprint(statementIdx-3)+", $"+fmt.Sprint(statementIdx-2)+", $"+fmt.Sprint(statementIdx-1)+", $"+fmt.Sprint(statementIdx)+")")
+		valuesIdx = append(valuesIdx, "($"+fmt.Sprint(statementIdx-5)+", $"+fmt.Sprint(statementIdx-4)+", $"+fmt.Sprint(statementIdx-3)+", $"+fmt.Sprint(statementIdx-2)+", $"+fmt.Sprint(statementIdx-1)+", $"+fmt.Sprint(statementIdx)+")")
 	}
 
 	statement = fmt.Sprintf(statement, strings.Join(valuesIdx, ","))

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -715,6 +715,14 @@ func (storage DBStorage) insertRecommendations(
 	clusterName types.ClusterName,
 	report types.ReportRules,
 ) (inserted int, err error) {
+	if len(report.HitRules) == 0 {
+		log.Info().
+			Int(organizationKey, int(orgID)).
+			Str(clusterKey, string(clusterName)).
+			Int(issuesCountKey, 0).
+			Msg("No new recommendation to insert")
+		return 0, nil
+	}
 	statement := `INSERT INTO recommendation (org_id, cluster_id, rule_fqdn, error_key, created_at) VALUES %s`
 
 	var valuesIdx []string

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -732,9 +732,9 @@ func (storage DBStorage) insertRecommendations(
 	creationtime := time.Now().UTC()
 	for idx, rule := range report.HitRules {
 		ruleFqdn := strings.TrimSuffix(string(rule.Module), ".report")
-		ruleId := ruleFqdn + "|" + string(rule.ErrorKey)
-		selectors[idx] = ruleId
-		valuesArg = append(valuesArg, orgID, clusterName, ruleFqdn, rule.ErrorKey, ruleId, creationtime)
+		ruleID := ruleFqdn + "|" + string(rule.ErrorKey)
+		selectors[idx] = ruleID
+		valuesArg = append(valuesArg, orgID, clusterName, ruleFqdn, rule.ErrorKey, ruleID, creationtime)
 		statementIdx = len(valuesArg)
 		valuesIdx = append(valuesIdx, "($"+fmt.Sprint(statementIdx-5)+", $"+fmt.Sprint(statementIdx-4)+", $"+fmt.Sprint(statementIdx-3)+", $"+fmt.Sprint(statementIdx-2)+", $"+fmt.Sprint(statementIdx-1)+", $"+fmt.Sprint(statementIdx)+")")
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -727,24 +727,25 @@ func (storage DBStorage) insertRecommendations(
 
 	var valuesIdx []string
 	var valuesArg []interface{}
-	inserted = 0
+	statementIdx := 0
 	selectors := make([]string, len(report.HitRules))
 	creationtime := time.Now().UTC()
 	for idx, rule := range report.HitRules {
 		ruleFqdn := strings.TrimSuffix(string(rule.Module), ".report")
 		selectors[idx] = ruleFqdn
 		valuesArg = append(valuesArg, orgID, clusterName, ruleFqdn, rule.ErrorKey, creationtime)
-		inserted = len(valuesArg)
-		valuesIdx = append(valuesIdx, "($"+fmt.Sprint(inserted-4)+", $"+fmt.Sprint(inserted-3)+", $"+fmt.Sprint(inserted-2)+", $"+fmt.Sprint(inserted-1)+", $"+fmt.Sprint(inserted)+")")
+		statementIdx = len(valuesArg)
+		valuesIdx = append(valuesIdx, "($"+fmt.Sprint(statementIdx-4)+", $"+fmt.Sprint(statementIdx-3)+", $"+fmt.Sprint(statementIdx-2)+", $"+fmt.Sprint(statementIdx-1)+", $"+fmt.Sprint(statementIdx)+")")
 	}
 
 	statement = fmt.Sprintf(statement, strings.Join(valuesIdx, ","))
+	inserted = len(selectors)
 	_, err = tx.Exec(statement, valuesArg...)
 	if err != nil {
 		log.Error().
 			Int(organizationKey, int(orgID)).
 			Str(clusterKey, string(clusterName)).
-			Int(issuesCountKey, len(selectors)).
+			Int(issuesCountKey, inserted).
 			Time(createdAtKey, creationtime).
 			Strs(selectorsKey, selectors).
 			Err(err).
@@ -754,10 +755,10 @@ func (storage DBStorage) insertRecommendations(
 	log.Info().
 		Int(organizationKey, int(orgID)).
 		Str(clusterKey, string(clusterName)).
-		Int(issuesCountKey, len(selectors)).
+		Int(issuesCountKey, inserted).
 		Time(createdAtKey, creationtime).
 		Strs(selectorsKey, selectors).
-		Msg("Recommendations inserted successfully")
+		Msg("Recommendations statementIdx successfully")
 
 	return
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1062,8 +1062,8 @@ func TestDBStorageInsertRecommendations(t *testing.T) {
 	expects.ExpectBegin()
 
 	expects.ExpectExec("INSERT INTO recommendation \\(org_id, cluster_id, rule_fqdn, error_key, rule_id, created_at\\) " +
-		"VALUES \\(\\$1, \\$2, \\$3\\, \\$4\\, \\$5\\, \\$6\\),"+
-		"\\(\\$7, \\$8, \\$9\\, \\$10\\, \\$11\\, \\$12\\),"+
+		"VALUES \\(\\$1, \\$2, \\$3\\, \\$4\\, \\$5\\, \\$6\\)," +
+		"\\(\\$7, \\$8, \\$9\\, \\$10\\, \\$11\\, \\$12\\)," +
 		"\\(\\$13, \\$14, \\$15\\, \\$16\\, \\$17\\, \\$18\\)").
 		WillReturnResult(driver.ResultNoRows)
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1061,8 +1061,10 @@ func TestDBStorageInsertRecommendations(t *testing.T) {
 
 	expects.ExpectBegin()
 
-	expects.ExpectExec("INSERT INTO recommendation \\(org_id, cluster_id, rule_fqdn, error_key, created_at\\) " +
-		"VALUES \\(\\$1, \\$2, \\$3\\, \\$4\\, \\$5\\),\\(\\$6, \\$7, \\$8\\, \\$9\\, \\$10\\),\\(\\$11, \\$12, \\$13\\, \\$14\\, \\$15\\)").
+	expects.ExpectExec("INSERT INTO recommendation \\(org_id, cluster_id, rule_fqdn, error_key, rule_id, created_at\\) " +
+		"VALUES \\(\\$1, \\$2, \\$3\\, \\$4\\, \\$5\\, \\$6\\),"+
+		"\\(\\$7, \\$8, \\$9\\, \\$10\\, \\$11\\, \\$12\\),"+
+		"\\(\\$13, \\$14, \\$15\\, \\$16\\, \\$17\\, \\$18\\)").
 		WillReturnResult(driver.ResultNoRows)
 
 	expects.ExpectCommit()

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1075,8 +1075,8 @@ func TestDBStorageInsertRecommendations(t *testing.T) {
 		PassedRules:  testdata.RuleOnReportResponses,
 		TotalCount:   3 * len(testdata.RuleOnReportResponses),
 	}
-	err := storage.InsertRecommendations(mockStorage.(*storage.DBStorage), testdata.OrgID, testdata.ClusterName, report)
-
+	inserted, err := storage.InsertRecommendations(mockStorage.(*storage.DBStorage), testdata.OrgID, testdata.ClusterName, report)
+	assert.Equal(t, 3, inserted)
 	helpers.FailOnError(t, err)
 }
 
@@ -1143,5 +1143,22 @@ func TestDBStorageWriteRecommendationForClusterAlreadyStoredAndDeleted(t *testin
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 	)
 
+	helpers.FailOnError(t, err)
+}
+
+// TestDBStorageInsertRecommendationsNoRuleHit checks that no
+// recommendations are inserted if there is no rule hits in the report
+func TestDBStorageInsertRecommendationsNoRuleHit(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
+	defer closer()
+
+	report := types.ReportRules{
+		SkippedRules: testdata.RuleOnReportResponses,
+		PassedRules:  testdata.RuleOnReportResponses,
+		TotalCount:   2 * len(testdata.RuleOnReportResponses),
+	}
+	inserted, err := storage.InsertRecommendations(mockStorage.(*storage.DBStorage), testdata.OrgID, testdata.ClusterName, report)
+
+	assert.Equal(t, 0, inserted)
 	helpers.FailOnError(t, err)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1061,8 +1061,8 @@ func TestDBStorageInsertRecommendations(t *testing.T) {
 
 	expects.ExpectBegin()
 
-	expects.ExpectExec("INSERT INTO recommendation \\(org_id, cluster_id, rule_fqdn, error_key\\) " +
-		"VALUES \\(\\$1, \\$2, \\$3\\, \\$4\\),\\(\\$5, \\$6, \\$7\\, \\$8\\),\\(\\$9, \\$10, \\$11\\, \\$12\\)").
+	expects.ExpectExec("INSERT INTO recommendation \\(org_id, cluster_id, rule_fqdn, error_key, created_at\\) " +
+		"VALUES \\(\\$1, \\$2, \\$3\\, \\$4\\, \\$5\\),\\(\\$6, \\$7, \\$8\\, \\$9\\, \\$10\\),\\(\\$11, \\$12, \\$13\\, \\$14\\, \\$15\\)").
 		WillReturnResult(driver.ResultNoRows)
 
 	expects.ExpectCommit()


### PR DESCRIPTION
# Description
- Fix the `recommendation` table's `rule_fqdn` column through migration19, and add UT in `migration/actual_migrations_test.go`
    - REGEXP_REPLACE(rule_fqdn, '\.(?!.*\|)(?!.*\.)', '|') replaces the last `.` found in the rule FQDN if the character `|` is not found in the current value 
- Fix some comments
- Fix insertion of empty recommendations (which fails due to bad SQL statement) when no rule hit in processed report
- Add `rule_id` column whose content is `rule.module|error_key`.
- Add `created_at` column in `recommendation` table, with default UTC timestamp in existing records, and update `storage.insertRecommendations` function to insert the timestamp.   

Fixes #1274 

## Type of change

- Bug fix
- New feature
- Unit tests

## Testing steps

new UTs + local testing

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
