### PR TITLE
add aggregator part for /rule/ recommendations list

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -77,6 +77,9 @@ const (
 	// ListOfDisabledRulesSystemWide returns a list of rules disabled from current account
 	ListOfDisabledRulesSystemWide = "rules/organizations/{org_id}/users/{user_id}/disabled_system_wide"
 
+	// RecommendationsListEndpoint receives a list of clusters in POST body and returns a list of all recommendations hitting for them
+	RecommendationsListEndpoint = "recommendations/organizations/{org_id}/users/{user_id}/list"
+
 	// Rating accepts a list of ratings in the request body and store them in the database for the given user
 	Rating = "rules/organizations/{org_id}/users/{user_id}/rating"
 	// MetricsEndpoint returns prometheus metrics
@@ -127,6 +130,9 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	router.HandleFunc(apiPrefix+UpdateRuleSystemWide, server.updateRuleSystemWide).Methods(http.MethodPost, http.MethodOptions)
 	router.HandleFunc(apiPrefix+ReadRuleSystemWide, server.readRuleSystemWide).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+ListOfDisabledRulesSystemWide, server.listOfDisabledRulesSystemWide).Methods(http.MethodGet)
+
+	// Insights Advisor related endpoints
+	router.HandleFunc(apiPrefix+RecommendationsListEndpoint, server.getRecommendations).Methods(http.MethodPost, http.MethodOptions)
 
 	// Prometheus metrics
 	router.Handle(apiPrefix+MetricsEndpoint, promhttp.Handler()).Methods(http.MethodGet)

--- a/server/reports.go
+++ b/server/reports.go
@@ -236,3 +236,42 @@ func (server *HTTPServer) reportForListOfClustersPayload(writer http.ResponseWri
 	// we were able to read the cluster IDs, let's process them
 	processListOfClusters(server, writer, request, orgID, listOfClusters)
 }
+
+// getRecommendations retrieves all recommendations hitting for all clusters in the org
+func (server *HTTPServer) getRecommendations(writer http.ResponseWriter, request *http.Request) {
+	// Extract user_id from URL
+	userID, ok := readUserID(writer, request)
+	if !ok {
+		// everything has been handled
+		return
+	}
+	log.Info().Str("userID", string(userID)).Msg("getRecommendations")
+
+	// extract org_id from URL
+	orgID, ok := readOrgID(writer, request)
+	if !ok {
+		// everything has been handled
+		return
+	}
+	log.Info().Int("orgID", int(orgID)).Msg("getRecommendations")
+
+	var listOfClusters []types.ClusterName
+	err := json.NewDecoder(request.Body).Decode(&listOfClusters)
+	if err != nil {
+		handleServerError(writer, err)
+		return
+	}
+	log.Info().Msgf("getRecommendations list of clusters: %v", listOfClusters)
+
+	recommendations, err := server.Storage.ReadRecommendationsForClusters(listOfClusters)
+	if err != nil {
+		log.Error().Err(err).Msg("Errors retrieving recommendations")
+		handleServerError(writer, err)
+		return
+	}
+
+	err = responses.SendOK(writer, responses.BuildOkResponseWithData("recommendations", recommendations))
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -300,3 +300,10 @@ func (*NoopStorage) ListOfSystemWideDisabledRules(
 	orgID types.OrgID, userID types.UserID) ([]utypes.SystemWideRuleDisable, error) {
 	return nil, nil
 }
+
+// ReadRecommendationsForClusters reads all recommendations from recommendation table for given organization
+func (*NoopStorage) ReadRecommendationsForClusters(
+	clusterList []types.ClusterName,
+) (utypes.RecommendationImpactedClusters, error) {
+	return nil, nil
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -175,6 +175,7 @@ type Storage interface {
 		ruleID types.RuleID, errorKey types.ErrorKey) (utypes.SystemWideRuleDisable, bool, error)
 	ListOfSystemWideDisabledRules(
 		orgID types.OrgID, userID types.UserID) ([]utypes.SystemWideRuleDisable, error)
+	ReadRecommendationsForClusters([]types.ClusterName) (utypes.RecommendationImpactedClusters, error)
 }
 
 // DBStorage is an implementation of Storage interface that use selected SQL like database
@@ -889,6 +890,58 @@ func finishTransaction(tx *sql.Tx, err error) {
 			log.Err(commitError).Msgf("error when trying to commit a transaction")
 		}
 	}
+}
+
+// ReadRecommendationsForClusters reads all recommendations from recommendation table for given organization
+func (storage DBStorage) ReadRecommendationsForClusters(
+	clusterList []types.ClusterName,
+) (utypes.RecommendationImpactedClusters, error) {
+
+	recommendationsMap := make(utypes.RecommendationImpactedClusters, 0)
+
+	// prepare arguments
+	args := argsWithClusterNames(clusterList)
+
+	// construct the `in` clausule in SQL query statement
+	inClausule := constructInClausule(len(clusterList))
+
+	// disable "G202 (CWE-89): SQL string concatenation"
+	// #nosec G202
+	query := `
+	SELECT
+		rule_id, count(*) as impacted_clusters_c
+	FROM
+		recommendation
+	WHERE
+		cluster_id in (` + inClausule + `)
+	GROUP BY
+		rule_id
+	`
+	rows, err := storage.connection.Query(query, args...)
+	if err != nil {
+		log.Error().Err(err).Msg("query to get recommendations")
+		return recommendationsMap, err
+	}
+
+	for rows.Next() {
+		var (
+			ruleID      types.RuleID
+			impactedCnt utypes.ImpactedClustersCnt
+		)
+
+		err := rows.Scan(
+			&ruleID,
+			&impactedCnt,
+		)
+		if err != nil {
+			log.Error().Err(err).Msg("read one recommendation")
+			return recommendationsMap, err
+		}
+
+		recommendationsMap[ruleID] = impactedCnt
+	}
+
+	return recommendationsMap, nil
 }
 
 // ReportsCount reads number of all records stored in database


### PR DESCRIPTION
# Description
Aggregator part for GET /rule/ which returns a list of recommendations for the active clusters in the organization (given the AMS API is alive) with a number the number of clusters its impacting.

ready for changes in the recommendation in progress by @epapbak

TODO: bump utils repo, modify unit tests

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Documentation update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
