### PR TITLE
[CCXDEV-5662]  consumer_test.go::TestKafkaConsumer_New_FindCoordinatorRequestError

### DIFF
--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -398,29 +398,6 @@ func TestKafkaConsumer_New(t *testing.T) {
 	}, testCaseTimeLimit)
 }
 
-// TODO: fix with new groups consumer
-//func TestKafkaConsumer_New_FindCoordinatorRequestError(t *testing.T) {
-//	helpers.RunTestWithTimeout(t, func(t *testing.T) {
-//		sarama.Logger = log.New(os.Stdout, saramaLogPrefix, log.LstdFlags)
-//
-//		mockBroker := sarama.NewMockBroker(t, 0)
-//		defer mockBroker.Close()
-//
-//		handlersMap := helpers.GetHandlersMapForMockConsumer(t, mockBroker, testTopicName)
-//		handlersMap["FindCoordinatorRequest"] = sarama.NewMockFindCoordinatorResponse(t).
-//			SetError(sarama.CoordinatorGroup, "", sarama.ErrUnknown)
-//
-//		mockBroker.SetHandlerByMap(handlersMap)
-//
-//		_, err := consumer.New(broker.Configuration{
-//			Address: mockBroker.Addr(),
-//			Topic:   testTopicName,
-//			Enabled: true,
-//		}, nil)
-//		assert.EqualError(t, err, "kafka server: Unexpected (unknown?) server error.")
-//	}, testCaseTimeLimit)
-//}
-
 func TestKafkaConsumer_ProcessMessage_OrganizationAllowlistDisabled(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
 	defer closer()


### PR DESCRIPTION
# Description

This test is commented because it is failing. It checks that `consumer.New` returns an error if the `FindCoordinatorRequest` fails. However, I've checked Sarama source code and the only scenario when sarama.NewConsumerGroup returns an error is when [the client is closed](https://github.com/Shopify/sarama/blob/65f0fec86aabe011db77ad641d31fddf14f3ca41/consumer.go#L107). This test makes no sense as changing the `FindCoordinatorRequest` doesn't affect the client itself, so it won't return an error in this case.

Fixes #CCXDEV-5662

## Type of change

- Unit tests (no changes in the code)

## Testing steps

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
