### PR TITLE
[CCXDEV-6146] Start using PostgreSQL in unit tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ 
+version: "3"
+services:
+  db:
+    ports:
+      - 5432:5432
+    image: registry.redhat.io/rhscl/postgresql-12-rhel7
+    environment:
+      - POSTGRESQL_USER=user
+      - POSTGRESQL_PASSWORD=password
+      - POSTGRESQL_ADMIN_PASSWORD=admin
+      - POSTGRESQL_DATABASE=aggregator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   db:
     ports:
       - 5432:5432
-    image: registry.redhat.io/rhscl/postgresql-12-rhel7
+    image: registry.redhat.io/rhscl/postgresql-10-rhel7
     environment:
       - POSTGRESQL_USER=user
       - POSTGRESQL_PASSWORD=password

--- a/migration/actual_migrations_test.go
+++ b/migration/actual_migrations_test.go
@@ -633,8 +633,8 @@ func TestMigration20(t *testing.T) {
 		&ruleFQDN, &ruleID,
 	)
 	helpers.FailOnError(t, err)
-	assert.Equal(t, testdata.Rule1ID, ruleFQDN)
-	assert.Equal(t, testdata.Rule1CompositeID, ruleID)
+	assert.Equal(t, testdata.Rule1ID, types.RuleID(ruleFQDN))
+	assert.Equal(t, testdata.Rule1CompositeID, types.RuleID(ruleID))
 
 	//Step down should rename rule_fqdn column to rule_id and it contains only plugin name
 	err = migration.SetDBVersion(db, dbDriver, 19)
@@ -654,5 +654,5 @@ func TestMigration20(t *testing.T) {
 		&ruleID,
 	)
 	helpers.FailOnError(t, err)
-	assert.Equal(t, testdata.Rule1ID, ruleID)
+	assert.Equal(t, testdata.Rule1ID, types.RuleID(ruleID))
 }

--- a/storage/rule_disable_test.go
+++ b/storage/rule_disable_test.go
@@ -64,7 +64,11 @@ func TestDBStorageDisableRuleSystemWideDoubleDisable(t *testing.T) {
 		"x")
 
 	// we expect the error to happen
-	assert.EqualError(t, err, "UNIQUE constraint failed: rule_disable.user_id, rule_disable.org_id, rule_disable.rule_id, rule_disable.error_key")
+	const sqliteErrMessage = "UNIQUE constraint failed: rule_disable.user_id, rule_disable.org_id, rule_disable.rule_id, rule_disable.error_key"
+	const postgresErrMessage = "pq: duplicate key value violates unique constraint \"rule_disable_pkey\""
+	if err.Error() != sqliteErrMessage && err.Error() != postgresErrMessage {
+		t.Fatalf("expected one of: \n%v\n%v\ngot:\n%v", sqliteErrMessage, postgresErrMessage, err.Error())
+	}
 
 	// close storage
 	closer()

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -616,9 +616,9 @@ func TestDBStorageVoteOnRuleDBExecError(t *testing.T) {
 	err = mockStorage.VoteOnRule("non int", testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID, types.UserVoteNone, "")
 	assert.Error(t, err)
 	const sqliteErrMessage = "CHECK constraint failed: cluster_rule_user_feedback"
-	const postgresErrMessage = "pq: invalid input syntax for integer"
+	const postgresErrMessage = "pq: invalid input syntax for type integer: \"non int\""
 	if err.Error() != sqliteErrMessage && !strings.HasPrefix(err.Error(), postgresErrMessage) {
-		t.Fatalf("expected on of: \n%v\n%v\ngot:\n%v", sqliteErrMessage, postgresErrMessage, err.Error())
+		t.Fatalf("expected one of: \n%v\n%v\ngot:\n%v", sqliteErrMessage, postgresErrMessage, err.Error())
 	}
 }
 

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -616,7 +616,7 @@ func TestDBStorageVoteOnRuleDBExecError(t *testing.T) {
 	err = mockStorage.VoteOnRule("non int", testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID, types.UserVoteNone, "")
 	assert.Error(t, err)
 	const sqliteErrMessage = "CHECK constraint failed: cluster_rule_user_feedback"
-	const postgresErrMessage = "pq: invalid input syntax for type integer: \"non int\""
+	const postgresErrMessage = "pq: invalid input syntax for integer: \"non int\""
 	if err.Error() != sqliteErrMessage && !strings.HasPrefix(err.Error(), postgresErrMessage) {
 		t.Fatalf("expected one of: \n%v\n%v\ngot:\n%v", sqliteErrMessage, postgresErrMessage, err.Error())
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -365,7 +365,7 @@ func TestDBStorageWriteReportForClusterExecError(t *testing.T) {
 	assert.Error(t, err)
 
 	const sqliteErrMessage = "CHECK constraint failed: report"
-	const postgresErrMessage = "pq: invalid input syntax for type integer"
+	const postgresErrMessage = "pq: invalid input syntax for integer"
 	if err.Error() != sqliteErrMessage && !strings.HasPrefix(err.Error(), postgresErrMessage) {
 		t.Fatalf("expected on of: \n%v\n%v\ngot:\n%v", sqliteErrMessage, postgresErrMessage, err.Error())
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -365,7 +365,7 @@ func TestDBStorageWriteReportForClusterExecError(t *testing.T) {
 	assert.Error(t, err)
 
 	const sqliteErrMessage = "CHECK constraint failed: report"
-	const postgresErrMessage = "pq: invalid input syntax for integer"
+	const postgresErrMessage = "pq: invalid input syntax for type integer"
 	if err.Error() != sqliteErrMessage && !strings.HasPrefix(err.Error(), postgresErrMessage) {
 		t.Fatalf("expected on of: \n%v\n%v\ngot:\n%v", sqliteErrMessage, postgresErrMessage, err.Error())
 	}

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -17,7 +17,7 @@ STORAGE=$1
 
 function run_unit_tests() {
     # shellcheck disable=SC2046
-    if ! go test -timeout 2m -coverprofile coverage.out $(go list ./... | grep -v tests | tr '\n' ' ')
+    if ! go test -timeout 3m -coverprofile coverage.out $(go list ./... | grep -v tests | tr '\n' ' ')
     then
         echo "unit tests failed"
         exit 1

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -28,7 +28,8 @@ if [ -z "$STORAGE" ] ; then
     # tests with sqlite
     echo "running unit tests with sqlite in memory"
     # shellcheck disable=SC2034
-    CONFIG_FILE=config.toml
+    path_to_config=$(pwd)/config.toml
+    export INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE="$path_to_config"
     run_unit_tests
 fi
 
@@ -36,6 +37,9 @@ if [ "$STORAGE" == "postgres" ]; then
     # tests with postgres
     echo "running unit tests with postgres"
     # shellcheck disable=SC2034
-    CONFIG_FILE=config-devel.toml
+    path_to_config=$(pwd)/config-devel.toml
+    export INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE="$path_to_config"
+    export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB="postgres"
+    export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS="admin"
     run_unit_tests
 fi


### PR DESCRIPTION
# Description

- Added the necessary environment variables to run the unit tests against PostgreSQL v10.
- Fixed the tests that were failing.

Fixes #CCXDEV-6146

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Made sure that `make test-postgres` is run against PostgreSQL and `make before_commit` too.

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
