### PR TITLE
Multiple INSERT into RULE_HITS table in one statement

### DIFF
--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -40,8 +40,9 @@ const (
 )
 
 var (
-	ConstructInClausule  = constructInClausule
-	ArgsWithClusterNames = argsWithClusterNames
+	ConstructInClausule     = constructInClausule
+	ArgsWithClusterNames    = argsWithClusterNames
+	ValuesForRuleHitsInsert = valuesForRuleHitsInsert
 )
 
 func GetConnection(storage *DBStorage) *sql.DB {

--- a/storage/rule_hit_preparation_test.go
+++ b/storage/rule_hit_preparation_test.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+
+	"github.com/RedHatInsights/insights-results-aggregator/storage"
+)
+
+func TestDBStorage_getRuleHitInsertStatement(t *testing.T) {
+	fakeStorage := storage.NewFromConnection(nil, -1)
+	r := fakeStorage.GetRuleHitInsertStatement(testdata.Report3RulesParsed)
+
+	// 5*3 placeholders expected
+	const expected = "INSERT INTO rule_hit(org_id, cluster_id, rule_fqdn, error_key, template_data) VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10),($11,$12,$13,$14,$15)"
+	assert.Equal(t, r, expected)
+}
+
+func TestDBStorage_valuesForRuleHitsInsert(t *testing.T) {
+	v := storage.ValuesForRuleHitsInsert(testdata.OrgID, testdata.ClusterName, testdata.Report3RulesParsed)
+
+	// 5*3 values expected
+	assert.Len(t, v, 15)
+
+	// just elementary tests
+	for i := 0; i < 15; i += 5 {
+		assert.Equal(t, v[i], testdata.OrgID)
+		assert.Equal(t, v[i+1], testdata.ClusterName)
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -784,7 +784,7 @@ func (storage DBStorage) GetRuleHitInsertStatement(rules []types.ReportItem) str
 	var placeholders []string
 
 	// fill-in placeholders for INSERT statement
-	for index, _ := range rules {
+	for index := range rules {
 		placeholders = append(
 			placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d)",
 				index*5+1,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -776,9 +776,9 @@ func (storage DBStorage) getReportUpsertQuery() string {
 	`
 }
 
-// getRuleHitInsertStatement method prepares DB statement to be used to write
+// GetRuleHitInsertStatement method prepares DB statement to be used to write
 // rule FQDN + rule error key into rule_hit table for given cluster_id
-func (storage DBStorage) getRuleHitInsertStatement(rules []types.ReportItem) string {
+func (storage DBStorage) GetRuleHitInsertStatement(rules []types.ReportItem) string {
 	const ruleInsertStatement = "INSERT INTO rule_hit(org_id, cluster_id, rule_fqdn, error_key, template_data) VALUES %s"
 
 	var placeholders []string
@@ -846,7 +846,7 @@ func (storage DBStorage) updateReport(
 	// possible to just insert new hits w/o the need to update on conflict
 	if len(rules) > 0 {
 		// Get the INSERT statement for writing a rule into the database.
-		ruleInsertStatement := storage.getRuleHitInsertStatement(rules)
+		ruleInsertStatement := storage.GetRuleHitInsertStatement(rules)
 
 		// Get values to be stored in rule_hits table
 		values := valuesForRuleHitsInsert(orgID, clusterName, rules)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -392,10 +392,9 @@ func TestDBStorageWriteReportForClusterFakePostgresOK(t *testing.T) {
 	expects.ExpectExec("DELETE FROM rule_hit").
 		WillReturnResult(driver.ResultNoRows)
 
-	for i := 0; i < len(testdata.Report3RulesParsed); i++ {
-		expects.ExpectExec("INSERT INTO rule_hit").
-			WillReturnResult(driver.ResultNoRows)
-	}
+	// one INSERT with multiple rows is expected
+	expects.ExpectExec("INSERT INTO rule_hit").
+		WillReturnResult(driver.ResultNoRows)
 
 	expects.ExpectExec("INSERT INTO report").
 		WillReturnResult(driver.ResultNoRows)


### PR DESCRIPTION
# Description

Multiple INSERT into RULE_HITS table in one statement

Fixes #1583 

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
