### PR TITLE
Adding aggregator part for OCP Advisor Clusters view (Milestone 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
 	github.com/RedHatInsights/insights-operator-utils v1.22.0
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.3
-	github.com/RedHatInsights/insights-results-types v1.2.0
+	github.com/RedHatInsights/insights-results-types v1.3.1
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,9 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.2/go.mod h1:E1UaB+IjJ/muxvMstVoqJrB82zVKNykjTtCiM3tMHoM=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.3 h1:K6j+Sr+S0iUqFEfevl+MI0dEXn5AxFeJn9FTU5razWA=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHNC7lBxYnu9AqMahABqvuclCzWUWSkbacQbUaehfI=
-github.com/RedHatInsights/insights-results-types v1.2.0 h1:tFaGQE2h/4OIhf8sI/lRwJ/Fh0soO7a47de9x4irIJs=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.1 h1:dctLHdEHsZuK1R0TTFomkYJHIk6je2okbrmMBnHWvAQ=
+github.com/RedHatInsights/insights-results-types v1.3.1/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/openapi.json
+++ b/openapi.json
@@ -1287,6 +1287,99 @@
         }
       }
     },
+    "/clusters/organizations/{org_id}/users/{user_id}/recommendations": {
+      "post": {
+        "summary": "getClustersRecommendationsList retrieves all hitting recommendations for all clusters given in the POST body",
+        "operationId": "getClustersRecommendationsPost",
+        "description": "Recommendations will be retrieved based on the list of cluster IDs that is part of request body.",
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "path",
+            "description": "Organization ID represented as positive integer",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "description": "Numeric ID of the user. An example: `42`",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "List of cluster IDs. An example: `34c3ecc5-624a-49a5-bab8-4fdc5e51a266.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Map of clusters and a list of hitting recommendations for corresponding clusters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "clusters": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "created_at": {
+                            "type": "string",
+                            "description": "The cluster ID in UUID format."
+                          },
+                          "recommendations": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "description": "The recommendation ID.",
+                              "example": "rule.module|ERROR_KEY"
+                            }
+                          }
+                        }
+                      },
+                      "example": {
+                        "1234ecc5-624a-49a5-bab8-4fdc5e51a266": {
+                          "created_at": "2021-09-07T15:50+00Z",
+                          "recommendations": [
+                            "rule.module1|ERROR_KEY1",
+                            "rule.module2|ERROR_KEY2"
+                          ]
+                        },
+                        "5678ecc5-624a-49a5-bab8-4fdc5e51a266": {
+                          "created_at": "2021-09-07T15:50+00Z",
+                          "recommendations": [
+                            "rule.module1|ERROR_KEY1",
+                            "rule.module2|ERROR_KEY2"
+                          ]
+                        }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/rules/users/{userId}/disabled": {
       "get": {
         "summary": "Returns a list of rules disabled from current account",

--- a/openapi.json
+++ b/openapi.json
@@ -1339,14 +1339,17 @@
                         "properties": {
                           "created_at": {
                             "type": "string",
-                            "description": "The cluster ID in UUID format."
+                            "description": "The time of last analysis for this cluster."
                           },
                           "recommendations": {
                             "type": "array",
                             "items": {
                               "type": "string",
-                              "description": "The recommendation ID.",
-                              "example": "rule.module|ERROR_KEY"
+                              "description": "The array of recommendation IDs",
+                              "example": [
+                                "rule.module|ERROR_KEY",
+                                "rule.another.module|SPECIFIC_KEY"
+                              ]
                             }
                           }
                         }

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -81,6 +81,8 @@ const (
 
 	// RecommendationsListEndpoint receives a list of clusters in POST body and returns a list of all recommendations hitting for them
 	RecommendationsListEndpoint = "recommendations/organizations/{org_id}/users/{user_id}/list"
+	// ClustersRecommendationsListEndpoint receives a list of clusters in POST body and returns a list of clusters with lists of hitting recommendations
+	ClustersRecommendationsListEndpoint = "clusters/organizations/{org_id}/users/{user_id}/recommendations"
 
 	// Rating accepts a list of ratings in the request body and store them in the database for the given user
 	Rating = "rules/organizations/{org_id}/users/{user_id}/rating"
@@ -166,4 +168,5 @@ func (server *HTTPServer) addRuleEnableDisableEndpointsToRouter(router *mux.Rout
 // are related to the Insights Advisor application
 func (server *HTTPServer) addInsightsAdvisorEndpointsToRouter(router *mux.Router, apiPrefix string) {
 	router.HandleFunc(apiPrefix+RecommendationsListEndpoint, server.getRecommendations).Methods(http.MethodPost, http.MethodOptions)
+	router.HandleFunc(apiPrefix+ClustersRecommendationsListEndpoint, server.getClustersRecommendationsList).Methods(http.MethodPost, http.MethodOptions)
 }

--- a/server/reports.go
+++ b/server/reports.go
@@ -305,7 +305,7 @@ func (server *HTTPServer) getRecommendations(writer http.ResponseWriter, request
 	}
 }
 
-// getClustersRecommendationsList retrieves all recommendations hitting for all clusters in the org
+// getClustersRecommendationsList retrieves all recommendations hitting for all clusters specified in the request body
 func (server *HTTPServer) getClustersRecommendationsList(writer http.ResponseWriter, request *http.Request) {
 	tStart := time.Now()
 

--- a/storage/consts.go
+++ b/storage/consts.go
@@ -25,10 +25,10 @@ const (
 	selectorsKey = "selectors"
 	// key for recommendations' creation time
 	createdAtKey = "created_at"
-
 	// closeStatementError error string
 	closeStatementError = "Unable to close statement"
-
 	// inClauseError when constructing IN clause fails
 	inClauseError = "error constructing WHERE IN clause"
+	// recommendationTimestampFormat represents the datetime format of the created_at of recommendation table
+	recommendationTimestampFormat = "2006-01-02 15:04:05.000000000+00:00"
 )

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -35,8 +35,9 @@ import (
 type SQLHooks = sqlHooks
 
 const (
-	LogFormatterString        = logFormatterString
-	SQLHooksKeyQueryBeginTime = sqlHooksKeyQueryBeginTime
+	LogFormatterString            = logFormatterString
+	SQLHooksKeyQueryBeginTime     = sqlHooksKeyQueryBeginTime
+	RecommendationTimestampFormat = recommendationTimestampFormat
 )
 
 var (

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -329,3 +329,10 @@ func (*NoopStorage) ListOfClustersForOrgSpecificRule(
 ) ([]ctypes.HittingClustersData, error) {
 	return nil, nil
 }
+
+// ReadClusterListRecommendations retrieves cluster IDs and a list of hitting rules for each one
+func (*NoopStorage) ReadClusterListRecommendations(
+	clusterList []string, orgID types.OrgID,
+) (ctypes.ClusterRecommendationMap, error) {
+	return nil, nil
+}

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -90,4 +90,6 @@ func TestNoopStorage_Methods_Cont2(t *testing.T) {
 	_, _ = noopStorage.ListOfSystemWideDisabledRules(orgID, userID)
 	_, _ = noopStorage.ListOfClustersForOrgSpecificRule(0, "", nil)
 	_, _ = noopStorage.ListOfClustersForOrgSpecificRule(0, "", []string{"a"})
+	_, _ = noopStorage.ReadRecommendationsForClusters([]string{}, types.OrgID(1))
+	_, _ = noopStorage.ReadClusterListRecommendations([]string{}, types.OrgID(1))
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -185,6 +185,9 @@ type Storage interface {
 	ListOfSystemWideDisabledRules(
 		orgID types.OrgID, userID types.UserID) ([]ctypes.SystemWideRuleDisable, error)
 	ReadRecommendationsForClusters([]string, types.OrgID) (ctypes.RecommendationImpactedClusters, error)
+	ReadClusterListRecommendations(clusterList []string, orgID types.OrgID) (
+		ctypes.ClusterRecommendationMap, error,
+	)
 }
 
 // DBStorage is an implementation of Storage interface that use selected SQL like database
@@ -1045,20 +1048,6 @@ func (storage DBStorage) ReadRecommendationsForClusters(
 		return recommendationsMap, err
 	}
 
-	if storage.dbDriverType != types.DBDriverSQLite3 {
-		// EXPLAIN query to check performance and index usage
-		explRows, err := storage.connection.Query("EXPLAIN ANALYZE "+query, orgID)
-		if err != nil {
-			log.Error().Err(err).Msg("error explaining query")
-			return recommendationsMap, err
-		}
-		for explRows.Next() {
-			var step string
-			_ = explRows.Scan(&step)
-			log.Info().Msgf("EXPLAIN ReadRecommendationsForClusters: %v", step)
-		}
-	}
-
 	for rows.Next() {
 		var (
 			ruleID      types.RuleID
@@ -1078,6 +1067,64 @@ func (storage DBStorage) ReadRecommendationsForClusters(
 	}
 
 	return recommendationsMap, nil
+}
+
+// ReadClusterListRecommendations retrieves cluster IDs and a list of hitting rules for each one
+func (storage DBStorage) ReadClusterListRecommendations(
+	clusterList []string,
+	orgID types.OrgID,
+) (ctypes.ClusterRecommendationMap, error) {
+
+	clusterMap := make(ctypes.ClusterRecommendationMap, 0)
+
+	if len(clusterList) < 1 {
+		return clusterMap, nil
+	}
+
+	// disable "G202 (CWE-89): SQL string concatenation"
+	// #nosec G202
+	query := `
+	SELECT
+		cluster_id, rule_id, created_at
+	FROM
+		recommendation
+	WHERE org_id = $1 AND cluster_id IN (%v)`
+	// #nosec G201
+	query = fmt.Sprintf(query, inClauseFromSlice(clusterList))
+
+	rows, err := storage.connection.Query(query, orgID)
+	if err != nil {
+		log.Error().Err(err).Msg("query to get recommendations")
+		return clusterMap, err
+	}
+
+	for rows.Next() {
+		var row ctypes.RecommendationRow
+
+		err := rows.Scan(
+			&row.ClusterID,
+			&row.RuleID,
+			&row.CreatedAt,
+		)
+		if err != nil {
+			log.Error().Err(err).Msg("read one recommendation")
+			return clusterMap, err
+		}
+
+		if cluster, exists := clusterMap[row.ClusterID]; exists {
+			cluster.Recommendations = append(cluster.Recommendations, row.RuleID)
+			clusterMap[row.ClusterID] = cluster
+		} else {
+			// create entry in map for new cluster ID
+			clusterMap[row.ClusterID] = ctypes.ClusterRecommendationList{
+				// created at is the same for all rows for each cluster
+				CreatedAt:       row.CreatedAt,
+				Recommendations: []ctypes.RuleID{row.RuleID},
+			}
+		}
+
+	}
+	return clusterMap, nil
 }
 
 // ReportsCount reads number of all records stored in database

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1391,12 +1391,8 @@ func TestDBStorageReadClusterListRecommendationsGet1Cluster(t *testing.T) {
 	expectedClusterID := types.ClusterName(clusterList[0])
 	assert.Contains(t, res, expectedClusterID)
 	assert.ElementsMatch(t, expectList, res[expectedClusterID].Recommendations)
-
-	/*
-		parsedTimestamp, err := time.Parse("2021-01-01 13:39:35.715453148+00:00", res[expectedClusterID].CreatedAt)
-		helpers.FailOnError(t, err)
-		assert.True(t, time.Now().Add(-time.Hour).Before(parsedTimestamp))
-	*/
+	// trivial timestamp check
+	assert.True(t, res[expectedClusterID].CreatedAt.After(time.Now().Add(-time.Hour)))
 }
 
 // TestDBStorageReadClusterListRecommendationsGet1Cluster loads several recommendations for the same org
@@ -1433,4 +1429,6 @@ func TestDBStorageReadClusterListRecommendationsGetMoreClusters(t *testing.T) {
 	assert.Contains(t, res, expectedCluster2ID)
 	assert.ElementsMatch(t, expectRuleList, res[expectedCluster1ID].Recommendations)
 	assert.ElementsMatch(t, expectRuleList, res[expectedCluster2ID].Recommendations)
+	assert.True(t, res[expectedCluster1ID].CreatedAt.After(time.Now().Add(-time.Hour)))
+	assert.True(t, res[expectedCluster2ID].CreatedAt.After(time.Now().Add(-time.Hour)))
 }


### PR DESCRIPTION
# Description
Needed for https://issues.redhat.com/browse/CCXDEV-6486
1st part of Clusters View in OCP Adivsor, the new endpoint returns a map of cluster IDs and a list of hitting rule IDs for each cluster.

Fixes CCXDEV-6486

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- REST API tests

## Testing steps
`make test` currently doesn't pass against sqlite

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
