### PR TITLE
Remove recommendations metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -113,6 +113,7 @@ var SQLQueriesDurations = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help: "SQL queries durations",
 }, []string{"query"})
 
+/*
 // SQLRecommendationsDeletes shows deleted entries in recommendations table.
 var SQLRecommendationsDeletes = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name: "sql_recommendations_deletes",
@@ -124,6 +125,7 @@ var SQLRecommendationsInserts = promauto.NewHistogramVec(prometheus.HistogramOpt
 	Name: "sql_recommendations_inserts",
 	Help: "Number of rows added to the SQL recommendation table when new report is processed",
 }, []string{"cluster"})
+*/
 
 // AddMetricsWithNamespace register the desired metrics using a given namespace
 func AddMetricsWithNamespace(namespace string) {
@@ -139,8 +141,8 @@ func AddMetricsWithNamespace(namespace string) {
 	prometheus.Unregister(FeedbackOnRules)
 	prometheus.Unregister(SQLQueriesCounter)
 	prometheus.Unregister(SQLQueriesDurations)
-	prometheus.Unregister(SQLRecommendationsDeletes)
-	prometheus.Unregister(SQLRecommendationsInserts)
+	//prometheus.Unregister(SQLRecommendationsDeletes)
+	//prometheus.Unregister(SQLRecommendationsInserts)
 
 	ConsumedMessages = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
@@ -192,14 +194,16 @@ func AddMetricsWithNamespace(namespace string) {
 		Name:      "sql_queries_durations",
 		Help:      "SQL queries durations",
 	}, []string{"query"})
-	SQLRecommendationsDeletes = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Name:      "sql_recommendations_deletes",
-		Help:      "Number of rows removed from the SQL recommendation table when new report is processed",
-	}, []string{"cluster"})
-	SQLRecommendationsInserts = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Name:      "sql_recommendations_inserts",
-		Help:      "Number of rows added to the SQL recommendation table when new report is processed",
-	}, []string{"cluster"})
+	/*
+		SQLRecommendationsDeletes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "sql_recommendations_deletes",
+			Help:      "Number of rows removed from the SQL recommendation table when new report is processed",
+		}, []string{"cluster"})
+		SQLRecommendationsInserts = promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "sql_recommendations_inserts",
+			Help:      "Number of rows added to the SQL recommendation table when new report is processed",
+		}, []string{"cluster"})
+	*/
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -457,10 +457,12 @@ func argsWithClusterNames(clusterNames []types.ClusterName) []interface{} {
 	return args
 }
 
+/*
 func updateRecommendationsMetrics(cluster string, deleted float64, inserted float64) {
 	metrics.SQLRecommendationsDeletes.WithLabelValues(cluster).Observe(deleted)
 	metrics.SQLRecommendationsInserts.WithLabelValues(cluster).Observe(inserted)
 }
+*/
 
 // ReadOrgIDsForClusters read organization IDs for given list of cluster names.
 func (storage DBStorage) ReadOrgIDsForClusters(clusterNames []types.ClusterName) ([]types.OrgID, error) {
@@ -895,7 +897,13 @@ func (storage DBStorage) WriteRecommendationsForCluster(
 			return err
 		}
 
-		updateRecommendationsMetrics(string(clusterName), float64(deleted), float64(inserted))
+		log.Info().
+			Int64("Deleted", deleted).
+			Int("Inserted", inserted).
+			Int(organizationKey, int(orgID)).
+			Str(clusterKey, string(clusterName)).
+			Msg("Updated recommendation table")
+		// updateRecommendationsMetrics(string(clusterName), float64(deleted), float64(inserted))
 
 		return nil
 	}(tx)


### PR DESCRIPTION
# Description

Recommendations metrics are growing too fast with the current implementation. This PR removes them until I can think of a way to control that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
