### PR TITLE
Set an empty version if cannot be found in DB (second option)

### DIFF
--- a/storage/info_rule_test.go
+++ b/storage/info_rule_test.go
@@ -15,7 +15,6 @@
 package storage_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,8 +29,6 @@ func TestWriteReportInfoForCluster(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
 	defer closer()
 
-	itemNotFoundError := &types.ItemNotFoundError{ItemID: fmt.Sprintf("%d/%s", testdata.OrgID, testdata.ClusterName)}
-
 	expectations := []struct {
 		input   []types.InfoItem
 		version types.Version
@@ -40,16 +37,16 @@ func TestWriteReportInfoForCluster(t *testing.T) {
 		{
 			input:   nil,
 			version: "",
-			err:     itemNotFoundError,
+			err:     nil,
 		},
 		{
 			input:   []types.InfoItem{},
 			version: "",
-			err:     itemNotFoundError,
+			err:     nil,
 		},
 		{
 			input: []types.InfoItem{
-				types.InfoItem{
+				{
 					InfoID: "An info ID",
 					Details: map[string]string{
 						"version": "1.0",
@@ -57,11 +54,11 @@ func TestWriteReportInfoForCluster(t *testing.T) {
 				},
 			},
 			version: "",
-			err:     itemNotFoundError,
+			err:     nil,
 		},
 		{
 			input: []types.InfoItem{
-				types.InfoItem{
+				{
 					InfoID: "version_info|CLUSTER_VERSION_INFO",
 					Details: map[string]string{
 						"version": "1.0",

--- a/storage/info_rules.go
+++ b/storage/info_rules.go
@@ -89,6 +89,10 @@ func (storage *DBStorage) ReadReportInfoForCluster(
 		orgID, clusterName,
 	).Scan(&version)
 
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+
 	err = types.ConvertDBError(err, []interface{}{orgID, clusterName})
 	return version, err
 }

--- a/storage/info_rules.go
+++ b/storage/info_rules.go
@@ -85,7 +85,16 @@ func (storage *DBStorage) ReadReportInfoForCluster(
 	var version types.Version
 
 	err := storage.connection.QueryRow(
-		"SELECT COALESCE (version_info, '') FROM report_info WHERE org_id = $1 AND cluster_id = $2;",
+		`
+SELECT 
+	COALESCE ( 
+		( 
+			SELECT version_info 
+			FROM report_info 
+			WHERE org_id = $1 AND cluster_id = $2 
+		), '') 
+		AS version_info;
+		`,
 		orgID, clusterName,
 	).Scan(&version)
 

--- a/storage/info_rules.go
+++ b/storage/info_rules.go
@@ -85,13 +85,9 @@ func (storage *DBStorage) ReadReportInfoForCluster(
 	var version types.Version
 
 	err := storage.connection.QueryRow(
-		"SELECT version_info FROM report_info WHERE org_id = $1 AND cluster_id = $2;",
+		"SELECT COALESCE (version_info, '') FROM report_info WHERE org_id = $1 AND cluster_id = $2;",
 		orgID, clusterName,
 	).Scan(&version)
-
-	if err == sql.ErrNoRows {
-		return "", nil
-	}
 
 	err = types.ConvertDBError(err, []interface{}{orgID, clusterName})
 	return version, err


### PR DESCRIPTION
# Description

In case there is no cluster version stored (which is very likely), return an empty string.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Unit tests.

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
