### PR TITLE
fix Migration 31 by deleting rows blocking the new PK

### DIFF
--- a/migration/mig_0031_alter_constraint_drop_user_id_advisor_ratings.go
+++ b/migration/mig_0031_alter_constraint_drop_user_id_advisor_ratings.go
@@ -42,10 +42,15 @@ var migrationStep = alterConstraintStep{
 var mig0031AlterConstraintDropUserAdvisorRatings = Migration{
 	StepUp: func(tx *sql.Tx, driver types.DBDriver) error {
 		if driver == types.DBDriverPostgres {
+			deleteInvalidRowsQuery := "DELETE FROM advisor_ratings WHERE user_id = '0'"
+			_, err := tx.Exec(deleteInvalidRowsQuery)
+			if err != nil {
+				return err
+			}
 
 			// user_id is in the primary key, we need to create a new one
 			dropPKQuery := fmt.Sprintf(alterTableDropPK, migrationStep.tableName, migrationStep.tableName)
-			_, err := tx.Exec(dropPKQuery)
+			_, err = tx.Exec(dropPKQuery)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description
I forgot that we started saving "0" when the `user_id` is empty (most of the times), so the new PK cannot be created until the problematic rows are deleted.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
`make before_commit`

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
