### PR TITLE
add disabled flag to cluster_rule_toggle query

### DIFF
--- a/storage/rule_toggle.go
+++ b/storage/rule_toggle.go
@@ -165,13 +165,14 @@ func (storage DBStorage) GetTogglesForRules(
 		cluster_rule_toggle
 	WHERE
 		cluster_id = $1 AND
-		rule_id in (%v) AND
-		user_id = $2
+		user_id = $2 AND
+		disabled = $3 AND
+		rule_id in (%v)
 	`
 	whereInStatement := inClauseFromSlice(ruleIDs)
 	query = fmt.Sprintf(query, whereInStatement)
 
-	rows, err := storage.connection.Query(query, clusterID, userID)
+	rows, err := storage.connection.Query(query, clusterID, userID, RuleToggleDisable)
 	if err != nil {
 		return toggles, err
 	}


### PR DESCRIPTION
# Description
one of the last things I have to try.. adding `true` to the cluster_rule_toggle query so I only get disabled rules, not re-enabled or others...

(the rest of the code looks like is taking care of this programmatically, but let's make sure we're not getting any other DB mess...)


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
`make before_commit`, unit tests not running for me locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
