### PR TITLE
[CCXDEV-6971] Return clusters version in clusters_detail endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20201009081018-083923779f00
 	github.com/RedHatInsights/insights-operator-utils v1.23.3
-	github.com/RedHatInsights/insights-results-aggregator-data v1.3.5
+	github.com/RedHatInsights/insights-results-aggregator-data v1.3.6
 	github.com/RedHatInsights/insights-results-types v1.3.8
 	github.com/Shopify/sarama v1.27.1
 	github.com/deckarep/golang-set v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbic
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.2/go.mod h1:E1UaB+IjJ/muxvMstVoqJrB82zVKNykjTtCiM3tMHoM=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHNC7lBxYnu9AqMahABqvuclCzWUWSkbacQbUaehfI=
-github.com/RedHatInsights/insights-results-aggregator-data v1.3.5 h1:6N0W03ccV2eNviMAJP2mO8Evj7kxeu1AymLbgZWZgSQ=
-github.com/RedHatInsights/insights-results-aggregator-data v1.3.5/go.mod h1:tOwmlIB5irSv1mTLgONuLrsbTp4vokl4ClJFClrrXX0=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.6 h1:RcZsn25t+km9/VBAcbks5oLx21HI0aQvLFldgEja5NY=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.6/go.mod h1:tOwmlIB5irSv1mTLgONuLrsbTp4vokl4ClJFClrrXX0=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.7/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.8 h1:WxoXrf60d5dF8rPDRoRT3bmoMwl+ywnBPMIo4TI0yhQ=

--- a/openapi.json
+++ b/openapi.json
@@ -66,7 +66,7 @@
                     "info": {
                       "type": "object",
                       "additionalProperties": {
-                         "type": "string"
+                        "type": "string"
                       }
                     },
                     "status": {
@@ -537,8 +537,7 @@
           "required": true,
           "content": {
             "text/plain": {
-              "schema": {
-              }
+              "schema": {}
             }
           }
         },
@@ -1420,8 +1419,7 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-              }
+              "schema": {}
             }
           }
         },
@@ -1500,8 +1498,7 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-              }
+              "schema": {}
             }
           }
         },
@@ -1647,8 +1644,7 @@
           "required": true,
           "content": {
             "text/plain": {
-              "schema": {
-              }
+              "schema": {}
             }
           }
         },
@@ -1656,8 +1652,7 @@
           "200": {
             "description": "List of disabled rules",
             "content": {
-              "application/json": {
-              }
+              "application/json": {}
             }
           }
         },
@@ -1780,8 +1775,7 @@
           "200": {
             "description": "A JSON containing report for this operation.",
             "content": {
-              "application/json": {
-              }
+              "application/json": {}
             }
           }
         }
@@ -1835,8 +1829,7 @@
           "required": true,
           "content": {
             "text/plain": {
-              "schema": {
-              }
+              "schema": {}
             }
           }
         },
@@ -1844,8 +1837,7 @@
           "200": {
             "description": "A JSON containing report for this operation.",
             "content": {
-              "application/json": {
-              }
+              "application/json": {}
             }
           }
         }
@@ -1899,8 +1891,7 @@
           "required": true,
           "content": {
             "text/plain": {
-              "schema": {
-              }
+              "schema": {}
             }
           }
         },
@@ -1908,8 +1899,7 @@
           "200": {
             "description": "A JSON containing report for this operation.",
             "content": {
-              "application/json": {
-              }
+              "application/json": {}
             }
           }
         }
@@ -1962,8 +1952,7 @@
           "200": {
             "description": "A JSON containing report for this operation.",
             "content": {
-              "application/json": {
-              }
+              "application/json": {}
             }
           }
         }
@@ -1998,8 +1987,7 @@
           "200": {
             "description": "A JSON containing report for this operation.",
             "content": {
-              "application/json": {
-              }
+              "application/json": {}
             }
           }
         }
@@ -2132,6 +2120,16 @@
                               "cluster_name": {
                                 "type": "string",
                                 "description": "The display name of a cluster. Filled later in smart-proxy with info from AMS API."
+                              },
+                              "cluster_version": {
+                                "type": "string",
+                                "description": "The version of the cluster.",
+                                "example": "1.0"
+                              },
+                              "last_checked_at": {
+                                "type": "string",
+                                "format": "date",
+                                "example": "2020-01-23T16:15:59.478901889Z"
                               }
                             }
                           }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1435,7 +1435,7 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.Org2ID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
-	_ = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	_ = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
 
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
@@ -1486,7 +1486,7 @@ func TestRuleClusterDetailEndpoint_ValidParametersActiveClusters(t *testing.T) {
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules, RecommendationCreatedAtTimestamp)
-	_ = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	_ = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
 
 	getRequestBody := fmt.Sprintf(`{"clusters":["%v"]}`, testdata.ClusterName)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -63,6 +63,17 @@ func checkResponseCode(t testing.TB, expected, actual int) {
 	}
 }
 
+func buildInfoWithVersion(version types.Version) []types.InfoItem {
+	return []types.InfoItem{
+		{
+			InfoID: "version_info|CLUSTER_VERSION_INFO",
+			Details: map[string]string{
+				"version": string(version),
+			},
+		},
+	}
+}
+
 func TestListOfClustersForNonExistingOrganization(t *testing.T) {
 	helpers.AssertAPIRequest(t, nil, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
@@ -1410,18 +1421,21 @@ func TestRuleClusterDetailEndpoint_OtherDBErrors(t *testing.T) {
 	})
 }
 
+// TODO: Add version_info
 func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	respBody := `{"clusters":[{"cluster":"%v", "cluster_name":"", "last_checked_at":"%v"}],"status":"ok"}`
+	respBody := `{"clusters":[{"cluster":"%v", "cluster_name":"", "cluster_version":"%v", "last_checked_at":"%v"}],"status":"ok"}`
 	expected := fmt.Sprintf(respBody,
 		testdata.ClusterName,
+		testdata.ClusterVersion,
 		RecommendationCreatedAtTimestamp,
 	)
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.Org2ID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
+	_ = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
 
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
@@ -1458,18 +1472,21 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 	})
 }
 
+// TODO: Add version_info
 func TestRuleClusterDetailEndpoint_ValidParametersActiveClusters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	respBody := `{"clusters":[{"cluster":"%v", "cluster_name":"", "last_checked_at":"%v"}],"status":"ok"}`
+	respBody := `{"clusters":[{"cluster":"%v", "cluster_name":"", "cluster_version":"%v", "last_checked_at":"%v"}],"status":"ok"}`
 	expected := fmt.Sprintf(respBody,
 		testdata.ClusterName,
+		testdata.ClusterVersion,
 		RecommendationCreatedAtTimestamp,
 	)
 
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules, RecommendationCreatedAtTimestamp)
+	_ = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
 
 	getRequestBody := fmt.Sprintf(`{"clusters":["%v"]}`, testdata.ClusterName)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1421,7 +1421,6 @@ func TestRuleClusterDetailEndpoint_OtherDBErrors(t *testing.T) {
 	})
 }
 
-// TODO: Add version_info
 func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()
@@ -1436,6 +1435,7 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
 	_ = mockStorage.WriteRecommendationsForCluster(testdata.Org2ID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
 	_ = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	_ = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
 
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
@@ -1472,7 +1472,6 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 	})
 }
 
-// TODO: Add version_info
 func TestRuleClusterDetailEndpoint_ValidParametersActiveClusters(t *testing.T) {
 	mockStorage, closer := helpers.MustGetMockStorage(t, true)
 	defer closer()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1432,10 +1432,13 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 		RecommendationCreatedAtTimestamp,
 	)
 
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.Org2ID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
-	_ = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
-	_ = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	err := mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
+	assert.NoError(t, err, fmt.Sprintf("error inserting report for cluster %s cluster and org %d", testdata.ClusterName, testdata.OrgID))
+	err = mockStorage.WriteRecommendationsForCluster(testdata.Org2ID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
+	assert.NoError(t, err, fmt.Sprintf("error inserting report for cluster %s cluster and org %d", testdata.ClusterName, testdata.Org2ID))
+
+	err = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	assert.NoError(t, err, fmt.Sprintf("error inserting info for cluster %s cluster and org %d", testdata.ClusterName, testdata.OrgID))
 
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
@@ -1445,6 +1448,10 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       expected,
 	})
+
+	err = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	assert.NoError(t, err, fmt.Sprintf("error inserting info for cluster %s cluster and org %d", testdata.ClusterName, testdata.Org2ID))
+
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.RuleClusterDetailEndpoint,
@@ -1454,6 +1461,9 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 		Body:       expected,
 	})
 
+	err = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	assert.NoError(t, err, fmt.Sprintf("error inserting info for cluster %s cluster and org %d", testdata.ClusterName, testdata.OrgID))
+
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.RuleClusterDetailEndpoint,
@@ -1462,6 +1472,10 @@ func TestRuleClusterDetailEndpoint_ValidParameters(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       expected,
 	})
+
+	err = mockStorage.WriteReportInfoForCluster(testdata.Org2ID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	assert.NoError(t, err, fmt.Sprintf("error inserting info for cluster %s cluster and org %d", testdata.ClusterName, testdata.Org2ID))
+
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.RuleClusterDetailEndpoint,
@@ -1483,9 +1497,12 @@ func TestRuleClusterDetailEndpoint_ValidParametersActiveClusters(t *testing.T) {
 		RecommendationCreatedAtTimestamp,
 	)
 
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
-	_ = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules, RecommendationCreatedAtTimestamp)
-	_ = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	err := mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.ClusterName, testdata.Report2Rules, RecommendationCreatedAtTimestamp)
+	assert.NoError(t, err, fmt.Sprintf("error inserting recommendation for cluster %s and org %d", testdata.ClusterName, testdata.OrgID))
+	err = mockStorage.WriteRecommendationsForCluster(testdata.OrgID, testdata.GetRandomClusterID(), testdata.Report2Rules, RecommendationCreatedAtTimestamp)
+	assert.NoError(t, err, fmt.Sprintf("error inserting recommendation for random cluster and org %d", testdata.OrgID))
+	err = mockStorage.WriteReportInfoForCluster(testdata.OrgID, testdata.ClusterName, buildInfoWithVersion(testdata.ClusterVersion), testdata.LastCheckedAt)
+	assert.NoError(t, err, fmt.Sprintf("error inserting info for cluster %s cluster and org %d", testdata.ClusterName, testdata.OrgID))
 
 	getRequestBody := fmt.Sprintf(`{"clusters":["%v"]}`, testdata.ClusterName)
 

--- a/types/types.go
+++ b/types/types.go
@@ -136,3 +136,9 @@ type RuleRating = types.RuleRating
 type Metadata struct {
 	GatheredAt time.Time `json:"gathering_time"`
 }
+
+// HittingClustersDataWithVersion used to store data of clusters hit by a concrete rule including the cluster version
+type HittingClustersDataWithVersion struct {
+	types.HittingClustersData
+	Version types.Version `json:"cluster_version"`
+}

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -16,8 +16,15 @@
 STORAGE=$1
 
 function run_unit_tests() {
+    if [ -z "$TEST_TO_RUN" ]; then
+        echo "No specific tests given. Running all available tests."
+        run_cmd=""
+    else
+        echo "Running specific test $TEST_TO_RUN"
+        run_cmd="-run $TEST_TO_RUN"
+    fi
     # shellcheck disable=SC2046
-    if ! go test -timeout 5m -coverprofile coverage.out $(go list ./... | grep -v tests | tr '\n' ' ')
+    if ! go test -timeout 5m $run_cmd -coverprofile coverage.out $(go list ./... | grep -v tests | tr '\n' ' ')
     then
         echo "unit tests failed"
         exit 1


### PR DESCRIPTION
# Description

Adding a `cluster_version` field to the already existing JSON.

Probably needs some refactoring as there is some code repetition. But first, I'd like to know your opinion about the changes.

Fixes #CCXDEV-6971

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Unit tests. **Pending to manually check.**

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
