### PR TITLE
Bump-up types to 1.3.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
 	github.com/RedHatInsights/insights-operator-utils v1.22.0
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.3
-	github.com/RedHatInsights/insights-results-types v1.3.1
+	github.com/RedHatInsights/insights-results-types v1.3.3
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHN
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.1 h1:dctLHdEHsZuK1R0TTFomkYJHIk6je2okbrmMBnHWvAQ=
 github.com/RedHatInsights/insights-results-types v1.3.1/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.3 h1:dJAik1xUQoOYCVitPF20M+iWJOi76FPcCR1ylISw/wo=
+github.com/RedHatInsights/insights-results-types v1.3.3/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=


### PR DESCRIPTION
# Description

Bump-up `types` to 1.3.3

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
