### PR TITLE
fix sqlite/psql different behaviour

### DIFF
--- a/storage/consts.go
+++ b/storage/consts.go
@@ -30,5 +30,5 @@ const (
 	// inClauseError when constructing IN clause fails
 	inClauseError = "error constructing WHERE IN clause"
 	// recommendationTimestampFormat represents the datetime format of the created_at of recommendation table
-	recommendationTimestampFormat = "2006-01-02 15:04:05.000000000+00:00"
+	recommendationTimestampFormat = "2006-01-02 15:04:05+00:00"
 )

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1114,7 +1114,7 @@ func (storage DBStorage) ReadClusterListRecommendations(
 				&timestamp,
 			)
 			if err != nil {
-				log.Error().Err(err).Msg("read one recommendation")
+				log.Error().Err(err).Msg("problem reading one recommendation")
 				return clusterMap, err
 			}
 		} else {
@@ -1125,7 +1125,7 @@ func (storage DBStorage) ReadClusterListRecommendations(
 				&timestampStr,
 			)
 			if err != nil {
-				log.Error().Err(err).Msg("read one recommendation")
+				log.Error().Err(err).Msg("problem reading one recommendation")
 				return clusterMap, err
 			}
 


### PR DESCRIPTION
# Description
the `created_at` column is behaving differently when being selected by SQLite driver and PSQL driver. 
PostgreSQL is able to autoparse the column into time.Time directly whereas SQLite needs manual time parse.

This PR fixes the behaviour for both drivers, it's not the prettiest solution in the world, but we shouldn't even test on SQLite when all environments use postgres.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
`make before_commit` + calling the endpoint from smart-proxy with both SQLite and PostgreSQL running

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
