### PR TITLE
add migration to clean-up cluster rule toggle and feedback tables

### DIFF
--- a/migration/mig_0022_cleanup_enable_disable_tables.go
+++ b/migration/mig_0022_cleanup_enable_disable_tables.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+var mig0022CleanupEnableDisableTables = Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		// delete from cluster_rule_toggle rows, where rule_id doesn't end in .report
+		_, err := tx.Exec(`
+			DELETE FROM cluster_rule_toggle WHERE rule_id NOT LIKE '%.report'
+		`)
+
+		if err != nil {
+			return err
+		}
+
+		// delete from cluster_user_rule_disable_feedback rows, where rule_id doesn't end in .report
+		_, err = tx.Exec(`
+			DELETE FROM cluster_user_rule_disable_feedback WHERE rule_id NOT LIKE '%.report'
+		`)
+
+		if err != nil {
+			return err
+		}
+
+		return err
+	},
+
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		// this is a one way operation, test thoroughly :)
+		return nil
+	},
+}

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -38,4 +38,5 @@ var migrations = []Migration{
 	mig0019ModifyRecommendationTable,
 	mig0020ModifyAdvisorRatingsTable,
 	mig0021AddGatheredAtToReport,
+	mig0022CleanupEnableDisableTables,
 }


### PR DESCRIPTION
# Description
Because of recent changes, we have inconsistencies in `cluster_rule_toggle` and `cluster_user_rule_disable_feedback`. Some rows have `.report` suffix in Rule ID column and some don't.

This migration deletes all rows, where `rule_id` column doesn't end with `.report` suffix. 

**Important**:
- I checked Advisor UI on STAGE and the `.report` suffix is correctly included in all endpoints which require it.
  - this will need to be confirmed on PROD too before we deploy this migration, otherwise it makes no sense to run it yet.

Fixes CCXDEV-7321

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps
I'm unable to run storage-related unit tests locally, so let's see if I can write tests on the first try :D 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
