### PR TITLE
Postgres on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - make style
     - stage: unit tests
       script:
-        - make test-postgres
+        - make test
         - ./check_coverage.sh
       after_success:
         - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ language: go
 go:
 - "1.16"
 
+services:
+  - postgresql
+
 jobs:
   include:
     - name: "Build 1.16"
@@ -27,7 +30,7 @@ jobs:
         - make style
     - stage: unit tests
       script:
-        - make test
+        - make test-postgres
         - ./check_coverage.sh
       after_success:
         - env

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ sqlite_db:
 license: install_addlicense
 	addlicense -c "Red Hat, Inc" -l "apache" -v ./
 
-before_commit: style test test-postgres integration_tests openapi-check license ## Checks done before commit
+before_commit: style test integration_tests openapi-check license ## Checks done before commit
 	./check_coverage.sh
 
 help: ## Show this help screen

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo json-check openapi-check style run test test-postgres cover integration_tests rest_api_tests sqlite_db license before_commit help godoc install_docgo install_addlicense
+.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo json-check openapi-check style run test cover integration_tests rest_api_tests sqlite_db license before_commit help godoc install_docgo install_addlicense
 
 SOURCES:=$(shell find . -name '*.go')
 BINARY:=insights-results-aggregator
@@ -72,9 +72,6 @@ automigrate: ${BINARY}
 
 test: ${BINARY} ## Run the unit tests
 	./unit-tests.sh
-
-test-postgres: ${BINARY}
-	./unit-tests.sh postgres
 
 cover: test
 	@go tool cover -html=coverage.out

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -455,7 +455,7 @@ func checkBadRuleFeedbackRequest(t *testing.T, message string, expectedStatus st
 // TestRuleFeedbackErrorLongMessage checks if message longer than 250 bytes is
 // rejected properly.
 func TestRuleFeedbackErrorLongMessage(t *testing.T) {
-	os.Clearenv()
+	// os.Clearenv()
 	mustLoadConfiguration("tests/config1")
 
 	checkBadRuleFeedbackRequest(t,
@@ -468,7 +468,6 @@ func TestRuleFeedbackErrorLongMessage(t *testing.T) {
 // message containing less than 250 Unicode characters, but longer than 250
 // bytes, is rejected
 func TestRuleFeedbackErrorLongMessageWithUnicodeCharacters(t *testing.T) {
-	os.Clearenv()
 	mustLoadConfiguration("tests/config1")
 
 	checkBadRuleFeedbackRequest(t,
@@ -1150,7 +1149,7 @@ func TestHTTPServer_RecommendationsListEndpoint_DifferentClusters(t *testing.T) 
 	defer closer()
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, "",
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, time.RFC3339,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1173,7 +1172,7 @@ func TestHTTPServer_RecommendationsListEndpoint_3Recs1Cluster(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, "",
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, time.RFC3339,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1208,12 +1207,12 @@ func TestHTTPServer_RecommendationsListEndpoint_3Recs2Clusters(t *testing.T) {
 	}
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.OrgID, clusterList[0], testdata.Report2Rules, "",
+		testdata.OrgID, clusterList[0], testdata.Report2Rules, time.RFC3339,
 	)
 	helpers.FailOnError(t, err)
 
 	err = mockStorage.WriteRecommendationsForCluster(
-		testdata.OrgID, clusterList[1], testdata.Report3Rules, "",
+		testdata.OrgID, clusterList[1], testdata.Report3Rules, time.RFC3339,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1268,7 +1267,7 @@ func TestRuleClusterDetailEndpoint_NoRowsFoundForGivenSelectorDBError(t *testing
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, "")
+	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, time.RFC3339)
 
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
@@ -1286,7 +1285,7 @@ func TestRuleClusterDetailEndpoint_BadBodyInRequest(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, "")
+	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, time.RFC3339)
 
 	// A request body omitting the closing '"'
 	getRequestBody := fmt.Sprintf(`{"clusters":["%v]}`, testdata.ClusterName)
@@ -1429,8 +1428,8 @@ func TestRuleClusterDetailEndpoint_InvalidParametersActiveClusters(t *testing.T)
 
 	errStr := `Error during parsing param 'org_id' with value 'x'. Error: 'unsigned integer expected'`
 
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, "")
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules, "")
+	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, time.RFC3339)
+	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules, time.RFC3339)
 
 	getRequestBody := fmt.Sprintf(`{"clusters":["%v"]}`, testdata.ClusterName)
 
@@ -1475,7 +1474,7 @@ func TestHTTPServer_ClustersRecommendationsListEndpoint_NoRecommendations(t *tes
 	defer closer()
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, "",
+		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, time.RFC3339,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1505,7 +1504,7 @@ func TestHTTPServer_ClustersRecommendationsListEndpoint_2Recs1Cluster(t *testing
 	)
 
 	err := mockStorage.WriteRecommendationsForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, "",
+		testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, time.RFC3339,
 	)
 	helpers.FailOnError(t, err)
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1405,7 +1405,7 @@ func TestDBStorageReadClusterListRecommendationsGet1Cluster(t *testing.T) {
 	assert.Contains(t, res, expectedClusterID)
 	assert.ElementsMatch(t, expectList, res[expectedClusterID].Recommendations)
 	// trivial timestamp check
-	assert.True(t, res[expectedClusterID].CreatedAt == testdata.LastCheckedAt)
+	assert.True(t, res[expectedClusterID].CreatedAt.Equal(testdata.LastCheckedAt))
 }
 
 // TestDBStorageReadClusterListRecommendationsGet1Cluster loads several recommendations for the same org
@@ -1442,6 +1442,6 @@ func TestDBStorageReadClusterListRecommendationsGetMoreClusters(t *testing.T) {
 	assert.Contains(t, res, expectedCluster2ID)
 	assert.ElementsMatch(t, expectRuleList, res[expectedCluster1ID].Recommendations)
 	assert.ElementsMatch(t, expectRuleList, res[expectedCluster2ID].Recommendations)
-	assert.True(t, res[expectedCluster1ID].CreatedAt == testdata.LastCheckedAt)
-	assert.True(t, res[expectedCluster2ID].CreatedAt == testdata.LastCheckedAt)
+	assert.True(t, res[expectedCluster1ID].CreatedAt.Equal(testdata.LastCheckedAt))
+	assert.True(t, res[expectedCluster2ID].CreatedAt.Equal(testdata.LastCheckedAt))
 }

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -39,11 +39,7 @@ const postgres = "postgres"
 // INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS is set to db admin's password
 // produces t.Fatal(err) on error
 func MustGetMockStorage(tb testing.TB, init bool) (storage.Storage, func()) {
-	if os.Getenv("INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB") == postgres {
-		return MustGetPostgresStorage(tb, init)
-	}
-
-	return MustGetSQLiteMemoryStorage(tb, init)
+	return MustGetPostgresStorage(tb, init)
 }
 
 // MustGetMockStorageWithExpects returns mock db storage

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -24,22 +24,9 @@ function run_unit_tests() {
     fi
 }
 
-if [ -z "$STORAGE" ] ; then
-    # tests with sqlite
-    echo "running unit tests with sqlite in memory"
-    # shellcheck disable=SC2034
-    path_to_config=$(pwd)/config.toml
-    export INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE="$path_to_config"
-    run_unit_tests
-fi
+path_to_config=$(pwd)/config-devel.toml
+export INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE="$path_to_config"
+export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB="postgres"
+export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS="admin"
+run_unit_tests
 
-if [ "$STORAGE" == "postgres" ]; then
-    # tests with postgres
-    echo "running unit tests with postgres"
-    # shellcheck disable=SC2034
-    path_to_config=$(pwd)/config-devel.toml
-    export INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE="$path_to_config"
-    export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB="postgres"
-    export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS="admin"
-    run_unit_tests
-fi

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -24,9 +24,32 @@ function run_unit_tests() {
     fi
 }
 
+function check_composer() {
+    if command -v docker-compose > /dev/null; then
+        COMPOSER=docker-compose
+    elif command -v podman-compose > /dev/null; then
+        COMPOSER=podman-compose
+    else
+        echo "Please, install docker-compose or podman-compose to run this tests"
+        exit 1
+    fi
+}
+
+
+
+if [ -z "$CI" ]; then
+    echo "Running postgres container locally"
+    check_composer
+    $COMPOSER up -d > /dev/null
+fi
+
 path_to_config=$(pwd)/config-devel.toml
 export INSIGHTS_RESULTS_AGGREGATOR_CONFIG_FILE="$path_to_config"
 export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB="postgres"
 export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS="admin"
 run_unit_tests
 
+if [ -z "$CI" ]; then
+    echo "Stopping postgres container"
+    $COMPOSER down > /dev/null
+fi


### PR DESCRIPTION
# Description

Making the unit tests to be run only using postgres

Fixes #CCXDEV-7000 (partially)

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Run `make test` and `make before_commit` locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
