### PR TITLE
[CCXDEV-6473] Update go image version to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.16.7 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.16 AS builder
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.15 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.16.7 AS builder
 
 COPY . .
 

--- a/ci/jenkins_slave_pod_template.yaml
+++ b/ci/jenkins_slave_pod_template.yaml
@@ -58,7 +58,7 @@ spec:
         limits:
           cpu: 300m
           memory: 512Mi
-    - image: registry.redhat.io/rhel8/go-toolset:1.16.7
+    - image: registry.redhat.io/rhel8/go-toolset:1.16
       name: builder
       tty: True
       env:

--- a/ci/jenkins_slave_pod_template.yaml
+++ b/ci/jenkins_slave_pod_template.yaml
@@ -58,7 +58,7 @@ spec:
         limits:
           cpu: 300m
           memory: 512Mi
-    - image: registry.redhat.io/rhel8/go-toolset:1.15
+    - image: registry.redhat.io/rhel8/go-toolset:1.16.7
       name: builder
       tty: True
       env:


### PR DESCRIPTION
# Description

Use [RHEL image](https://catalog.redhat.com/software/containers/rhel8/go-toolset/5b9c810add19c70b45cbd666?container-tabs=overview) with `go 1.16` version.

Fixes [CCXDEV-6473](https://issues.redhat.com/browse/CCXDEV-6473).

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
