### PR TITLE
Fix timeout problems on CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
+          args: --timeout=3m
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
# Description

CI is experiencing some problems because from time to time the job takes more than 1m, the default timeout. Increasing it.

## Type of change
- Refactor (refactoring code, removing useless files)

## Testing steps

Locally run

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
