### PR TITLE
Proper btree indexing, not using sequential scan

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1000,8 +1000,11 @@ func (storage DBStorage) WriteRecommendationsForCluster(
 		var deleted int64 = 0
 		// Delete current recommendations for the cluster if some report has been previously stored for this cluster
 		if _, ok := storage.clustersLastChecked[clusterName]; ok {
+			// it is needed to use `org_id = $1` condition there
+			// because it allows DB to use proper btree indexing
+			// and not slow sequential scan
 			result, err := tx.Exec(
-				"DELETE FROM recommendation WHERE cluster_id = $1;", clusterName)
+				"DELETE FROM recommendation WHERE org_id = $1 AND cluster_id = $2;", orgID, clusterName)
 			err = types.ConvertDBError(err, []interface{}{clusterName})
 			if err != nil {
 				log.Error().Err(err).Msgf("Unable to delete the existing recommendations for %s", clusterName)


### PR DESCRIPTION
# Description

Use proper btree indexing, not using sequential scan
![write_duration_3](https://user-images.githubusercontent.com/4579967/161490560-b5d3821a-5c3e-4390-aee5-8b98f3f87404.png)
![write_speed_3](https://user-images.githubusercontent.com/4579967/161490562-c1ce833f-e6fb-4f24-9651-4ffee3f9fa89.png)

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Can be done locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
