### PR TITLE
Fix: ability to start Insights Results Aggregator with Redis as a storage

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -144,6 +144,10 @@ func closeStorage(storage storage.Storage) {
 // autoMigrate is set performs migration to the latest schema version
 // available.
 func prepareDBMigrations(dbStorage storage.Storage) int {
+	if conf.GetStorageConfiguration().Type != "sql" {
+		log.Info().Msg("Skipping migration for non-SQL database type")
+		return ExitStatusOK
+	}
 	// This is only used by some unit tests.
 	if autoMigrate {
 		if err := dbStorage.MigrateToLatest(); err != nil {

--- a/server.go
+++ b/server.go
@@ -49,13 +49,20 @@ func startServer() error {
 
 	// try to retrieve the actual DB migration version
 	// and add it into the `params` map
-	currentVersion, err := migration.GetDBVersion(dbStorage.GetConnection())
-	if err != nil {
-		const msg = "Unable to retrieve DB migration version"
-		log.Error().Err(err).Msg(msg)
-		serverInstance.InfoParams["DB_version"] = msg
+	log.Info().Msg("Setting DB version for /info endpoint")
+	if conf.GetStorageConfiguration().Type == "sql" {
+		// migration and DB versioning is now supported for SQL
+		// databases only
+		currentVersion, err := migration.GetDBVersion(dbStorage.GetConnection())
+		if err != nil {
+			const msg = "Unable to retrieve DB migration version"
+			log.Error().Err(err).Msg(msg)
+			serverInstance.InfoParams["DB_version"] = msg
+		} else {
+			serverInstance.InfoParams["DB_version"] = strconv.Itoa(int(currentVersion))
+		}
 	} else {
-		serverInstance.InfoParams["DB_version"] = strconv.Itoa(int(currentVersion))
+		serverInstance.InfoParams["DB_version"] = "not supported"
 	}
 
 	err = serverInstance.Start(finishServerInstanceInitialization)

--- a/storage/redis_storage.go
+++ b/storage/redis_storage.go
@@ -21,6 +21,8 @@ import (
 	"github.com/RedHatInsights/insights-content-service/content"
 	"github.com/Shopify/sarama"
 
+	"github.com/rs/zerolog/log"
+
 	ctypes "github.com/RedHatInsights/insights-results-types"
 
 	"github.com/RedHatInsights/insights-results-aggregator/types"
@@ -31,6 +33,7 @@ type RedisStorage struct{}
 
 // Init noop
 func (*RedisStorage) Init() error {
+	log.Info().Msg("Redis database Init()")
 	return nil
 }
 
@@ -388,6 +391,7 @@ func (*RedisStorage) GetConnection() *sql.DB {
 // PrintRuleDisableDebugInfo is a temporary helper function used to print form
 // cluster rule toggle related tables
 func (*RedisStorage) PrintRuleDisableDebugInfo() {
+	log.Info().Msg("PrintRuleDisableDebugInfo() skipped for Redis storage")
 }
 
 // GetDBDriverType returns db driver type

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -256,6 +256,11 @@ func newNoopStorage(configuration Configuration) (Storage, error) {
 
 // newRedisStorage function creates and initializes a new instance of Redis storage
 func newRedisStorage(configuration Configuration) (Storage, error) {
+	redisCfg := configuration.RedisConfiguration
+	log.Info().
+		Str("Endpoint", redisCfg.RedisEndpoint).
+		Int("Database index", redisCfg.RedisDatabase).
+		Msg("Making connection to Redis storage")
 	return &RedisStorage{}, nil
 }
 


### PR DESCRIPTION
# Description

Fix: ability to start Insights Results Aggregator with Redis as a storage

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
