### PR TITLE
Using types from insights-results-types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,9 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
-	github.com/RedHatInsights/insights-operator-utils v1.21.5
-	github.com/RedHatInsights/insights-results-aggregator-data v1.3.2
+	github.com/RedHatInsights/insights-operator-utils v1.22.0
+	github.com/RedHatInsights/insights-results-aggregator-data v1.3.3
+	github.com/RedHatInsights/insights-results-types v1.2.0
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,9 @@ github.com/RedHatInsights/insights-operator-utils v1.8.3/go.mod h1:L6alrkNSM+uBz
 github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
-github.com/RedHatInsights/insights-operator-utils v1.21.5 h1:hnb2M4sbzbfp7LzQeMxY58MwC2WAXnmzLYRsA1K2W4A=
-github.com/RedHatInsights/insights-operator-utils v1.21.5/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
+github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
+github.com/RedHatInsights/insights-operator-utils v1.22.0 h1:rXK/n6gJca5u/jmi62QyOeAR0EaUcoBLmGdBwqMBG7s=
+github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
@@ -51,8 +52,11 @@ github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720
 github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023/go.mod h1:SDeBuNY8AIwkD4JB5/I54ArWG7qngP5/Ydn7xbu2iZo=
 github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbiccYJ8whbpLLvNGMiaFzyMPs1A/2/Jh0P2U9DXF+4=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
-github.com/RedHatInsights/insights-results-aggregator-data v1.3.2 h1:3QdTNy2f7ly4Iioae4r86QYCyxdW0itmfs4QYhsy3eY=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.2/go.mod h1:E1UaB+IjJ/muxvMstVoqJrB82zVKNykjTtCiM3tMHoM=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.3 h1:K6j+Sr+S0iUqFEfevl+MI0dEXn5AxFeJn9FTU5razWA=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHNC7lBxYnu9AqMahABqvuclCzWUWSkbacQbUaehfI=
+github.com/RedHatInsights/insights-results-types v1.2.0 h1:tFaGQE2h/4OIhf8sI/lRwJ/Fh0soO7a47de9x4irIJs=
+github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/server/auth.go
+++ b/server/auth.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	"github.com/RedHatInsights/insights-operator-utils/collections"
-	"github.com/RedHatInsights/insights-operator-utils/types"
+	types "github.com/RedHatInsights/insights-results-types"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/rs/zerolog/log"
 )

--- a/server/server.go
+++ b/server/server.go
@@ -65,7 +65,7 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/storage"
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 
-	utypes "github.com/RedHatInsights/insights-operator-utils/types"
+	ctypes "github.com/RedHatInsights/insights-results-types"
 )
 
 const (
@@ -409,7 +409,7 @@ func (server *HTTPServer) getFeedbackMessageFromBody(request *http.Request) (str
 
 // getJustificationFromBody retrieves the justification provided by user from body of the request
 func (server *HTTPServer) getJustificationFromBody(request *http.Request) (string, error) {
-	var justification utypes.AcknowledgementJustification
+	var justification ctypes.AcknowledgementJustification
 
 	err := json.NewDecoder(request.Body).Decode(&justification)
 	if err != nil {
@@ -454,7 +454,7 @@ func (server *HTTPServer) RuleClusterDetailEndpoint(writer http.ResponseWriter, 
 		Str(userIDstr, string(userID)).
 		Msgf("GET clusters detail for rule %s", selector)
 
-	var clusters []utypes.HittingClustersData
+	var clusters []ctypes.HittingClustersData
 	var err error
 
 	if request.ContentLength > 0 {
@@ -475,7 +475,7 @@ func (server *HTTPServer) RuleClusterDetailEndpoint(writer http.ResponseWriter, 
 	}
 
 	resp := responses.BuildOkResponse()
-	resp["meta"] = utypes.HittingClustersMetadata{
+	resp["meta"] = ctypes.HittingClustersMetadata{
 		Count:    len(clusters),
 		Selector: selector,
 	}

--- a/server/server_read_report_test.go
+++ b/server/server_read_report_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	operator_utils_types "github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	ctypes "github.com/RedHatInsights/insights-results-types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/RedHatInsights/insights-results-aggregator/server"
@@ -433,8 +433,8 @@ func TestReadReport_RuleDisableFeedback(t *testing.T) {
 				t, expected, got,
 				func(
 					t testing.TB,
-					expectedRules []operator_utils_types.RuleOnReport,
-					gotRules []operator_utils_types.RuleOnReport,
+					expectedRules []ctypes.RuleOnReport,
+					gotRules []ctypes.RuleOnReport,
 				) {
 					assert.Equal(t, len(expectedRules), len(gotRules))
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -29,8 +29,8 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	operator_utils_types "github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	ctypes "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -748,9 +748,9 @@ func TestHTTPServer_SaveDisableFeedback_Error_CheckUserClusterPermissions(t *tes
 		EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID},
 		Body:         `{"message": ""}`,
 		XRHIdentity: helpers.MakeXRHTokenString(t, &types.Token{
-			Identity: operator_utils_types.Identity{
+			Identity: ctypes.Identity{
 				AccountNumber: testdata.UserID,
-				Internal: operator_utils_types.Internal{
+				Internal: ctypes.Internal{
 					OrgID: testdata.Org2ID,
 				},
 			},
@@ -1314,7 +1314,7 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	respBody := `{"data":[{"cluster":"%v"}],"meta":{"count":%v, "rule_id":"%v"},"status":"ok"}`
+	respBody := `{"data":[{"cluster":"%v", "cluster_name":""}],"meta":{"count":%v, "rule_id":"%v"},"status":"ok"}`
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.Org2ID, testdata.ClusterName, testdata.Report2Rules)
@@ -1364,7 +1364,7 @@ func TestRuleClusterDetailEndpoint_ValidParametersActiveClusters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	respBody := `{"data":[{"cluster":"%v"}],"meta":{"count":%v, "rule_id":"%v"},"status":"ok"}`
+	respBody := `{"data":[{"cluster":"%v", "cluster_name":""}],"meta":{"count":%v, "rule_id":"%v"},"status":"ok"}`
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules)

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -20,7 +20,8 @@ import (
 	"github.com/RedHatInsights/insights-content-service/content"
 	"github.com/Shopify/sarama"
 
-	utypes "github.com/RedHatInsights/insights-operator-utils/types"
+	ctypes "github.com/RedHatInsights/insights-results-types"
+
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
@@ -241,7 +242,7 @@ func (*NoopStorage) ReadReportsForClusters(clusterNames []types.ClusterName) (ma
 
 // ListOfDisabledRules function returns list of all rules disabled from a
 // specified account (noop).
-func (*NoopStorage) ListOfDisabledRules(userID types.UserID) ([]utypes.DisabledRule, error) {
+func (*NoopStorage) ListOfDisabledRules(userID types.UserID) ([]ctypes.DisabledRule, error) {
 	return nil, nil
 }
 
@@ -302,14 +303,14 @@ func (*NoopStorage) UpdateDisabledRuleJustification(
 // ReadDisabledRule function returns disabled rule (if disabled) from database
 func (*NoopStorage) ReadDisabledRule(
 	orgID types.OrgID, userID types.UserID,
-	ruleID types.RuleID, errorKey types.ErrorKey) (utypes.SystemWideRuleDisable, bool, error) {
-	return utypes.SystemWideRuleDisable{}, true, nil
+	ruleID types.RuleID, errorKey types.ErrorKey) (ctypes.SystemWideRuleDisable, bool, error) {
+	return ctypes.SystemWideRuleDisable{}, true, nil
 }
 
 // ListOfSystemWideDisabledRules function returns list of all rules that have been
 // disabled for all clusters by given user
 func (*NoopStorage) ListOfSystemWideDisabledRules(
-	orgID types.OrgID, userID types.UserID) ([]utypes.SystemWideRuleDisable, error) {
+	orgID types.OrgID, userID types.UserID) ([]ctypes.SystemWideRuleDisable, error) {
 	return nil, nil
 }
 
@@ -317,7 +318,7 @@ func (*NoopStorage) ListOfSystemWideDisabledRules(
 func (*NoopStorage) ReadRecommendationsForClusters(
 	clusterList []string,
 	orgID types.OrgID,
-) (utypes.RecommendationImpactedClusters, error) {
+) (ctypes.RecommendationImpactedClusters, error) {
 	return nil, nil
 }
 
@@ -325,6 +326,6 @@ func (*NoopStorage) ReadRecommendationsForClusters(
 // given organization that are affected by given rule
 func (*NoopStorage) ListOfClustersForOrgSpecificRule(
 	orgID types.OrgID, ruleID types.RuleSelector, activeClusters []string,
-) ([]utypes.HittingClustersData, error) {
+) ([]ctypes.HittingClustersData, error) {
 	return nil, nil
 }

--- a/storage/rule_disable.go
+++ b/storage/rule_disable.go
@@ -19,7 +19,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	utypes "github.com/RedHatInsights/insights-operator-utils/types"
+	ctypes "github.com/RedHatInsights/insights-results-types"
+
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
@@ -125,8 +126,8 @@ func (storage DBStorage) UpdateDisabledRuleJustification(
 // ReadDisabledRule function returns disabled rule (if disabled) from database
 func (storage DBStorage) ReadDisabledRule(
 	orgID types.OrgID, userID types.UserID,
-	ruleID types.RuleID, errorKey types.ErrorKey) (utypes.SystemWideRuleDisable, bool, error) {
-	var disabledRule utypes.SystemWideRuleDisable
+	ruleID types.RuleID, errorKey types.ErrorKey) (ctypes.SystemWideRuleDisable, bool, error) {
+	var disabledRule ctypes.SystemWideRuleDisable
 
 	query := `SELECT
 			 org_id,
@@ -177,8 +178,8 @@ func (storage DBStorage) ReadDisabledRule(
 // ListOfSystemWideDisabledRules function returns list of all rules that have been
 // disabled for all clusters by given user
 func (storage DBStorage) ListOfSystemWideDisabledRules(
-	orgID types.OrgID, userID types.UserID) ([]utypes.SystemWideRuleDisable, error) {
-	disabledRules := make([]utypes.SystemWideRuleDisable, 0)
+	orgID types.OrgID, userID types.UserID) ([]ctypes.SystemWideRuleDisable, error) {
+	disabledRules := make([]ctypes.SystemWideRuleDisable, 0)
 	query := `SELECT
 			 org_id,
 			 user_id,
@@ -202,7 +203,7 @@ func (storage DBStorage) ListOfSystemWideDisabledRules(
 	defer closeRows(rows)
 
 	for rows.Next() {
-		var disabledRule utypes.SystemWideRuleDisable
+		var disabledRule ctypes.SystemWideRuleDisable
 
 		err = rows.Scan(&disabledRule.OrgID,
 			&disabledRule.UserID,

--- a/storage/rule_list.go
+++ b/storage/rule_list.go
@@ -19,7 +19,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	utypes "github.com/RedHatInsights/insights-operator-utils/types"
+	ctypes "github.com/RedHatInsights/insights-results-types"
+
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
@@ -86,8 +87,8 @@ func (storage DBStorage) ListOfReasons(userID types.UserID) ([]DisabledRuleReaso
 
 // ListOfDisabledRules function returns list of all rules disabled from a
 // specified account.
-func (storage DBStorage) ListOfDisabledRules(userID types.UserID) ([]utypes.DisabledRule, error) {
-	disabledRules := make([]utypes.DisabledRule, 0)
+func (storage DBStorage) ListOfDisabledRules(userID types.UserID) ([]ctypes.DisabledRule, error) {
+	disabledRules := make([]ctypes.DisabledRule, 0)
 	query := `SELECT
                          cluster_id,
 			 rule_id,
@@ -112,7 +113,7 @@ func (storage DBStorage) ListOfDisabledRules(userID types.UserID) ([]utypes.Disa
 	defer closeRows(rows)
 
 	for rows.Next() {
-		var disabledRule utypes.DisabledRule
+		var disabledRule ctypes.DisabledRule
 
 		err = rows.Scan(&disabledRule.ClusterID,
 			&disabledRule.RuleID,

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -19,14 +19,15 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	utypes "github.com/RedHatInsights/insights-operator-utils/types"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
+	utypes "github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	ctypes "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -771,7 +772,7 @@ func TestDBStorageListClustersForHittingRules(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	clusterIds := []utypes.ClusterName{
+	clusterIds := []ctypes.ClusterName{
 		testdata.GetRandomClusterID(),
 		testdata.GetRandomClusterID(),
 		testdata.GetRandomClusterID(),
@@ -791,26 +792,26 @@ func TestDBStorageListClustersForHittingRules(t *testing.T) {
 
 	//Rule1|ERR_KEY1 is present in testdata.Report3Rules and testdata.Report2Rules,
 	//but only clusters for testdata.OrgID are returned
-	expectedClustersOrg1Rule1Err1 := []utypes.HittingClustersData{
+	expectedClustersOrg1Rule1Err1 := []ctypes.HittingClustersData{
 		{Cluster: clusterIds[0]},
 	}
 	//Rule2|ERR_KEY2 is present in testdata.Report3Rules and testdata.Report2Rules,
 	//but only clusters for testdata.OrgID are returned
-	expectedClustersOrg1Rule2Err2 := []utypes.HittingClustersData{
+	expectedClustersOrg1Rule2Err2 := []ctypes.HittingClustersData{
 		{Cluster: clusterIds[0]},
 	}
 	//Rule3|ERR_KEY3 is present in testdata.Report3Rules
-	expectedClustersOrg1Rule3Err3 := []utypes.HittingClustersData{
+	expectedClustersOrg1Rule3Err3 := []ctypes.HittingClustersData{
 		{Cluster: clusterIds[0]},
 	}
 	//Rule1|ERR_KEY1 is present in testdata.Report3Rules and testdata.Report2Rules,
 	//but only clusters for testdata.Org2ID are returned
-	expectedClustersOrg2Rule1Err1 := []utypes.HittingClustersData{
+	expectedClustersOrg2Rule1Err1 := []ctypes.HittingClustersData{
 		{Cluster: clusterIds[2]},
 	}
 	//Rule2|ERR_KEY2 is present in testdata.Report3Rules and testdata.Report2Rules,
 	//but only clusters for testdata.Org2ID are returned
-	expectedClustersOrg2Rule2Err2 := []utypes.HittingClustersData{
+	expectedClustersOrg2Rule2Err2 := []ctypes.HittingClustersData{
 		{Cluster: clusterIds[2]},
 	}
 
@@ -842,12 +843,12 @@ func TestDBStorageListClustersForHittingRules(t *testing.T) {
 	list, err = mockStorage.ListOfClustersForOrgSpecificRule(testdata.OrgID, types.RuleSelector(testdata.Rule1CompositeID), []string{string(clusterIds[1]), string(clusterIds[2])})
 	assert.Error(t, err)
 	assert.IsType(t, &utypes.ItemNotFoundError{}, err)
-	assert.Equal(t, []utypes.HittingClustersData{}, list)
+	assert.Equal(t, []ctypes.HittingClustersData{}, list)
 
 	list, err = mockStorage.ListOfClustersForOrgSpecificRule(testdata.Org2ID, types.RuleSelector(testdata.Rule1CompositeID), []string{string(clusterIds[0]), string(clusterIds[1])})
 	assert.Error(t, err)
 	assert.IsType(t, &utypes.ItemNotFoundError{}, err)
-	assert.Equal(t, []utypes.HittingClustersData{}, list)
+	assert.Equal(t, []ctypes.HittingClustersData{}, list)
 }
 
 // TestDBStorageListClustersForHittingRulesOrgNotFound checks that an empty
@@ -864,7 +865,7 @@ func TestDBStorageListClustersForHittingRulesOrgNotFound(t *testing.T) {
 	list, err := mockStorage.ListOfClustersForOrgSpecificRule(testdata.Org2ID, types.RuleSelector(testdata.Rule1CompositeID), nil)
 	assert.Error(t, err)
 	assert.IsType(t, &utypes.ItemNotFoundError{}, err)
-	assert.Equal(t, []utypes.HittingClustersData{}, list)
+	assert.Equal(t, []ctypes.HittingClustersData{}, list)
 }
 
 // TestDBStorageListClustersForHittingRulesOrgNotFound checks that an empty
@@ -883,12 +884,12 @@ func TestDBStorageListClustersForHittingRulesRuleNotFound(t *testing.T) {
 	list, err := mockStorage.ListOfClustersForOrgSpecificRule(testdata.OrgID, types.RuleSelector(testdata.Rule3CompositeID), nil)
 	assert.Error(t, err)
 	assert.IsType(t, &utypes.ItemNotFoundError{}, err)
-	assert.Equal(t, []utypes.HittingClustersData{}, list)
+	assert.Equal(t, []ctypes.HittingClustersData{}, list)
 
 	list, err = mockStorage.ListOfClustersForOrgSpecificRule(testdata.OrgID, types.RuleSelector(testdata.Rule3CompositeID), []string{string(testdata.GetRandomClusterID())})
 	assert.Error(t, err)
 	assert.IsType(t, &utypes.ItemNotFoundError{}, err)
-	assert.Equal(t, []utypes.HittingClustersData{}, list)
+	assert.Equal(t, []ctypes.HittingClustersData{}, list)
 }
 
 // TestDBStorageListClustersForHittingRulesNoRowsFound checks that an empty
@@ -903,7 +904,7 @@ func TestDBStorageListClustersForHittingRulesNoRowsFound(t *testing.T) {
 	list, err := mockStorage.ListOfClustersForOrgSpecificRule(testdata.OrgID, types.RuleSelector(testdata.Rule3CompositeID), nil)
 	assert.Error(t, err)
 	assert.IsType(t, &utypes.ItemNotFoundError{}, err)
-	assert.Equal(t, []utypes.HittingClustersData{}, list)
+	assert.Equal(t, []ctypes.HittingClustersData{}, list)
 }
 
 // TestDBStorageListClustersForHittingRulesNoRowsFound checks that an empty
@@ -920,5 +921,5 @@ func TestDBStorageListFilteredClustersForHittingRulesNoRowsFound(t *testing.T) {
 	list, err := mockStorage.ListOfClustersForOrgSpecificRule(testdata.OrgID, types.RuleSelector(testdata.Rule3CompositeID), []string{string(testdata.ClusterName)})
 	assert.Error(t, err)
 	assert.IsType(t, &utypes.ItemNotFoundError{}, err)
-	assert.Equal(t, []utypes.HittingClustersData{}, list)
+	assert.Equal(t, []ctypes.HittingClustersData{}, list)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
-	utypes "github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	ctypes "github.com/RedHatInsights/insights-results-types"
 	"github.com/Shopify/sarama"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -1173,8 +1173,8 @@ func TestDBStorageReadRecommendationsForClusters(t *testing.T) {
 	)
 	helpers.FailOnError(t, err)
 
-	expectingImpactedC := utypes.ImpactedClustersCnt(1)
-	expect := utypes.RecommendationImpactedClusters{
+	expectingImpactedC := ctypes.ImpactedClustersCnt(1)
+	expect := ctypes.RecommendationImpactedClusters{
 		testdata.Rule1CompositeID: expectingImpactedC,
 		testdata.Rule2CompositeID: expectingImpactedC,
 		testdata.Rule3CompositeID: expectingImpactedC,
@@ -1215,11 +1215,11 @@ func TestDBStorageReadRecommendationsForClustersMoreClusters(t *testing.T) {
 	)
 	helpers.FailOnError(t, err)
 
-	expect2Impacted := utypes.ImpactedClustersCnt(2)
-	expect := utypes.RecommendationImpactedClusters{
+	expect2Impacted := ctypes.ImpactedClustersCnt(2)
+	expect := ctypes.RecommendationImpactedClusters{
 		testdata.Rule1CompositeID: expect2Impacted,
 		testdata.Rule2CompositeID: expect2Impacted,
-		testdata.Rule3CompositeID: utypes.ImpactedClustersCnt(1),
+		testdata.Rule3CompositeID: ctypes.ImpactedClustersCnt(1),
 	}
 
 	res, err := mockStorage.ReadRecommendationsForClusters(clusterList, testdata.OrgID)
@@ -1239,7 +1239,7 @@ func TestDBStorageReadRecommendationsForClustersNoRecommendations(t *testing.T) 
 	)
 	helpers.FailOnError(t, err)
 
-	expect := utypes.RecommendationImpactedClusters{}
+	expect := ctypes.RecommendationImpactedClusters{}
 
 	res, err := mockStorage.ReadRecommendationsForClusters([]string{string(testdata.ClusterName)}, testdata.OrgID)
 	helpers.FailOnError(t, err)
@@ -1257,7 +1257,7 @@ func TestDBStorageReadRecommendationsForClustersEmptyList_Reproducer(t *testing.
 	)
 	helpers.FailOnError(t, err)
 
-	expect := utypes.RecommendationImpactedClusters{}
+	expect := ctypes.RecommendationImpactedClusters{}
 
 	res, err := mockStorage.ReadRecommendationsForClusters([]string{}, testdata.OrgID)
 
@@ -1287,8 +1287,8 @@ func TestDBStorageReadRecommendationsGetSelectedClusters(t *testing.T) {
 	res, err := mockStorage.ReadRecommendationsForClusters([]string{string(clusterList[0])}, testdata.OrgID)
 	helpers.FailOnError(t, err)
 
-	expect1Impacted := utypes.ImpactedClustersCnt(1)
-	expect := utypes.RecommendationImpactedClusters{
+	expect1Impacted := ctypes.ImpactedClustersCnt(1)
+	expect := ctypes.RecommendationImpactedClusters{
 		testdata.Rule1CompositeID: expect1Impacted,
 		testdata.Rule2CompositeID: expect1Impacted,
 		testdata.Rule3CompositeID: expect1Impacted,
@@ -1315,5 +1315,5 @@ func TestDBStorageReadRecommendationsForNonexistingClusters(t *testing.T) {
 	res, err := mockStorage.ReadRecommendationsForClusters(clusterList, testdata.OrgID)
 	helpers.FailOnError(t, err)
 
-	assert.Equal(t, utypes.RecommendationImpactedClusters{}, res)
+	assert.Equal(t, ctypes.RecommendationImpactedClusters{}, res)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"github.com/RedHatInsights/insights-operator-utils/types"
+	types "github.com/RedHatInsights/insights-results-types"
 )
 
 // OrgID represents organization ID


### PR DESCRIPTION
# Description

Using `insights-results-types` repository for type definitions.
Adapted current unit tests to new fields in those types

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Run `make before_commit`

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
