### PR TITLE
temporarily disable cloudwatch to check logs

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -448,7 +448,7 @@ parameters:
   value: "false"
   required: true
 - name: CLOUDWATCH_ENABLED
-  value: "true"
+  value: "false"
   required: true
 - name: CREATE_STREAM_IF_NOT_EXISTS
   value: "true"


### PR DESCRIPTION
# Description
we need the logs to debug the ongoing prod issue with 404s.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
