### PR TITLE
Remove `user_id` from everything cluster_rule_toggle related

### DIFF
--- a/migration/mig_0029_alter_cluster_rule_toggle_user_id.go
+++ b/migration/mig_0029_alter_cluster_rule_toggle_user_id.go
@@ -27,12 +27,6 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
-type alterConstraintStep struct {
-	tableName     string
-	oldConstraint string
-	newConstraint string
-}
-
 var mig0029DropClusterRuleToggleUserIDColumn = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
 		if driver == types.DBDriverPostgres {

--- a/migration/mig_0029_alter_cluster_rule_toggle_user_id.go
+++ b/migration/mig_0029_alter_cluster_rule_toggle_user_id.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This migration drops the user_id columns from all tables.
+// Some tables have the user_id in the PRIMARY KEY, but we should be OK dropping it
+// anyway because user_id was actually account_number, so the tables shouldn't have
+// duplicate records per rule (or per cluster) per organization.
+// Organization IDs were added and populated in previous migrations.
+
+package migration
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+type alterConstraintStep struct {
+	tableName     string
+	oldConstraint string
+	newConstraint string
+}
+
+var mig0029DropClusterRuleToggleUserIDColumn = Migration{
+	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
+		if driver == types.DBDriverPostgres {
+			dropColumnQuery := fmt.Sprintf(alterTableDropColumnQuery, clusterRuleToggleTable, userIDColumn)
+			_, err := tx.Exec(dropColumnQuery)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		if driver == types.DBDriverPostgres {
+			addColumnQuery := fmt.Sprintf(alterTableAddVarcharColumn, clusterRuleToggleTable, userIDColumn)
+			_, err := tx.Exec(addColumnQuery)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -48,6 +48,9 @@ const (
 	clusterReportTable                  = "report"
 	clusterRuleToggleTable              = "cluster_rule_toggle"
 	clusterUserRuleDisableFeedbackTable = "cluster_user_rule_disable_feedback"
+	alterTableDropColumnQuery           = "ALTER TABLE %v DROP COLUMN IF EXISTS %v"
+	alterTableAddVarcharColumn          = "ALTER TABLE %v ADD COLUMN %v VARCHAR NOT NULL DEFAULT '-1'"
+	userIDColumn                        = "user_id"
 )
 
 // GetMaxVersion returns the highest available migration version.

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -45,4 +45,5 @@ var migrations = []Migration{
 	mig0026AddAndPopulateOrgIDColumns,
 	mig0027CleanupInvalidRowsMissingOrgID,
 	mig0028AlterRuleDisablePKAndIndex,
+	mig0029DropClusterRuleToggleUserIDColumn,
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1827,7 +1827,7 @@
         ]
       }
     },
-    "/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/users/{user_id}/enable": {
+    "/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/enable": {
       "put": {
         "summary": "Re-enables a rule for all clusters",
         "operationId": "EnableRuleSystemWide",
@@ -1859,15 +1859,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "description": "Numeric ID of the user. An example: `42`",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1880,7 +1871,7 @@
         }
       }
     },
-    "/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/users/{user_id}/disable": {
+    "/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/disable": {
       "put": {
         "summary": "Disables a rule for all clusters",
         "operationId": "DisableRuleSystemWide",
@@ -1909,15 +1900,6 @@
             "in": "path",
             "required": true,
             "description": "Numeric ID of organization",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "description": "Numeric ID of the user. An example: `42`",
             "schema": {
               "type": "string"
             }

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -56,9 +56,9 @@ const (
 	// ClustersForOrganizationEndpoint returns all clusters for {organization}
 	ClustersForOrganizationEndpoint = "organizations/{organization}/clusters"
 	// DisableRuleForClusterEndpoint disables a rule for specified cluster
-	DisableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/users/{user_id}/disable"
+	DisableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/disable"
 	// EnableRuleForClusterEndpoint re-enables a rule for specified cluster
-	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/users/{user_id}/enable"
+	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/enable"
 	// DisableRuleFeedbackEndpoint accepts a feedback from user when (s)he disables a rule
 	DisableRuleFeedbackEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/organizations/{org_id}/users/{user_id}/disable_feedback"
 	// ListOfDisabledRules returns a list of rules disabled from current account

--- a/server/rules.go
+++ b/server/rules.go
@@ -53,19 +53,13 @@ func (server *HTTPServer) toggleRuleForCluster(writer http.ResponseWriter, reque
 		return
 	}
 
-	userID, successful := readUserID(writer, request)
-	if !successful {
-		// everything has been handled already
-		return
-	}
-
 	orgID, successful := readOrgID(writer, request)
 	if !successful {
 		// everything has been handled already
 		return
 	}
 
-	err := server.Storage.ToggleRuleForCluster(clusterID, ruleID, errorKey, orgID, userID, toggleRule)
+	err := server.Storage.ToggleRuleForCluster(clusterID, ruleID, errorKey, orgID, toggleRule)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to toggle rule for selected cluster")
 		handleServerError(writer, err)

--- a/server/server_read_report_test.go
+++ b/server/server_read_report_test.go
@@ -258,7 +258,7 @@ func TestReadReportDisableRule(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodPut,
 		Endpoint:     server.DisableRuleForClusterEndpoint,
-		EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       `{"status": "ok"}`,
@@ -293,7 +293,7 @@ func TestReadReportDisableRule(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodPut,
 		Endpoint:     server.EnableRuleForClusterEndpoint,
-		EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       `{"status": "ok"}`,
@@ -369,7 +369,7 @@ func TestReadReport_RuleDisableFeedback(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodPut,
 		Endpoint:     server.DisableRuleForClusterEndpoint,
-		EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       `{"status": "ok"}`,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -628,7 +628,7 @@ func TestRuleToggle(t *testing.T) {
 			helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 				Method:       http.MethodPut,
 				Endpoint:     endpoint,
-				EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID},
+				EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusOK,
 				Body:       `{"status": "ok"}`,
@@ -1682,7 +1682,7 @@ func TestHTTPServer_ListOfDisabledClusters_OneDisabled(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodPut,
 		Endpoint:     server.DisableRuleForClusterEndpoint,
-		EndpointArgs: []interface{}{clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       `{"status": "ok"}`,
@@ -1721,7 +1721,7 @@ func TestHTTPServer_ListOfDisabledClusters_JustificationTests(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodPut,
 		Endpoint:     server.DisableRuleForClusterEndpoint,
-		EndpointArgs: []interface{}{clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       `{"status": "ok"}`,

--- a/storage/info_rule_test.go
+++ b/storage/info_rule_test.go
@@ -140,7 +140,7 @@ func TestDBStorageReadClusterListRecommendationsWithVersion(t *testing.T) {
 		testdata.OrgID,
 		testdata.ClusterName,
 		[]types.InfoItem{
-			types.InfoItem{
+			{
 				InfoID: "version_info|CLUSTER_VERSION_INFO",
 				Details: map[string]string{
 					"version": string(testdata.ClusterVersion),

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -189,7 +189,7 @@ func (*NoopStorage) WriteConsumerError(*sarama.ConsumerMessage, error) error {
 
 // ToggleRuleForCluster noop
 func (*NoopStorage) ToggleRuleForCluster(
-	types.ClusterName, types.RuleID, types.ErrorKey, types.OrgID, types.UserID, RuleToggle,
+	types.ClusterName, types.RuleID, types.ErrorKey, types.OrgID, RuleToggle,
 ) error {
 	return nil
 }

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -59,7 +59,7 @@ func TestNoopStorage_Methods_Cont(t *testing.T) {
 	_ = noopStorage.CreateRuleErrorKey(types.RuleErrorKey{})
 	_ = noopStorage.DeleteRuleErrorKey("", "")
 	_ = noopStorage.WriteConsumerError(nil, nil)
-	_ = noopStorage.ToggleRuleForCluster("", "", "", 0, "", 0)
+	_ = noopStorage.ToggleRuleForCluster("", "", "", 0, 0)
 	_ = noopStorage.DeleteFromRuleClusterToggle("", "")
 	_, _ = noopStorage.GetFromClusterRuleToggle("", "")
 	_, _ = noopStorage.GetTogglesForRules("", nil, types.OrgID(1))

--- a/storage/rule_list.go
+++ b/storage/rule_list.go
@@ -116,12 +116,14 @@ func (storage DBStorage) ListOfDisabledRules(orgID types.OrgID) ([]ctypes.Disabl
 	for rows.Next() {
 		var disabledRule ctypes.DisabledRule
 
-		err = rows.Scan(&disabledRule.ClusterID,
+		err = rows.Scan(
+			&disabledRule.ClusterID,
 			&disabledRule.RuleID,
 			&disabledRule.ErrorKey,
 			&disabledRule.DisabledAt,
 			&disabledRule.UpdatedAt,
-			&disabledRule.Disabled)
+			&disabledRule.Disabled,
+		)
 
 		if err != nil {
 			log.Error().Err(err).Msg("ReadListOfDisabledRules database error")
@@ -178,12 +180,14 @@ func (storage DBStorage) ListOfDisabledRulesForClusters(
 	for rows.Next() {
 		var disabledRule ctypes.DisabledRule
 
-		err = rows.Scan(&disabledRule.ClusterID,
+		err = rows.Scan(
+			&disabledRule.ClusterID,
 			&disabledRule.RuleID,
 			&disabledRule.ErrorKey,
 			&disabledRule.DisabledAt,
 			&disabledRule.UpdatedAt,
-			&disabledRule.Disabled)
+			&disabledRule.Disabled,
+		)
 
 		if err != nil {
 			log.Error().Err(err).Msg("ReadListOfDisabledRulesForClusters database error")

--- a/storage/rule_toggle.go
+++ b/storage/rule_toggle.go
@@ -50,7 +50,6 @@ func (storage DBStorage) ToggleRuleForCluster(
 	ruleID types.RuleID,
 	errorKey types.ErrorKey,
 	orgID types.OrgID,
-	userID types.UserID,
 	ruleToggle RuleToggle,
 ) error {
 
@@ -71,16 +70,15 @@ func (storage DBStorage) ToggleRuleForCluster(
 
 	query = `
 		INSERT INTO cluster_rule_toggle(
-			cluster_id, rule_id, error_key, org_id, user_id, disabled, disabled_at, enabled_at, updated_at
+			cluster_id, rule_id, error_key, org_id, disabled, disabled_at, enabled_at, updated_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (cluster_id, rule_id, error_key) DO UPDATE SET
 			org_id = $4,
-			user_id = $5,
-		    disabled = $6,
-			disabled_at = $7,
-			enabled_at = $8,
-			updated_at = $9
+		    disabled = $5,
+			disabled_at = $6,
+			enabled_at = $7,
+			updated_at = $8
 	`
 
 	_, err := storage.connection.Exec(
@@ -89,7 +87,6 @@ func (storage DBStorage) ToggleRuleForCluster(
 		ruleID,
 		errorKey,
 		orgID,
-		userID,
 		ruleToggle,
 		disabledAt,
 		enabledAt,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -141,7 +141,6 @@ type Storage interface {
 		ruleID types.RuleID,
 		errorKey types.ErrorKey,
 		orgID types.OrgID,
-		userID types.UserID,
 		ruleToggle RuleToggle,
 	) error
 	GetFromClusterRuleToggle(

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -62,7 +62,7 @@ func TestDBStorage_ToggleRuleForCluster(t *testing.T) {
 			mustWriteReport3Rules(t, mockStorage)
 
 			helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
-				testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID, state,
+				testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, state,
 			))
 
 			_, err := mockStorage.GetFromClusterRuleToggle(testdata.ClusterName, testdata.Rule1ID)
@@ -76,7 +76,7 @@ func TestDBStorage_ToggleRuleForCluster_UnexpectedRuleToggleValue(t *testing.T) 
 	defer closer()
 
 	err := mockStorage.ToggleRuleForCluster(
-		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID, -999,
+		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, -999,
 	)
 	assert.EqualError(t, err, "Unexpected rule toggle value")
 }
@@ -86,7 +86,7 @@ func TestDBStorage_ToggleRuleForCluster_DBError(t *testing.T) {
 	closer()
 
 	err := mockStorage.ToggleRuleForCluster(
-		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID, storage.RuleToggleDisable,
+		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, storage.RuleToggleDisable,
 	)
 	assert.EqualError(t, err, "sql: database is closed")
 }
@@ -116,7 +116,7 @@ func TestDBStorageGetTogglesForRules_OneRuleDisabled(t *testing.T) {
 	defer closer()
 
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
-		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID, storage.RuleToggleDisable,
+		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, storage.RuleToggleDisable,
 	))
 
 	result, err := mockStorage.GetTogglesForRules(
@@ -145,7 +145,7 @@ func TestDBStorageToggleRuleAndGet(t *testing.T) {
 			mustWriteReport3Rules(t, mockStorage)
 
 			helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
-				testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, testdata.UserID, state,
+				testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, state,
 			))
 
 			toggledRule, err := mockStorage.GetFromClusterRuleToggle(testdata.ClusterName, testdata.Rule1ID)
@@ -261,7 +261,7 @@ func TestDBStorageListOfDisabledRulesOneRule(t *testing.T) {
 	// disable one rule
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled rules
@@ -291,11 +291,11 @@ func TestDBStorageListOfDisabledRulesTwoRules(t *testing.T) {
 	// disable two rules
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		testdata.ClusterName, testdata.Rule2ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled rules
@@ -327,7 +327,7 @@ func TestDBStorageListOfDisabledRulesNoRule(t *testing.T) {
 	// enable one rule
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleEnable,
+		storage.RuleToggleEnable,
 	))
 
 	// try to read list of disabled rules
@@ -862,7 +862,7 @@ func TestDBStorageListOfDisabledClustersOneRule(t *testing.T) {
 	// disable one cluster
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled clusters
@@ -892,12 +892,12 @@ func TestDBStorageListOfDisabledClustersTwoClusters(t *testing.T) {
 	// disable two clusters, same rule
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		clusters[2], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled clusters
@@ -930,7 +930,7 @@ func TestDBStorageListOfDisabledClustersDifferentRule(t *testing.T) {
 	// disable one cluster
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled clusters, but requesting different rule than disabled
@@ -958,7 +958,7 @@ func TestDBStorageListOfDisabledClustersFeedback(t *testing.T) {
 	// disable one cluster
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// add feedback
@@ -995,7 +995,7 @@ func TestDBStorageListOfDisabledClustersFeedbackUpdate(t *testing.T) {
 	// disable one cluster
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		clusters[0], testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// add feedback
@@ -1076,7 +1076,7 @@ func TestDBStorageListOfDisabledRulesForClustersOneRule(t *testing.T) {
 	// disable one rule
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		ctypes.ClusterName(clusters[0]), testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled rules
@@ -1113,11 +1113,11 @@ func TestDBStorageListOfDisabledRulesForClustersTwoRules(t *testing.T) {
 	// disable same rule, different clusters
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		ctypes.ClusterName(clusters[0]), testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		ctypes.ClusterName(clusters[1]), testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled rules
@@ -1147,7 +1147,7 @@ func TestDBStorageListOfDisabledRulesForClustersNoRule(t *testing.T) {
 	// disable one rule for one cluster
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		ctypes.ClusterName(clusters[0]), testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled rules, we're requesting a list for a different list of clusters
@@ -1160,7 +1160,7 @@ func TestDBStorageListOfDisabledRulesForClustersNoRule(t *testing.T) {
 	// disable one rule for one of the clusters we want
 	helpers.FailOnError(t, mockStorage.ToggleRuleForCluster(
 		ctypes.ClusterName(clusters[1]), testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID,
-		testdata.UserID, storage.RuleToggleDisable,
+		storage.RuleToggleDisable,
 	))
 
 	// try to read list of disabled rules, this time there should be one rule among them

--- a/utils/fill_in_disable_rule_tables.py
+++ b/utils/fill_in_disable_rule_tables.py
@@ -168,9 +168,9 @@ def insert_into_db_for_clusters(
     try:
         # try to perform insert statement
         insertStatement = """INSERT INTO cluster_rule_toggle
-                             (cluster_id, rule_id, error_key, user_id, disabled, disabled_at,
+                             (cluster_id, rule_id, error_key, disabled, disabled_at,
                              updated_at, org_id)
-                             VALUES(%s, %s, %s, %s, 1, %s, %s, 1);"""
+                             VALUES(%s, %s, %s, 1, %s, %s, 1);"""
 
         # generate timestamp to be stored in database
         timestamp = datetime.now().strftime("%Y-%m-%d")
@@ -182,7 +182,6 @@ def insert_into_db_for_clusters(
                 cluster_id,
                 rule_selector[0],
                 rule_selector[1],
-                account_id,
                 timestamp,
                 timestamp,
             ),


### PR DESCRIPTION
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Changes in REST API schema
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit`

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
