### PR TITLE
Improve migration19's stepDown and UT

### DIFF
--- a/migration/actual_migrations_test.go
+++ b/migration/actual_migrations_test.go
@@ -419,6 +419,11 @@ func TestMigration19(t *testing.T) {
 	err := migration.SetDBVersion(db, dbDriver, 18)
 	helpers.FailOnError(t, err)
 
+	err = db.QueryRow(`SELECT created_at FROM recommendation`).Err()
+	assert.Error(t, err, "created_at column should not exist")
+	err = db.QueryRow(`SELECT rule_id FROM recommendation`).Err()
+	assert.Error(t, err, "rule_id column should not exist")
+
 	correctRuleID := testdata.Rule1ID + "|" + testdata.ErrorKey1
 	incorrectRuleFQDN := testdata.Rule1ID + "." + testdata.ErrorKey1
 
@@ -499,4 +504,13 @@ func TestMigration19(t *testing.T) {
 	helpers.FailOnError(t, err)
 	assert.False(t, timestamp.IsZero(), "The timestamp column was not created with a default value")
 	assert.True(t, timestamp.UTC().Equal(timestamp), "The stored timestamp is not in UTC format")
+
+	//Step down should remove created_at and rule_id columns
+	err = migration.SetDBVersion(db, dbDriver, 18)
+	helpers.FailOnError(t, err)
+
+	err = db.QueryRow(`SELECT created_at FROM recommendation`).Err()
+	assert.Error(t, err, "created_at column should not exist")
+	err = db.QueryRow(`SELECT rule_id FROM recommendation`).Err()
+	assert.Error(t, err, "rule_id column should not exist")
 }

--- a/migration/mig_0019_modify_recommendation_table.go
+++ b/migration/mig_0019_modify_recommendation_table.go
@@ -82,6 +82,14 @@ var mig0019ModifyRecommendationTable = Migration{
 			`)
 
 			return err
+		} else if driver == types.DBDriverSQLite3 {
+			// Why would SQLite allow you to drop a column...
+			_, err := tx.Exec(`
+				CREATE TABLE recommendation_temp AS SELECT org_id, cluster_id, rule_fqdn, error_key FROM recommendation;
+				DROP TABLE recommendation;
+				ALTER TABLE recommendation_temp RENAME TO recommendation;
+			`)
+			return err
 		}
 		return nil
 	},


### PR DESCRIPTION
# Description

Remove `rule_id` and `created_at` columns in SQLite too during step down from migration 19

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Added more checks in corresponding UT + 
## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
