### PR TITLE
Ignore gosec in ListOfClustersForOrgSpecificRule...

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -393,11 +393,13 @@ func (storage DBStorage) ListOfClustersForOrgSpecificRule(
 
 	var whereClause string
 	if activeClusters != nil {
+		// #nosec G201
 		whereClause = fmt.Sprintf(`WHERE org_id = $1 AND rule_id = $2 AND cluster_id IN (%v)`,
 			inClauseFromSlice(activeClusters))
 	} else {
 		whereClause = `WHERE org_id = $1 AND rule_id = $2`
 	}
+	// #nosec G202
 	query := `SELECT cluster_id FROM recommendation ` + whereClause + ` ORDER BY cluster_id;`
 
 	rows, err := storage.connection.Query(query, orgID, ruleID)


### PR DESCRIPTION
# Description

G201 and G202 prevent SQL injection, but in this case, the formatted and concatenated queries are created with controlled data.

## Type of change

N/A

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
