### PR TITLE
Metainfo endpoint 1st step - read `stored_at` attribute from database

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -150,7 +150,7 @@ func (server *HTTPServer) readReportForCluster(writer http.ResponseWriter, reque
 		return
 	}
 
-	reports, lastChecked, err := server.Storage.ReadReportForCluster(orgID, clusterName)
+	reports, lastChecked, _, err := server.Storage.ReadReportForCluster(orgID, clusterName)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to read report for cluster")
 		handleServerError(writer, err)

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -49,8 +49,8 @@ func (*NoopStorage) ListOfClustersForOrg(types.OrgID, time.Time) ([]types.Cluste
 }
 
 // ReadReportForCluster noop
-func (*NoopStorage) ReadReportForCluster(types.OrgID, types.ClusterName) ([]types.RuleOnReport, types.Timestamp, error) {
-	return []types.RuleOnReport{}, "", nil
+func (*NoopStorage) ReadReportForCluster(types.OrgID, types.ClusterName) ([]types.RuleOnReport, types.Timestamp, types.Timestamp, error) {
+	return []types.RuleOnReport{}, "", "", nil
 }
 
 // ReadSingleRuleTemplateData noop

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -33,7 +33,7 @@ func TestNoopStorage_Methods(t *testing.T) {
 	_ = noopStorage.Close()
 	_, _ = noopStorage.ListOfOrgs()
 	_, _ = noopStorage.ListOfClustersForOrg(0, time.Now())
-	_, _, _ = noopStorage.ReadReportForCluster(0, "")
+	_, _, _, _ = noopStorage.ReadReportForCluster(0, "")
 	_, _, _ = noopStorage.ReadReportForClusterByClusterName("")
 	_, _ = noopStorage.GetLatestKafkaOffset()
 	_ = noopStorage.WriteReportForCluster(0, "", "", []types.ReportItem{}, time.Now(), time.Now(), 0)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -59,7 +59,7 @@ func checkReportForCluster(
 	expected []types.RuleOnReport,
 ) {
 	// try to read report for cluster
-	result, _, err := s.ReadReportForCluster(orgID, clusterName)
+	result, _, _, err := s.ReadReportForCluster(orgID, clusterName)
 	helpers.FailOnError(t, err)
 
 	// and check the read report with expected one
@@ -104,7 +104,7 @@ func TestDBStorageReadReportForClusterEmptyTable(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	_, _, err := mockStorage.ReadReportForCluster(testdata.OrgID, testdata.ClusterName)
+	_, _, _, err := mockStorage.ReadReportForCluster(testdata.OrgID, testdata.ClusterName)
 	if _, ok := err.(*types.ItemNotFoundError); err == nil || !ok {
 		t.Fatalf("expected ItemNotFoundError, got %T, %+v", err, err)
 	}
@@ -125,7 +125,7 @@ func TestDBStorageReadReportForClusterClosedStorage(t *testing.T) {
 	// we need to close storage right now
 	closer()
 
-	_, _, err := mockStorage.ReadReportForCluster(testdata.OrgID, testdata.ClusterName)
+	_, _, _, err := mockStorage.ReadReportForCluster(testdata.OrgID, testdata.ClusterName)
 	assert.EqualError(t, err, "sql: database is closed")
 }
 
@@ -206,7 +206,7 @@ func TestDBStorageReadReportNoTable(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, false)
 	defer closer()
 
-	_, _, err := mockStorage.ReadReportForCluster(testdata.OrgID, testdata.ClusterName)
+	_, _, _, err := mockStorage.ReadReportForCluster(testdata.OrgID, testdata.ClusterName)
 	assert.EqualError(t, err, "no such table: report")
 }
 
@@ -305,7 +305,7 @@ func TestDBStorageClusterOrgTransfer(t *testing.T) {
 	assert.Equal(t, orgID, testdata.Org2ID)
 
 	// org2 can read cluster2
-	_, _, err = mockStorage.ReadReportForCluster(testdata.Org2ID, cluster2ID)
+	_, _, _, err = mockStorage.ReadReportForCluster(testdata.Org2ID, cluster2ID)
 	helpers.FailOnError(t, err)
 
 	// "org transfer"
@@ -322,11 +322,11 @@ func TestDBStorageClusterOrgTransfer(t *testing.T) {
 	assert.Equal(t, orgID, testdata.OrgID)
 
 	// org2 can no longer read cluster2
-	_, _, err = mockStorage.ReadReportForCluster(testdata.Org2ID, cluster2ID)
+	_, _, _, err = mockStorage.ReadReportForCluster(testdata.Org2ID, cluster2ID)
 	assert.NotNil(t, err)
 
 	// org1 can now  read cluster2
-	_, _, err = mockStorage.ReadReportForCluster(testdata.OrgID, cluster2ID)
+	_, _, _, err = mockStorage.ReadReportForCluster(testdata.OrgID, cluster2ID)
 	helpers.FailOnError(t, err)
 }
 


### PR DESCRIPTION
# Description

Metainfo endpoint 1st step - read `stored_at` attribute from database

## Type of change

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
