### PR TITLE
Fix clusters_detail per recommendation SQL query

### DIFF
--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -323,7 +323,7 @@ func (*NoopStorage) ReadRecommendationsForClusters(
 // ListOfClustersForOrgSpecificRule returns list of all clusters for
 // given organization that are affected by given rule
 func (*NoopStorage) ListOfClustersForOrgSpecificRule(
-	orgID types.OrgID, ruleID types.RuleSelector, activeClusters interface{},
+	orgID types.OrgID, ruleID types.RuleSelector, activeClusters []string,
 ) ([]utypes.HittingClustersData, error) {
 	return nil, nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -56,7 +56,7 @@ type Storage interface {
 		orgID types.OrgID, timeLimit time.Time) ([]types.ClusterName, error,
 	)
 	ListOfClustersForOrgSpecificRule(
-		orgID types.OrgID, ruleID types.RuleSelector, activeClusters interface{},
+		orgID types.OrgID, ruleID types.RuleSelector, activeClusters []string,
 	) ([]utypes.HittingClustersData, error)
 	ReadReportForCluster(
 		orgID types.OrgID, clusterName types.ClusterName) ([]types.RuleOnReport, types.Timestamp, error,
@@ -392,12 +392,12 @@ func (storage DBStorage) ListOfClustersForOrg(orgID types.OrgID, timeLimit time.
 func (storage DBStorage) ListOfClustersForOrgSpecificRule(
 	orgID types.OrgID,
 	ruleID types.RuleSelector,
-	activeClusters interface{}) (
+	activeClusters []string) (
 	[]utypes.HittingClustersData, error) {
 	results := make([]utypes.HittingClustersData, 0)
 
 	var whereClause string
-	if activeClusters != nil {
+	if len(activeClusters) > 0 {
 		// #nosec G201
 		whereClause = fmt.Sprintf(`WHERE org_id = $1 AND rule_id = $2 AND cluster_id IN (%v)`,
 			inClauseFromSlice(activeClusters))


### PR DESCRIPTION
# Description

Comparing activeClusters slice with nil was not a good idea, and the resulting SQL query for the `clusters_detail` endpoint was incorrect as we were entering the wrong condition with no data, resulting in the following query:  `SELECT cluster_id FROM recommendation WHERE org_id = $1 AND rule_id = $2 AND cluster_id IN ('') ORDER BY cluster_id;`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

- Tested locally with smart-proxy calls to check that the endpoint now works as expected
- `make test` and `make test-postgres` pass
- CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
