### PR TITLE
enable migration 0022 after fixed infra issues

### DIFF
--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -38,5 +38,5 @@ var migrations = []Migration{
 	mig0019ModifyRecommendationTable,
 	mig0020ModifyAdvisorRatingsTable,
 	mig0021AddGatheredAtToReport,
-	//mig0022CleanupEnableDisableTables,
+	mig0022CleanupEnableDisableTables,
 }


### PR DESCRIPTION
# Description
yesterday we were facing infra issues and weren't able to run this migraiton on stage, let's run it now.

## Testing steps
problems with local UTs

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
