### PR TITLE
add migration to clean-up cluster rule toggle and feedback tables

### DIFF
--- a/migration/actual_migrations_test.go
+++ b/migration/actual_migrations_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/RedHatInsights/insights-results-aggregator/migration"
+	"github.com/RedHatInsights/insights-results-aggregator/storage"
 	ira_helpers "github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
@@ -655,4 +656,95 @@ func TestMigration20(t *testing.T) {
 	)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, testdata.Rule1ID, types.RuleID(ruleID))
+}
+
+func TestMigration22(t *testing.T) {
+	db, dbDriver, closer := prepareDBAndInfo(t)
+	defer closer()
+
+	if dbDriver == types.DBDriverSQLite3 {
+		// sqlite is no longer supported
+		return
+	}
+
+	err := migration.SetDBVersion(db, dbDriver, 21)
+	helpers.FailOnError(t, err)
+
+	var expectedCorrectCount int
+
+	// insert toggles and feedbacks
+	for i := 0; i < 10; i++ {
+		ruleID := testdata.Rule1ID
+
+		// we expect 4 with the suffix (correct) and 6 without the suffix (to be deleted)
+		if i%2 == 0 {
+			ruleID = ruleID + migration.DotReportSuffix
+			expectedCorrectCount++
+		}
+
+		// insert toggles
+		_, err = db.Exec(`
+				INSERT INTO cluster_rule_toggle
+				(cluster_id, rule_id, error_key, user_id, disabled, updated_at)
+				VALUES
+				($1, $2, $3, $4, $5, $6)
+			`,
+			testdata.GetRandomClusterID(),
+			ruleID,
+			testdata.ErrorKey1, // we don't care about error key or any other column
+			testdata.UserID,
+			storage.RuleToggleDisable,
+			time.Now(),
+		)
+		helpers.FailOnError(t, err)
+
+		// insert disable feedbacks
+		_, err = db.Exec(`
+				INSERT INTO cluster_user_rule_disable_feedback
+				(cluster_id, rule_id, error_key, user_id, message, added_at, updated_at)
+				VALUES
+				($1, $2, $3, $4, $5, $6, $6)
+			`,
+			testdata.GetRandomClusterID(),
+			ruleID,
+			testdata.ErrorKey1, // we don't care about error key or any other column
+			testdata.UserID,
+			"",
+			time.Now(),
+		)
+		helpers.FailOnError(t, err)
+	}
+
+	// migrate to 22
+	err = migration.SetDBVersion(db, dbDriver, 22)
+	helpers.FailOnError(t, err)
+
+	// retrieve numbers of rows
+	var togglesAfterMigrationCount, feedbacksAfterMigrationCount int
+
+	err = db.QueryRow(`
+	SELECT
+		count(*)
+	FROM
+		cluster_rule_toggle
+	`).Scan(
+		&togglesAfterMigrationCount,
+	)
+	helpers.FailOnError(t, err)
+	// must match with expected count
+	assert.Equal(t, expectedCorrectCount, togglesAfterMigrationCount)
+
+	err = db.QueryRow(`
+	SELECT
+		count(*)
+	FROM
+		cluster_user_rule_disable_feedback
+	`).Scan(
+		&feedbacksAfterMigrationCount,
+	)
+	helpers.FailOnError(t, err)
+	// must match with expected count
+	assert.Equal(t, expectedCorrectCount, feedbacksAfterMigrationCount)
+
+	// there is no need to test StepDown because it's a NOOP
 }

--- a/migration/mig_0022_cleanup_enable_disable_tables.go
+++ b/migration/mig_0022_cleanup_enable_disable_tables.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+// DotReportSuffix is used
+const DotReportSuffix = ".report"
+
+var mig0022CleanupEnableDisableTables = Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		// delete from cluster_rule_toggle rows, where rule_id doesn't end in .report
+		_, err := tx.Exec(`
+			DELETE FROM cluster_rule_toggle WHERE rule_id NOT LIKE '%$1'
+		`, DotReportSuffix)
+
+		if err != nil {
+			return err
+		}
+
+		// delete from cluster_user_rule_disable_feedback rows, where rule_id doesn't end in .report
+		_, err = tx.Exec(`
+			DELETE FROM cluster_user_rule_disable_feedback WHERE rule_id NOT LIKE '%$1'
+		`, DotReportSuffix)
+
+		if err != nil {
+			return err
+		}
+
+		return err
+	},
+
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		// this is a one way operation, test thoroughly :)
+		return nil
+	},
+}

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -38,4 +38,5 @@ var migrations = []Migration{
 	mig0019ModifyRecommendationTable,
 	mig0020ModifyAdvisorRatingsTable,
 	mig0021AddGatheredAtToReport,
+	mig0022CleanupEnableDisableTables,
 }


### PR DESCRIPTION
# Description
Because of recent changes, we have inconsistencies in `cluster_rule_toggle` and `cluster_user_rule_disable_feedback`. Some rows have `.report` suffix in Rule ID column and some don't.

This migration deletes all rows, where `rule_id` column doesn't end with `.report` suffix. 

**Important**:
- I checked Advisor UI on STAGE and the `.report` suffix is correctly included in all endpoints which require it.
  - this will need to be confirmed on PROD too before we deploy this migration, otherwise it makes no sense to run it yet.

Fixes CCXDEV-7321

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps
I'm unable to run storage-related unit tests locally, so let's see if I can write tests on the first try :D 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
