### PR TITLE
[CCXDEV-11124] Add deployment for cache-writer (just Redis)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,6 +41,11 @@ redis-cli -h cache-writer-redis -p 6379 SET mykey "Hello\nWorld";
 redis-cli -h cache-writer-redis -p 6379 GET mykey;
 ```
 
+You can also check that the metrics are exposed:
+```
+curl cache-writer-redis-metrics:9121/metrics
+```
+
 Don't worry if you can't see the command prompt. Just write and execute commands.
 Then exit with CTRL+D.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,52 @@
+# Deployment
+
+## Testing the local version of the cache-writer in ephemeral
+
+1. Install `bonfire`
+```
+pip install crc-bonfire
+```
+
+2. Log into https://console-openshift-console.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/k8s/cluster/projects
+
+```
+oc login --token=${TOKEN} --server=https://api.c-rh-c-eph.8p0c.p1.openshiftapps.com:6443
+```
+
+3. Reserve a namespace
+```
+NAMESPACE=$(bonfire namespace reserve)
+```
+
+4. Deploy the cache-writer and Redis workloads
+```
+bonfire deploy -c deploy/test-cache-writer.yaml -n $NAMESPACE ccx-data-pipeline
+```
+
+5. Test that you can read and write from Redis
+
+Spin up a container:
+
+```
+oc --namespace $NAMESPACE run test -i --rm \
+    --image=quay.io/edge-infrastructure/redis:6.2.7-debian-10-r23 \
+    sh
+```
+
+And run:
+```
+export REDISCLI_AUTH="rNOp(B^!Y1tRpGL50w_6rAv~"
+redis-cli -h cache-writer-redis -p 6379 ping; echo $?
+redis-cli -h cache-writer-redis -p 6379 SET mykey "Hello\nWorld";
+redis-cli -h cache-writer-redis -p 6379 GET mykey;
+```
+
+Don't worry if you can't see the command prompt. Just write and execute commands.
+Then exit with CTRL+D.
+
+6. TODO: Test the cache-writer
+
+7. Delete the namespace
+```
+bonfire namespace release $NAMESPACE 
+```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -36,14 +36,14 @@ oc --namespace $NAMESPACE run test -i --rm \
 And run:
 ```
 export REDISCLI_AUTH="rNOp(B^!Y1tRpGL50w_6rAv~"
-redis-cli -h cache-writer-redis -p 6379 ping; echo $?
-redis-cli -h cache-writer-redis -p 6379 SET mykey "Hello\nWorld";
-redis-cli -h cache-writer-redis -p 6379 GET mykey;
+redis-cli -h ccx-redis -p 6379 ping; echo $?
+redis-cli -h ccx-redis -p 6379 SET mykey "Hello\nWorld";
+redis-cli -h ccx-redis -p 6379 GET mykey;
 ```
 
 You can also check that the metrics are exposed:
 ```
-curl cache-writer-redis-metrics:9121/metrics
+curl ccx-redis-metrics:9121/metrics
 ```
 
 Don't worry if you can't see the command prompt. Just write and execute commands.

--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -28,7 +28,7 @@ objects:
       app: ccx-data-pipeline
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
-    name: cache-writer-redis
+    name: ccx-redis
   spec:
     replicas: 1
     selector:
@@ -36,7 +36,7 @@ objects:
         app: ccx-data-pipeline
         app.kubernetes.io/instance: cache-writer
         app.kubernetes.io/name: redis
-    serviceName: cache-writer-redis-headless
+    serviceName: ccx-redis-headless
     template:
       metadata:
         labels:
@@ -114,7 +114,7 @@ objects:
           - mountPath: /health
             name: health
           - mountPath: /data
-            name: cache-writer-redis-data
+            name: ccx-redis-data
             subPath: null
           - mountPath: /opt/bitnami/redis/mounted-etc
             name: config
@@ -132,7 +132,7 @@ objects:
             redis_exporter
           env:
           - name: REDIS_ALIAS
-            value: cache-writer-redis
+            value: ccx-redis
           - name: REDIS_USER
             value: default
           - name: REDIS_PASSWORD
@@ -156,14 +156,14 @@ objects:
         volumes:
         - configMap:
             defaultMode: 493
-            name: cache-writer-redis-scripts
+            name: ccx-redis-scripts
           name: start-scripts
         - configMap:
             defaultMode: 493
-            name: cache-writer-redis-health
+            name: ccx-redis-health
           name: health
         - configMap:
-            name: cache-writer-redis-configuration
+            name: ccx-redis-configuration
           name: config
         - emptyDir: {}
           name: redis-tmp-conf
@@ -178,7 +178,7 @@ objects:
           app: ccx-data-pipeline
           app.kubernetes.io/instance: cache-writer
           app.kubernetes.io/name: redis
-        name: cache-writer-redis-data
+        name: ccx-redis-data
       spec:
         accessModes:
         - ReadWriteOnce
@@ -192,7 +192,7 @@ objects:
       app: ccx-data-pipeline
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
-    name: cache-writer-redis-metrics
+    name: ccx-redis-metrics
   spec:
     ports:
     - name: http-metrics
@@ -211,7 +211,7 @@ objects:
       app: ccx-data-pipeline
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
-    name: cache-writer-redis
+    name: ccx-redis
   spec:
     internalTrafficPolicy: Cluster
     ports:
@@ -232,7 +232,7 @@ objects:
       app: ccx-data-pipeline
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
-    name: cache-writer-redis-headless
+    name: ccx-redis-headless
   spec:
     clusterIP: None
     ports:
@@ -268,7 +268,7 @@ objects:
       app: ccx-data-pipeline
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
-    name: cache-writer-redis-scripts
+    name: ccx-redis-scripts
 - apiVersion: v1
   data:
     ping_liveness_local.sh: |-
@@ -371,7 +371,7 @@ objects:
       app: ccx-data-pipeline
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
-    name: cache-writer-redis-health
+    name: ccx-redis-health
 - apiVersion: v1
   data:
     master.conf: |-
@@ -400,7 +400,7 @@ objects:
       app: ccx-data-pipeline
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
-    name: cache-writer-redis-configuration
+    name: ccx-redis-configuration
 
 parameters:
 # cache-writer

--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -1,0 +1,420 @@
+# Copyright 2023 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ccx-cache-writer
+objects:
+# TODO: Add the cache-writer deployment + services
+
+# Redis instance (https://github.com/openshift-assisted/assisted-events-stream/blob/master/openshift/template.yaml)
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    name: cache-writer-redis
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ccx-data-pipeline
+        app.kubernetes.io/instance: cache-writer
+        app.kubernetes.io/name: redis
+    serviceName: cache-writer-redis-headless
+    template:
+      metadata:
+        labels:
+          app: ccx-data-pipeline
+          app.kubernetes.io/instance: cache-writer
+          app.kubernetes.io/name: redis
+      spec:
+        affinity:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: ccx-data-pipeline
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        containers:
+        - args:
+          - -c
+          - /opt/bitnami/scripts/start-scripts/start-master.sh
+          command:
+          - /bin/bash
+          env:
+          - name: BITNAMI_DEBUG
+            value: "false"
+          - name: REDIS_REPLICATION_MODE
+            value: master
+          - name: ALLOW_EMPTY_PASSWORD
+            value: "no"
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: ${REDIS_CREDENTIALS_SECRETNAME}
+          - name: REDIS_TLS_ENABLED
+            value: "no"
+          - name: REDIS_PORT
+            value: "6379"
+          image: ${REDIS_IMAGE_NAME}:${REDIS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - /health/ping_liveness_local.sh 5
+            failureThreshold: 5
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 6
+          name: redis
+          ports:
+          - containerPort: 6379
+            name: redis
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - /health/ping_readiness_local.sh 1
+            failureThreshold: 5
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /opt/bitnami/scripts/start-scripts
+            name: start-scripts
+          - mountPath: /health
+            name: health
+          - mountPath: /data
+            name: cache-writer-redis-data
+            subPath: null
+          - mountPath: /opt/bitnami/redis/mounted-etc
+            name: config
+          - mountPath: /opt/bitnami/redis/etc/
+            name: redis-tmp-conf
+          - mountPath: /tmp
+            name: tmp
+        - command:
+          - /bin/bash
+          - -c
+          - |
+            if [[ -f '/secrets/redis-password' ]]; then
+            export REDIS_PASSWORD=$(cat /secrets/redis-password)
+            fi
+            redis_exporter
+          env:
+          - name: REDIS_ALIAS
+            value: cache-writer-redis
+          - name: REDIS_USER
+            value: default
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: ${REDIS_CREDENTIALS_SECRETNAME}
+          image: ${REDIS_EXPORTER_IMAGE_NAME}:${REDIS_EXPORTER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: metrics
+          ports:
+          - containerPort: 9121
+            name: metrics
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts: null
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - configMap:
+            defaultMode: 493
+            name: cache-writer-redis-scripts
+          name: start-scripts
+        - configMap:
+            defaultMode: 493
+            name: cache-writer-redis-health
+          name: health
+        - configMap:
+            name: cache-writer-redis-configuration
+          name: config
+        - emptyDir: {}
+          name: redis-tmp-conf
+        - emptyDir: {}
+          name: tmp
+    updateStrategy:
+      rollingUpdate: {}
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app: ccx-data-pipeline
+          app.kubernetes.io/instance: cache-writer
+          app.kubernetes.io/name: redis
+        name: cache-writer-redis-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${REDIS_STORAGE}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    name: cache-writer-redis-metrics
+  spec:
+    ports:
+    - name: http-metrics
+      port: 9121
+      protocol: TCP
+      targetPort: metrics
+    selector:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    name: cache-writer-redis
+  spec:
+    internalTrafficPolicy: Cluster
+    ports:
+    - name: tcp-redis
+      nodePort: null
+      port: 6379
+      targetPort: redis
+    selector:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    name: cache-writer-redis-headless
+  spec:
+    clusterIP: None
+    ports:
+    - name: tcp-redis
+      port: 6379
+      targetPort: redis
+    selector:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    type: ClusterIP
+- apiVersion: v1
+  data:
+    start-master.sh: |
+      #!/bin/bash
+
+      [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
+      if [[ ! -f /opt/bitnami/redis/etc/master.conf ]];then
+          cp /opt/bitnami/redis/mounted-etc/master.conf /opt/bitnami/redis/etc/master.conf
+      fi
+      if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
+          cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
+      fi
+      ARGS=("--port" "${REDIS_PORT}")
+      ARGS+=("--requirepass" "${REDIS_PASSWORD}")
+      ARGS+=("--masterauth" "${REDIS_PASSWORD}")
+      ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
+      ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
+      exec redis-server "${ARGS[@]}"
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    name: cache-writer-redis-scripts
+- apiVersion: v1
+  data:
+    ping_liveness_local.sh: |-
+      #!/bin/bash
+
+      [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
+      [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
+      response=$(
+        timeout -s 3 $1 \
+        redis-cli \
+          -h localhost \
+          -p $REDIS_PORT \
+          ping
+      )
+      if [ "$?" -eq "124" ]; then
+        echo "Timed out"
+        exit 1
+      fi
+      responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
+      if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ] && [ "$responseFirstWord" != "MASTERDOWN" ]; then
+        echo "$response"
+        exit 1
+      fi
+    ping_liveness_local_and_master.sh: |-
+      script_dir="$(dirname "$0")"
+      exit_status=0
+      "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
+      "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
+      exit $exit_status
+    ping_liveness_master.sh: |-
+      #!/bin/bash
+
+      [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
+      [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
+      response=$(
+        timeout -s 3 $1 \
+        redis-cli \
+          -h $REDIS_MASTER_HOST \
+          -p $REDIS_MASTER_PORT_NUMBER \
+          ping
+      )
+      if [ "$?" -eq "124" ]; then
+        echo "Timed out"
+        exit 1
+      fi
+      responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
+      if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ]; then
+        echo "$response"
+        exit 1
+      fi
+    ping_readiness_local.sh: |-
+      #!/bin/bash
+
+      [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
+      [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
+      response=$(
+        timeout -s 3 $1 \
+        redis-cli \
+          -h localhost \
+          -p $REDIS_PORT \
+          ping
+      )
+      if [ "$?" -eq "124" ]; then
+        echo "Timed out"
+        exit 1
+      fi
+      if [ "$response" != "PONG" ]; then
+        echo "$response"
+        exit 1
+      fi
+    ping_readiness_local_and_master.sh: |-
+      script_dir="$(dirname "$0")"
+      exit_status=0
+      "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
+      "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
+      exit $exit_status
+    ping_readiness_master.sh: |-
+      #!/bin/bash
+
+      [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
+      [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
+      response=$(
+        timeout -s 3 $1 \
+        redis-cli \
+          -h $REDIS_MASTER_HOST \
+          -p $REDIS_MASTER_PORT_NUMBER \
+          ping
+      )
+      if [ "$?" -eq "124" ]; then
+        echo "Timed out"
+        exit 1
+      fi
+      if [ "$response" != "PONG" ]; then
+        echo "$response"
+        exit 1
+      fi
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    name: cache-writer-redis-health
+- apiVersion: v1
+  data:
+    master.conf: |-
+      dir /data
+      # User-supplied master configuration:
+      rename-command FLUSHDB ""
+      rename-command FLUSHALL ""
+      # End of master configuration
+    redis.conf: |-
+      # User-supplied common configuration:
+      # Enable AOF https://redis.io/topics/persistence#append-only-file
+      appendonly yes
+      # Disable RDB persistence, AOF persistence already enabled.
+      save ""
+      # End of common configuration
+    replica.conf: |-
+      dir /data
+      slave-read-only yes
+      # User-supplied replica configuration:
+      rename-command FLUSHDB ""
+      rename-command FLUSHALL ""
+      # End of replica configuration
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: ccx-data-pipeline
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: redis
+    name: cache-writer-redis-configuration
+
+parameters:
+# cache-writer
+
+# redis
+- name: REDIS_EXPORTER_IMAGE_TAG
+  value: 1.37.0-debian-10-r63
+- name: REDIS_EXPORTER_IMAGE_NAME
+  value: quay.io/edge-infrastructure/redis-exporter
+- name: REDIS_IMAGE_TAG
+  value: 6.2.7-debian-10-r23
+- name: REDIS_IMAGE_NAME
+  value: quay.io/edge-infrastructure/redis
+- name: REDIS_STORAGE
+  value: 100Gi
+- name: REDIS_CREDENTIALS_SECRETNAME
+  value: cache-writer-redis-credentials

--- a/deploy/test-cache-writer.yaml
+++ b/deploy/test-cache-writer.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+# Bonfire deployment configuration
+# Defines where to fetch the file that defines application configs
+
+appsFile:
+  host: gitlab
+  repo: insights-platform/cicd-common
+  path: bonfire_configs/ephemeral_apps.yaml
+
+apps:
+- name: ccx-data-pipeline
+  components:
+    - name:  ccx-insights-results-aggregator
+      host: local
+      repo: .
+      path: deploy/cache-writer.yaml
+      parameters:
+        ENV_NAME: env-ocm
+        IMAGE_TAG: latest


### PR DESCRIPTION
# Description

Adding a StatefulSet + services for deploying Redis as part of the cache-writer app. It's still missing the deployment of the cache-writer, as it's not developed yet.

It's heavily inspired and copied from https://github.com/openshift-assisted/assisted-events-stream/blob/master/openshift/template.yaml.

Part of #CCXDEV-11124

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Following the docs I added in this same PR, deploying the Redis in an ephemeral namespace and testing manually that it can be queried.

Note that you have to hardcode the password to a specific value because the secret cannot be pulled yet, it's waiting for: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/69387

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
