### PR TITLE
Adding support for clowder topics mapping

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -319,7 +319,10 @@ objects:
         topicName: ${INCOMING_TOPIC}
       - replicas: 3
         partitions: 1
-        topicName: platform.payload-status
+        topicName: ${PAYLOAD_TRACKER_TOPIC}
+      - replicas: 3
+        partitions: 1
+        topicName: ${DEAD_LETTER_QUEUE_TOPIC}
 
 - kind: Service
   apiVersion: v1


### PR DESCRIPTION
# Description

This PR adds support to get the topic names from Clowder topics mapping, in order to get the real topic name instead of the requested one. This will become mandatory for managed Kafka deployments.

Fixes [#CCX9202](https://issues.redhat.com/browse/CCXDEV-9202)

## Type of change
- New feature (non-breaking change which adds functionality)

## Testing steps

Tested locally with unit tests and local clowder config

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
