### PR TITLE
re-add migration 0022 after confirming it's not the cause of pod resources error

### DIFF
--- a/migration/actual_migrations_test.go
+++ b/migration/actual_migrations_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/RedHatInsights/insights-results-aggregator/migration"
+	"github.com/RedHatInsights/insights-results-aggregator/storage"
 	ira_helpers "github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
@@ -562,4 +563,171 @@ func TestMigration18(t *testing.T) {
 		types.UserVoteLike,
 	)
 	helpers.FailOnError(t, err)
+}
+
+func TestMigration20(t *testing.T) {
+	db, dbDriver, closer := prepareDBAndInfo(t)
+	defer closer()
+
+	if dbDriver == types.DBDriverSQLite3 {
+		// nothing worth testing for sqlite
+		return
+	}
+
+	err := migration.SetDBVersion(db, dbDriver, 19)
+	helpers.FailOnError(t, err)
+
+	err = db.QueryRow(`SELECT rule_fqdn FROM advisor_ratings`).Err()
+	assert.Error(t, err, "rule_fqdn column should not exist")
+
+	_, err = db.Exec(`
+		INSERT INTO advisor_ratings
+		(user_id, org_id, rule_id, error_key, rated_at, last_updated_at, rating)
+		VALUES
+		($1, $2, $3, $4, $5, $6, $7)
+	`,
+		testdata.UserID,
+		testdata.OrgID,
+		testdata.Rule1ID,
+		testdata.ErrorKey1,
+		time.Now(),
+		time.Now(),
+		types.UserVoteLike,
+	)
+	helpers.FailOnError(t, err)
+
+	err = migration.SetDBVersion(db, dbDriver, 20)
+	helpers.FailOnError(t, err)
+
+	var (
+		ruleFQDN string
+		ruleID   string
+	)
+
+	err = db.QueryRow(`
+			SELECT
+				rule_fqdn, rule_id
+			FROM
+				advisor_ratings
+			WHERE
+				user_id = $1 AND org_id = $2`,
+		testdata.UserID, testdata.OrgID,
+	).Scan(
+		&ruleFQDN, &ruleID,
+	)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, testdata.Rule1ID, types.RuleID(ruleFQDN))
+	assert.Equal(t, testdata.Rule1CompositeID, types.RuleID(ruleID))
+
+	// Step down should rename rule_fqdn column to rule_id and it contains only plugin name
+	err = migration.SetDBVersion(db, dbDriver, 19)
+	helpers.FailOnError(t, err)
+
+	err = db.QueryRow(`SELECT rule_fqdn FROM advisor_ratings`).Err()
+	assert.Error(t, err, "rule_fqdn column should not exist")
+	err = db.QueryRow(`
+			SELECT
+				rule_id
+			FROM
+				advisor_ratings
+			WHERE
+				user_id = $1 AND org_id = $2`,
+		testdata.UserID, testdata.OrgID,
+	).Scan(
+		&ruleID,
+	)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, testdata.Rule1ID, types.RuleID(ruleID))
+}
+
+func TestMigration22(t *testing.T) {
+	db, dbDriver, closer := prepareDBAndInfo(t)
+	defer closer()
+
+	if dbDriver == types.DBDriverSQLite3 {
+		// sqlite is no longer supported
+		return
+	}
+
+	err := migration.SetDBVersion(db, dbDriver, 21)
+	helpers.FailOnError(t, err)
+
+	var expectedCorrectCount int
+
+	// insert toggles and feedbacks
+	for i := 0; i < 10; i++ {
+		ruleID := testdata.Rule1ID
+		clusterID := testdata.GetRandomClusterID()
+
+		// we expect 4 with the suffix (correct) and 6 without the suffix (to be deleted)
+		if i%2 == 0 {
+			ruleID = ruleID + ".report"
+			expectedCorrectCount++
+		}
+
+		// insert toggles
+		_, err = db.Exec(`
+				INSERT INTO cluster_rule_toggle
+				(cluster_id, rule_id, error_key, user_id, disabled, updated_at)
+				VALUES
+				($1, $2, $3, $4, $5, $6)
+			`,
+			clusterID,
+			ruleID,
+			testdata.ErrorKey1, // we don't care about error key or any other column
+			testdata.UserID,
+			storage.RuleToggleDisable,
+			time.Now(),
+		)
+		helpers.FailOnError(t, err)
+
+		// insert disable feedbacks
+		_, err = db.Exec(`
+				INSERT INTO cluster_user_rule_disable_feedback
+				(cluster_id, rule_id, error_key, user_id, message, added_at, updated_at)
+				VALUES
+				($1, $2, $3, $4, $5, $6, $6)
+			`,
+			clusterID,
+			ruleID,
+			testdata.ErrorKey1, // we don't care about error key or any other column
+			testdata.UserID,
+			"",
+			time.Now(),
+		)
+		helpers.FailOnError(t, err)
+	}
+
+	// migrate to 22
+	err = migration.SetDBVersion(db, dbDriver, 22)
+	helpers.FailOnError(t, err)
+
+	// retrieve numbers of rows
+	var togglesAfterMigrationCount, feedbacksAfterMigrationCount int
+
+	err = db.QueryRow(`
+	SELECT
+		count(*)
+	FROM
+		cluster_rule_toggle
+	`).Scan(
+		&togglesAfterMigrationCount,
+	)
+	helpers.FailOnError(t, err)
+	// must match with expected count
+	assert.Equal(t, expectedCorrectCount, togglesAfterMigrationCount)
+
+	err = db.QueryRow(`
+	SELECT
+		count(*)
+	FROM
+		cluster_user_rule_disable_feedback
+	`).Scan(
+		&feedbacksAfterMigrationCount,
+	)
+	helpers.FailOnError(t, err)
+	// must match with expected count
+	assert.Equal(t, expectedCorrectCount, feedbacksAfterMigrationCount)
+
+	// there is no need to test StepDown because it's a NOOP
 }

--- a/migration/mig_0022_cleanup_enable_disable_tables.go
+++ b/migration/mig_0022_cleanup_enable_disable_tables.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+var mig0022CleanupEnableDisableTables = Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		// delete from cluster_rule_toggle rows, where rule_id doesn't end in .report
+		_, err := tx.Exec(`
+			DELETE FROM cluster_rule_toggle WHERE rule_id NOT LIKE '%.report'
+		`)
+
+		if err != nil {
+			return err
+		}
+
+		// delete from cluster_user_rule_disable_feedback rows, where rule_id doesn't end in .report
+		_, err = tx.Exec(`
+			DELETE FROM cluster_user_rule_disable_feedback WHERE rule_id NOT LIKE '%.report'
+		`)
+
+		if err != nil {
+			return err
+		}
+
+		return err
+	},
+
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		// this is a one way operation, test thoroughly :)
+		return nil
+	},
+}

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -38,4 +38,5 @@ var migrations = []Migration{
 	mig0019ModifyRecommendationTable,
 	mig0020ModifyAdvisorRatingsTable,
 	mig0021AddGatheredAtToReport,
+	mig0022CleanupEnableDisableTables,
 }


### PR DESCRIPTION
# Description
In the previous PRs we reverted the migration and the CPU issue was still happening.
We then set pod count/replicas to 0 and then back to normal values, which fixed the deployment, meaning there is some underlying infra issue, but we atleast know a workaround for now.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
