### PR TITLE
Return/expose DB version in /info REST API endpoint

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,10 +16,12 @@ package main
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-results-aggregator/conf"
+	"github.com/RedHatInsights/insights-results-aggregator/migration"
 	"github.com/RedHatInsights/insights-results-aggregator/server"
 )
 
@@ -46,6 +48,17 @@ func startServer() error {
 
 	// fill-in additional info used by /info endpoint handler
 	fillInInfoParams(serverInstance.InfoParams)
+
+	// try to retrieve the actual DB migration version
+	// and add it into the `params` map
+	currentVersion, err := migration.GetDBVersion(dbStorage.GetConnection())
+	if err != nil {
+		const msg = "Unable to retrieve DB migration version"
+		log.Error().Err(err).Msg(msg)
+		serverInstance.InfoParams["DB_version"] = msg
+	} else {
+		serverInstance.InfoParams["DB_version"] = strconv.Itoa(int(currentVersion))
+	}
 
 	err = serverInstance.Start(finishServerInstanceInitialization)
 	if err != nil {

--- a/tests/rest/info.go
+++ b/tests/rest/info.go
@@ -1,0 +1,72 @@
+/*
+Copyright © 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"encoding/json"
+
+	"github.com/verdverm/frisby"
+)
+
+// InfoResponse represents response from /info endpoint
+type InfoResponse struct {
+	Info   map[string]string `json:"info"`
+	Status string            `json:"status"`
+}
+
+// checkInfoEndpoint performs elementary checks for /info endpoint
+func checkInfoEndpoint() {
+	var expectedInfoKeys []string = []string{
+		"BuildBranch",
+		"BuildCommit",
+		"BuildTime",
+		"BuildVersion",
+		"DB_version",
+		"UtilsVersion",
+	}
+
+	f := frisby.Create("Check the /info endpoint").Get(apiURL + "info")
+	setAuthHeaderForOrganization(f, knownOrganizations[0])
+	f.Send()
+	f.ExpectStatus(200)
+	f.ExpectHeader(contentTypeHeader, "application/json; charset=utf-8")
+
+	// check the response
+	text, err := f.Resp.Content()
+	if err != nil {
+		f.AddError(err.Error())
+	} else {
+		response := InfoResponse{}
+		err := json.Unmarshal(text, &response)
+		if err != nil {
+			f.AddError(err.Error())
+		}
+		if response.Status != "ok" {
+			f.AddError("Expecting 'status' to be set to 'ok'")
+		}
+		if len(response.Info) == 0 {
+			f.AddError("Info node is empty")
+		}
+		for _, expectedKey := range expectedInfoKeys {
+			_, found := response.Info[expectedKey]
+			if !found {
+				f.AddError("Info node does not contain key " + expectedKey)
+			}
+		}
+	}
+	f.PrintReport()
+}

--- a/tests/rest/rest.go
+++ b/tests/rest/rest.go
@@ -49,6 +49,9 @@ func ServerTests() {
 	// tests for metrics hat is accessible via its endpoint as well
 	// implementation of these tests is stored in metrics.go
 	checkPrometheusMetrics()
+
+	// tests for /info endpoint
+	checkInfoEndpoint()
 }
 
 // BasicTests implements basic tests for REST API apiPrefix


### PR DESCRIPTION
# Description

Return/expose DB version in `/info` REST API endpoint

Fixes #1305

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Can be checked locally:

```
{
  "info": {
    "BuildBranch": "master",
    "BuildCommit": "f78b8d80f5c3614d5602b8f7c8bb137b9ff79be2",
    "BuildTime": "Tue Nov  2 09:03:46 CET 2021",
    "BuildVersion": "0.5",
    "DB_version": "20",
    "UtilsVersion": "v1.21.5"
  },
  "status": "ok"
}
```

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
