### PR TITLE
clusters_detail endpoint - return rule_id instead of rule_selector in JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
-	github.com/RedHatInsights/insights-operator-utils v1.21.3
+	github.com/RedHatInsights/insights-operator-utils v1.21.4
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.2
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/RedHatInsights/insights-operator-utils v1.8.3/go.mod h1:L6alrkNSM+uBz
 github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
-github.com/RedHatInsights/insights-operator-utils v1.21.3 h1:ZQ1nrLp4LrBUnJkn9TLbHWru8+QCiJObfgg1MQBgMgQ=
-github.com/RedHatInsights/insights-operator-utils v1.21.3/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
+github.com/RedHatInsights/insights-operator-utils v1.21.4 h1:bWDLMfQLuJ3928e6gcUMJhJUNxnJbeR+eDbopE7TSzI=
+github.com/RedHatInsights/insights-operator-utils v1.21.4/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1314,7 +1314,7 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	respBody := `{"data":[{"cluster":"%v"}],"meta":{"count":%v, "rule_selector":"%v"},"status":"ok"}`
+	respBody := `{"data":[{"cluster":"%v"}],"meta":{"count":%v, "rule_id":"%v"},"status":"ok"}`
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.Org2ID, testdata.ClusterName, testdata.Report2Rules)
@@ -1364,7 +1364,7 @@ func TestRuleClusterDetailEndpoint_ValidParametersActiveClusters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	respBody := `{"data":[{"cluster":"%v"}],"meta":{"count":%v, "rule_selector":"%v"},"status":"ok"}`
+	respBody := `{"data":[{"cluster":"%v"}],"meta":{"count":%v, "rule_id":"%v"},"status":"ok"}`
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules)


### PR DESCRIPTION
# Description

Return `rule_id` in response sent to smart_proxy instead of `rule_selector`, for consistency on the client side.

- The rule_selector type will only be used internally for now, until we can refactor it all.
- This change only affects /rule/{rule_selector}/clusters_detail endpoint.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

CI + local testing

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
