### PR TITLE
Storing the gathering time from metadata into database, if present

### DIFF
--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -40,6 +40,7 @@ type incomingMessage struct {
 	LastChecked string              `json:"LastChecked"`
 	Version     types.SchemaVersion `json:"Version"`
 	RequestID   types.RequestID     `json:"RequestId"`
+	Metadata    types.Metadata      `json:"Metadata"`
 	ParsedHits  []types.ReportItem
 }
 
@@ -216,6 +217,7 @@ func (consumer *KafkaConsumer) ProcessMessage(msg *sarama.ConsumerMessage) (type
 		types.ClusterReport(reportAsBytes),
 		message.ParsedHits,
 		lastCheckedTime,
+		message.Metadata.GatheredAt,
 		storedAtTime,
 		types.KafkaOffset(msg.Offset),
 	)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -122,7 +122,16 @@ func TestWrittenReportsMetric(t *testing.T) {
 	// other tests may run at the same process
 	initValue := int64(getCounterValue(metrics.WrittenReports))
 
-	err := mockStorage.WriteReportForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), 0)
+	err := mockStorage.WriteReportForCluster(
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		time.Now(),
+		time.Now(),
+		0,
+	)
 	helpers.FailOnError(t, err)
 
 	assertCounterValue(t, 1, metrics.WrittenReports, initValue)
@@ -134,6 +143,7 @@ func TestWrittenReportsMetric(t *testing.T) {
 			testdata.Report3Rules,
 			testdata.Report3RulesParsed,
 			testdata.LastCheckedAt.Add(time.Duration(i+1)*time.Second),
+			time.Now(),
 			time.Now(),
 			types.KafkaOffset(i+1),
 		)

--- a/server/report_benchmarks_test.go
+++ b/server/report_benchmarks_test.go
@@ -136,7 +136,16 @@ func initTestReports(b *testing.B, n uint, mockStorage storage.Storage, reportPr
 		clusterID := testdata.GetRandomClusterID()
 		report, rules := reportProvider()
 
-		err := mockStorage.WriteReportForCluster(orgID, clusterID, report, rules, time.Now(), time.Now(), testdata.KafkaOffset)
+		err := mockStorage.WriteReportForCluster(
+			orgID,
+			clusterID,
+			report,
+			rules,
+			time.Now(),
+			time.Now(),
+			time.Now(),
+			testdata.KafkaOffset,
+		)
 		helpers.FailOnError(b, err)
 
 		testReportDataItems = append(testReportDataItems, testReportData{

--- a/server/server_read_report_metainfo_test.go
+++ b/server/server_read_report_metainfo_test.go
@@ -81,7 +81,14 @@ func TestReadExistingEmptyReportMetainfo(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, testdata.ReportEmptyRulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report0Rules,
+		testdata.ReportEmptyRulesParsed,
+		testdata.LastCheckedAt,
+		time.Now(),
+		testdata.LastCheckedAt,
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -126,6 +133,7 @@ func TestReadReportMetainfo(t *testing.T) {
 		testdata.Report3Rules,
 		testdata.Report3RulesParsed,
 		testdata.LastCheckedAt,
+		time.Now(),
 		testdata.LastCheckedAt,
 		testdata.KafkaOffset,
 	)

--- a/server/server_read_report_test.go
+++ b/server/server_read_report_test.go
@@ -84,7 +84,14 @@ func TestHttpServer_readReportForCluster_NoRules(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, testdata.ReportEmptyRulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report0Rules,
+		testdata.ReportEmptyRulesParsed,
+		testdata.LastCheckedAt,
+		testdata.LastCheckedAt,
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -133,6 +140,7 @@ func TestReadReport(t *testing.T) {
 		testdata.Report3RulesParsed,
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
+		time.Now(),
 		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
@@ -159,6 +167,7 @@ func TestReadRuleReport(t *testing.T) {
 		testdata.Report3RulesParsed,
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
+		time.Now(),
 		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
@@ -196,6 +205,7 @@ func TestReadReportDisableRule(t *testing.T) {
 		testdata.Report2RulesParsed,
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
+		time.Now(),
 		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
@@ -261,6 +271,7 @@ func TestReadReportDisableRuleMultipleUsers(t *testing.T) {
 		testdata.Report2RulesParsed,
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
+		time.Now(),
 		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
@@ -394,6 +405,7 @@ func TestReadReport_RuleDisableFeedback(t *testing.T) {
 		testdata.Report2RulesParsed,
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
+		time.Now(),
 		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -79,7 +79,14 @@ func TestListOfClustersForOrganizationOK(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		time.Now(),
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -160,12 +167,26 @@ func TestListOfOrganizationsOK(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		1, "8083c377-8a05-4922-af8d-e7d0970c1f49", "{}", testdata.ReportEmptyRulesParsed, time.Now(), time.Now(), testdata.KafkaOffset,
+		1,
+		"8083c377-8a05-4922-af8d-e7d0970c1f49",
+		"{}",
+		testdata.ReportEmptyRulesParsed,
+		time.Now(),
+		time.Now(),
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
 	err = mockStorage.WriteReportForCluster(
-		5, "52ab955f-b769-444d-8170-4b676c5d3c85", "{}", testdata.ReportEmptyRulesParsed, time.Now(), time.Now(), testdata.KafkaOffset,
+		5,
+		"52ab955f-b769-444d-8170-4b676c5d3c85",
+		"{}",
+		testdata.ReportEmptyRulesParsed,
+		time.Now(),
+		time.Now(),
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -298,7 +319,14 @@ func TestRuleFeedbackVote(t *testing.T) {
 			defer closer()
 
 			err := mockStorage.WriteReportForCluster(
-				testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+				testdata.OrgID,
+				testdata.ClusterName,
+				testdata.Report3Rules,
+				testdata.Report3RulesParsed,
+				testdata.LastCheckedAt,
+				testdata.LastCheckedAt,
+				time.Now(),
+				testdata.KafkaOffset,
 			)
 			helpers.FailOnError(t, err)
 
@@ -438,7 +466,8 @@ func checkBadRuleFeedbackRequest(t *testing.T, message string, expectedStatus st
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
-		testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt,
+		time.Now(), testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
@@ -494,7 +523,8 @@ func TestHTTPServer_GetVoteOnRule_DBError(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed,
+		testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -549,7 +579,14 @@ func TestHTTPServer_GetVoteOnRule(t *testing.T) {
 			defer closer()
 
 			err := mockStorage.WriteReportForCluster(
-				testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+				testdata.OrgID,
+				testdata.ClusterName,
+				testdata.Report3Rules,
+				testdata.Report3RulesParsed,
+				testdata.LastCheckedAt,
+				testdata.LastCheckedAt,
+				time.Now(),
+				testdata.KafkaOffset,
 			)
 			helpers.FailOnError(t, err)
 
@@ -594,7 +631,14 @@ func TestRuleToggle(t *testing.T) {
 			defer closer()
 
 			err := mockStorage.WriteReportForCluster(
-				testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+				testdata.OrgID,
+				testdata.ClusterName,
+				testdata.Report3Rules,
+				testdata.Report3RulesParsed,
+				testdata.LastCheckedAt,
+				testdata.LastCheckedAt,
+				time.Now(),
+				testdata.KafkaOffset,
 			)
 			helpers.FailOnError(t, err)
 
@@ -699,7 +743,14 @@ func TestHTTPServer_SaveDisableFeedback(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		testdata.LastCheckedAt,
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -740,7 +791,14 @@ func TestHTTPServer_SaveDisableFeedback_Error_CheckUserClusterPermissions(t *tes
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		testdata.LastCheckedAt,
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -769,7 +827,14 @@ func TestHTTPServer_SaveDisableFeedback_Error_BadBody(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		testdata.LastCheckedAt,
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -788,7 +853,14 @@ func TestHTTPServer_SaveDisableFeedback_Error_DBError(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.KafkaOffset,
+		testdata.OrgID,
+		testdata.ClusterName,
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		testdata.LastCheckedAt,
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1586,7 +1658,14 @@ func TestHTTPServer_ListOfDisabledClusters_OneDisabled(t *testing.T) {
 	}
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, clusters[0], testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.OrgID,
+		clusters[0],
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		time.Now(),
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1618,7 +1697,14 @@ func TestHTTPServer_ListOfDisabledClusters_JustificationTests(t *testing.T) {
 	}
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, clusters[0], testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.OrgID,
+		clusters[0],
+		testdata.Report3Rules,
+		testdata.Report3RulesParsed,
+		testdata.LastCheckedAt,
+		time.Now(),
+		time.Now(),
+		testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 

--- a/server/vote_endpoints_benchmarks_test.go
+++ b/server/vote_endpoints_benchmarks_test.go
@@ -147,7 +147,14 @@ func prepareVoteEndpointArgs(tb testing.TB, numberOfEndpointArgs uint, mockStora
 		userID := types.UserID(testdata.GetRandomUserID())
 
 		err := mockStorage.WriteReportForCluster(
-			testdata.OrgID, clusterID, "{}", testdata.ReportEmptyRulesParsed, time.Now(), time.Now(), testdata.KafkaOffset,
+			testdata.OrgID,
+			clusterID,
+			"{}",
+			testdata.ReportEmptyRulesParsed,
+			time.Now(),
+			time.Now(),
+			time.Now(),
+			testdata.KafkaOffset,
 		)
 		helpers.FailOnError(tb, err)
 

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -72,7 +72,7 @@ func (*NoopStorage) GetLatestKafkaOffset() (types.KafkaOffset, error) {
 
 // WriteReportForCluster noop
 func (*NoopStorage) WriteReportForCluster(
-	types.OrgID, types.ClusterName, types.ClusterReport, []types.ReportItem, time.Time, time.Time, types.KafkaOffset,
+	types.OrgID, types.ClusterName, types.ClusterReport, []types.ReportItem, time.Time, time.Time, time.Time, types.KafkaOffset,
 ) error {
 	return nil
 }

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -36,7 +36,7 @@ func TestNoopStorage_Methods(t *testing.T) {
 	_, _, _, _ = noopStorage.ReadReportForCluster(0, "")
 	_, _, _ = noopStorage.ReadReportForClusterByClusterName("")
 	_, _ = noopStorage.GetLatestKafkaOffset()
-	_ = noopStorage.WriteReportForCluster(0, "", "", []types.ReportItem{}, time.Now(), time.Now(), 0)
+	_ = noopStorage.WriteReportForCluster(0, "", "", []types.ReportItem{}, time.Now(), time.Now(), time.Now(), 0)
 	_, _ = noopStorage.ReportsCount()
 	_ = noopStorage.VoteOnRule("", "", "", "", 0, "")
 	_ = noopStorage.AddOrUpdateFeedbackOnRule("", "", "", "", "")

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -39,14 +39,14 @@ import (
 
 func mustWriteReport3Rules(t *testing.T, mockStorage storage.Storage) {
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 }
 
 func mustWriteReport3RulesForCluster(t *testing.T, mockStorage storage.Storage, clusterName types.ClusterName) {
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, clusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.OrgID, clusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
 	)
 	helpers.FailOnError(t, err)
 }

--- a/storage/storage_write_recommendations_benchmark_test.go
+++ b/storage/storage_write_recommendations_benchmark_test.go
@@ -17,13 +17,14 @@ package storage_test
 import (
 	"database/sql"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
-	"testing"
-	"time"
 
 	"github.com/RedHatInsights/insights-results-aggregator/storage"
 	ira_helpers "github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
@@ -512,7 +513,7 @@ func BenchmarkWriteReportAndRecommendationsNoConflict(b *testing.B) {
 
 	for benchIter := 0; benchIter < b.N; benchIter++ {
 		for id := range clusterIDSet.content {
-			err := storage.WriteReportForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report2Rules, testdata.Report2RulesParsed, time.Now(), time.Now(), types.KafkaOffset(0))
+			err := storage.WriteReportForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report2Rules, testdata.Report2RulesParsed, time.Now(), time.Now(), time.Now(), types.KafkaOffset(0))
 			helpers.FailOnError(b, err)
 			err = storage.WriteRecommendationsForCluster(types.OrgID(1), types.ClusterName(id), Report20Rules, RecommendationCreatedAtTimestamp)
 			helpers.FailOnError(b, err)

--- a/types/types.go
+++ b/types/types.go
@@ -17,6 +17,8 @@
 package types
 
 import (
+	"time"
+
 	types "github.com/RedHatInsights/insights-results-types"
 )
 
@@ -117,3 +119,8 @@ type SchemaVersion = types.SchemaVersion
 
 // RuleRating represents a rule rating element sent by the user
 type RuleRating = types.RuleRating
+
+// Metadata represents the metadata field in the Kafka topic messages
+type Metadata struct {
+	GatheredAt time.Time `json:"gathering_time"`
+}


### PR DESCRIPTION
# Description

Extract the "Metadata" field in the consumed messages from Kafka and, if present, store it in the database "record" table

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Run unit tests locally. Run an example locally and checked the value stored in the DB

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
