### PR TITLE
Enable the public port for IRA web service

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -47,7 +47,8 @@ objects:
         minReplicas: ${{MIN_REPLICAS}}
         webServices:
           public:
-            enabled: false
+            enabled: true
+            apiPath: insights-results-aggregator
           private:
             enabled: true
           metrics:


### PR DESCRIPTION
# Description

This pull request modifies `clowdapp.yml` configuration file in order to enable the public port for insights-results-aggregator web service. This change is one of the requirements to complete the migration of front-end apps (like OCP Advisor, OCM) under c.r.c. to containerized builds. Since the apps are dependent on IRA backend, the service has to be available through the defined `apiPath`. More context: https://consoledot.pages.redhat.com/docs/dev/getting-started/frontend-migration.html#_step_0_add_apipath_to_back_end_clowdapp_web_service, https://consoledot.pages.redhat.com/clowder/dev/providers/web.html.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
