### PR TITLE
Revert "use readAndTrimRuleSelector in /rating and /cluster_details endpoint"

### DIFF
--- a/server/rating.go
+++ b/server/rating.go
@@ -82,7 +82,7 @@ func (server *HTTPServer) getRuleRating(writer http.ResponseWriter, request *htt
 		return
 	}
 
-	ruleSelector, ok := readAndTrimRuleSelector(writer, request)
+	ruleSelector, ok := readRuleSelector(writer, request)
 	if !ok {
 		return
 	}

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -31,7 +31,7 @@ import (
 var (
 	readRuleID                = httputils.ReadRuleID
 	readErrorKey              = httputils.ReadErrorKey
-	readAndTrimRuleSelector   = httputils.ReadAndTrimRuleSelector
+	readRuleSelector          = httputils.ReadRuleSelector
 	getRouterParam            = httputils.GetRouterParam
 	getRouterPositiveIntParam = httputils.GetRouterPositiveIntParam
 	validateClusterName       = httputils.ValidateClusterName

--- a/server/server.go
+++ b/server/server.go
@@ -493,7 +493,7 @@ func (server *HTTPServer) RuleClusterDetailEndpoint(writer http.ResponseWriter, 
 	if !successful {
 		return
 	}
-	selector, successful := readAndTrimRuleSelector(writer, request)
+	selector, successful := readRuleSelector(writer, request)
 	if !successful {
 		return
 	}


### PR DESCRIPTION
Reverts RedHatInsights/insights-results-aggregator#1424

Not needed in the end.