### PR TITLE
Use Go 1.17 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@
 
 language: go
 go:
-- "1.16"
+- "1.17"
 
 services:
   - postgresql
 
 jobs:
   include:
-    - name: "Build 1.16"
+    - name: "Build 1.17"
       stage: build
       script:
         - make


### PR DESCRIPTION
# Description

Use Go 1.17 on CI

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
