### PR TITLE
Get rid of `user_id` in `advisor_ratings` table

### DIFF
--- a/migration/mig_0031_alter_constraint_drop_user_id_advisor_ratings.go
+++ b/migration/mig_0031_alter_constraint_drop_user_id_advisor_ratings.go
@@ -1,0 +1,103 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This migration drops the user_id columns from the advisor_ratings table.
+// Some tables have the user_id in the PRIMARY KEY, but we should be OK dropping it
+// anyway because user_id was actually account_number, so the tables shouldn't have
+// duplicate records per rule (or per cluster) per organization.
+// Organization IDs were added and populated in previous migrations.
+
+package migration
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+type alterConstraintStep struct {
+	tableName     string
+	oldConstraint string
+	newConstraint string
+}
+
+var migrationStep = alterConstraintStep{
+	tableName:     "advisor_ratings",
+	oldConstraint: "(user_id, org_id, rule_fqdn, error_key)",
+	newConstraint: "(org_id, rule_fqdn, error_key)",
+}
+
+var mig0031AlterConstraintDropUserAdvisorRatings = Migration{
+	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
+		if driver == types.DBDriverPostgres {
+
+			// user_id is in the primary key, we need to create a new one
+			dropPKQuery := fmt.Sprintf(alterTableDropPK, migrationStep.tableName, migrationStep.tableName)
+			_, err := tx.Exec(dropPKQuery)
+			if err != nil {
+				return err
+			}
+
+			addPKQuery := fmt.Sprintf(
+				alterTableAddPK,
+				migrationStep.tableName,
+				migrationStep.tableName,
+				migrationStep.newConstraint,
+			)
+
+			_, err = tx.Exec(addPKQuery)
+			if err != nil {
+				return err
+			}
+
+			dropColumnQuery := fmt.Sprintf(alterTableDropColumnQuery, migrationStep.tableName, userIDColumn)
+			_, err = tx.Exec(dropColumnQuery)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		if driver == types.DBDriverPostgres {
+
+			addColumnQuery := fmt.Sprintf(alterTableAddVarcharColumn, migrationStep.tableName, userIDColumn)
+			_, err := tx.Exec(addColumnQuery)
+			if err != nil {
+				return err
+			}
+
+			dropPKQuery := fmt.Sprintf(alterTableDropPK, migrationStep.tableName, migrationStep.tableName)
+			_, err = tx.Exec(dropPKQuery)
+			if err != nil {
+				return err
+			}
+
+			addPKQuery := fmt.Sprintf(
+				alterTableAddPK,
+				migrationStep.tableName,
+				migrationStep.tableName,
+				migrationStep.oldConstraint,
+			)
+			_, err = tx.Exec(addPKQuery)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -50,6 +50,8 @@ const (
 	clusterUserRuleDisableFeedbackTable = "cluster_user_rule_disable_feedback"
 	alterTableDropColumnQuery           = "ALTER TABLE %v DROP COLUMN IF EXISTS %v"
 	alterTableAddVarcharColumn          = "ALTER TABLE %v ADD COLUMN %v VARCHAR NOT NULL DEFAULT '-1'"
+	alterTableDropPK                    = "ALTER TABLE %v DROP CONSTRAINT IF EXISTS %v_pkey"
+	alterTableAddPK                     = "ALTER TABLE %v ADD CONSTRAINT %v_pkey PRIMARY KEY %v"
 	userIDColumn                        = "user_id"
 )
 

--- a/migration/migrations.go
+++ b/migration/migrations.go
@@ -47,4 +47,5 @@ var migrations = []Migration{
 	mig0028AlterRuleDisablePKAndIndex,
 	mig0029DropClusterRuleToggleUserIDColumn,
 	mig0030DropRuleDisableUserIDColumn,
+	mig0031AlterConstraintDropUserAdvisorRatings,
 }

--- a/openapi.json
+++ b/openapi.json
@@ -2027,7 +2027,7 @@
         }
       }
     },
-    "/rules/organizations/{orgId}/users/{userId}/rating": {
+    "/rules/organizations/{orgId}/rating": {
       "post": {
         "tags": [
           "prod"
@@ -2038,16 +2038,6 @@
             "in": "path",
             "required": true,
             "description": "Numeric ID of the organization",
-            "schema": {
-              "type": "string"
-            },
-            "example": "42"
-          },
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "description": "Numeric ID of the user",
             "schema": {
               "type": "string"
             },
@@ -2200,7 +2190,7 @@
         ]
       }
     },
-    "/rules/{rule_selector}/organizations/{org_id}/users/{user_id}/rating": {
+    "/rules/{rule_selector}/organizations/{org_id}/rating": {
       "get": {
         "summary": "Returns the user rating for given rule ID.",
         "operationId": "getRatingForRecommendation",
@@ -2224,16 +2214,6 @@
               "type": "string"
             },
             "example": "123422"
-          },
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "description": "Numeric ID of the user",
-            "schema": {
-              "type": "string"
-            },
-            "example": "42"
           }
         ],
         "responses": {

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -20,6 +20,7 @@ set -exv
 # Options that must be configured by app owner
 # --------------------------------------------
 APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
+REF_ENV="insights-stage"
 COMPONENT_NAME="ccx-insights-results"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/insights-results-aggregator"
 COMPONENTS="ccx-data-pipeline ccx-insights-results insights-content-service insights-results-smart-proxy"  # space-separated list of components to laod

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -91,9 +91,9 @@ const (
 	ClustersRecommendationsListEndpoint = "clusters/organizations/{org_id}/users/{user_id}/recommendations"
 
 	// Rating accepts a list of ratings in the request body and store them in the database for the given user
-	Rating = "rules/organizations/{org_id}/users/{user_id}/rating"
+	Rating = "rules/organizations/{org_id}/rating"
 	// GetRating retrieves the rating for a specific rule and user
-	GetRating = "rules/{rule_selector}/organizations/{org_id}/users/{user_id}/rating"
+	GetRating = "rules/{rule_selector}/organizations/{org_id}/rating"
 
 	// InfoEndpoint returns basic information about Insights Aggregator
 	// version, utils repository version, commit hash etc.

--- a/server/rating.go
+++ b/server/rating.go
@@ -29,13 +29,6 @@ func (server *HTTPServer) setRuleRating(writer http.ResponseWriter, request *htt
 		return
 	}
 
-	// Extract user_id from URL
-	userID, ok := readUserID(writer, request)
-	if !ok {
-		// everything is handled
-		return
-	}
-
 	// extract org_id from URL
 	orgID, ok := readOrgID(writer, request)
 	if !ok {
@@ -52,7 +45,7 @@ func (server *HTTPServer) setRuleRating(writer http.ResponseWriter, request *htt
 	}
 
 	// Store to the db
-	err = server.Storage.RateOnRule(userID, orgID, ruleID, errorKey, rating.Rating)
+	err = server.Storage.RateOnRule(orgID, ruleID, errorKey, rating.Rating)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to store rating")
 		handleServerError(writer, err)
@@ -72,11 +65,6 @@ func (server *HTTPServer) setRuleRating(writer http.ResponseWriter, request *htt
 func (server *HTTPServer) getRuleRating(writer http.ResponseWriter, request *http.Request) {
 	log.Info().Msg("getRuleRating")
 
-	userID, ok := readUserID(writer, request)
-	if !ok {
-		return
-	}
-
 	orgID, ok := readOrgID(writer, request)
 	if !ok {
 		return
@@ -87,7 +75,7 @@ func (server *HTTPServer) getRuleRating(writer http.ResponseWriter, request *htt
 		return
 	}
 
-	rating, err := server.Storage.GetRuleRating(userID, orgID, ruleSelector)
+	rating, err := server.Storage.GetRuleRating(orgID, ruleSelector)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to get rating")
 		handleServerError(writer, err)

--- a/server/rating_test.go
+++ b/server/rating_test.go
@@ -32,7 +32,7 @@ func TestHTTPServer_RateOnRule(t *testing.T) {
 	helpers.AssertAPIRequest(t, nil, nil, &helpers.APIRequest{
 		Method:       http.MethodPost,
 		Endpoint:     server.Rating,
-		EndpointArgs: []interface{}{testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.OrgID},
 		Body:         ratingBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
@@ -46,7 +46,7 @@ func TestHTTPServer_RateOnRuleNoContent(t *testing.T) {
 	helpers.AssertAPIRequest(t, nil, nil, &helpers.APIRequest{
 		Method:       http.MethodPost,
 		Endpoint:     server.Rating,
-		EndpointArgs: []interface{}{testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusBadRequest,
 		Body:       expectedError,
@@ -59,7 +59,7 @@ func TestHTTPServer_RateOnRuleBadContent(t *testing.T) {
 	helpers.AssertAPIRequest(t, nil, nil, &helpers.APIRequest{
 		Method:       http.MethodPost,
 		Endpoint:     server.Rating,
-		EndpointArgs: []interface{}{testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.OrgID},
 		Body:         ratingBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusBadRequest,
@@ -70,7 +70,7 @@ func TestHTTPServer_getRuleRating_NoRating(t *testing.T) {
 	helpers.AssertAPIRequest(t, nil, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.GetRating,
-		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusNotFound,
 	})
@@ -82,7 +82,7 @@ func TestHTTPServer_getRuleRating_OK(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.RateOnRule(
-		testdata.UserID, testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
+		testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
 	)
 	helpers.FailOnError(t, err)
 
@@ -92,7 +92,7 @@ func TestHTTPServer_getRuleRating_OK(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.GetRating,
-		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       expectedResponseBody,
@@ -104,7 +104,7 @@ func TestHTTPServer_getRuleRating_MultipleOK(t *testing.T) {
 	defer closer()
 
 	err := mockStorage.RateOnRule(
-		testdata.UserID, testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
+		testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
 	)
 	helpers.FailOnError(t, err)
 
@@ -114,14 +114,14 @@ func TestHTTPServer_getRuleRating_MultipleOK(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.GetRating,
-		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       expectedResponseBody,
 	})
 
 	err = mockStorage.RateOnRule(
-		testdata.UserID, testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteDislike,
+		testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteDislike,
 	)
 	helpers.FailOnError(t, err)
 
@@ -131,7 +131,7 @@ func TestHTTPServer_getRuleRating_MultipleOK(t *testing.T) {
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.GetRating,
-		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID, testdata.UserID},
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID, testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       expectedResponseBody,

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -289,7 +289,6 @@ func (*NoopStorage) ListOfDisabledRulesForClusters(
 
 // RateOnRule function stores the vote (rating) given by an user to a rule+error key
 func (*NoopStorage) RateOnRule(
-	types.UserID,
 	types.OrgID,
 	types.RuleID,
 	types.ErrorKey,
@@ -300,7 +299,6 @@ func (*NoopStorage) RateOnRule(
 
 // GetRuleRating retrieves rating for given rule and user
 func (*NoopStorage) GetRuleRating(
-	userID types.UserID,
 	orgID types.OrgID,
 	ruleSelector types.RuleSelector,
 ) (

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -75,9 +75,8 @@ func TestNoopStorage_Methods_Cont(t *testing.T) {
 	_, _ = noopStorage.ListOfReasons("")
 	_, _ = noopStorage.ListOfDisabledRulesForClusters([]string{}, types.OrgID(1))
 	_ = noopStorage.WriteRecommendationsForCluster(0, "", "", "")
-	_ = noopStorage.RateOnRule(types.UserID("99"), types.OrgID(1), "", "",
-		types.UserVote(1))
-	_, _ = noopStorage.GetRuleRating(types.UserID("99"), types.OrgID(1), "id")
+	_ = noopStorage.RateOnRule(types.OrgID(1), "", "", types.UserVote(1))
+	_, _ = noopStorage.GetRuleRating(types.OrgID(1), "id")
 }
 
 func TestNoopStorage_Methods_Cont2(t *testing.T) {

--- a/storage/rating_test.go
+++ b/storage/rating_test.go
@@ -32,7 +32,7 @@ func TestDBStorage_RateOnRule(t *testing.T) {
 	mustWriteReport3Rules(t, mockStorage)
 
 	err := mockStorage.RateOnRule(
-		testdata.UserID, testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
+		testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
 	)
 	helpers.FailOnError(t, err)
 }
@@ -44,11 +44,11 @@ func TestDBStorage_GetRuleRating(t *testing.T) {
 	mustWriteReport3Rules(t, mockStorage)
 
 	err := mockStorage.RateOnRule(
-		testdata.UserID, testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
+		testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
 	)
 	helpers.FailOnError(t, err)
 
-	rating, err := mockStorage.GetRuleRating(testdata.UserID, testdata.OrgID, types.RuleSelector(testdata.Rule1CompositeID))
+	rating, err := mockStorage.GetRuleRating(testdata.OrgID, types.RuleSelector(testdata.Rule1CompositeID))
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, types.UserVoteLike, rating.Rating)
@@ -62,10 +62,10 @@ func TestDBStorage_GetRuleRating_NotFound(t *testing.T) {
 	mustWriteReport3Rules(t, mockStorage)
 
 	err := mockStorage.RateOnRule(
-		testdata.UserID, testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
+		testdata.OrgID, testdata.Rule1ID, testdata.ErrorKey1, types.UserVoteLike,
 	)
 	helpers.FailOnError(t, err)
 
-	_, err = mockStorage.GetRuleRating(testdata.UserID, testdata.OrgID, types.RuleSelector(testdata.Rule2CompositeID))
+	_, err = mockStorage.GetRuleRating(testdata.OrgID, types.RuleSelector(testdata.Rule2CompositeID))
 	assert.NotNil(t, err)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -181,14 +181,12 @@ type Storage interface {
 		errorKey types.ErrorKey,
 	) ([]ctypes.DisabledClusterInfo, error)
 	RateOnRule(
-		types.UserID,
 		types.OrgID,
 		types.RuleID,
 		types.ErrorKey,
 		types.UserVote,
 	) error
 	GetRuleRating(
-		types.UserID,
 		types.OrgID,
 		types.RuleSelector,
 	) (types.RuleRating, error)


### PR DESCRIPTION
# Description

This one is a bit more complicated than the previous ones, because the `user_id` is in the primary key, but we should be OK dropping it anyway because user_id was actually account_number, so the tables shouldn't have duplicate records per rule (or per cluster) per organization.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit`

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
