### PR TITLE
Pass `RequestID` to store report method in all implemented interfaces

### DIFF
--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -252,6 +252,7 @@ func (consumer *KafkaConsumer) processMessage(msg *sarama.ConsumerMessage) (type
 		message.Metadata.GatheredAt,
 		storedAtTime,
 		types.KafkaOffset(msg.Offset),
+		message.RequestID,
 	)
 	if err == types.ErrOldReport {
 		logMessageInfo(consumer, msg, message, "Skipping because a more recent report already exists for this cluster")

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -130,6 +130,7 @@ func TestWrittenReportsMetric(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		0,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -145,6 +146,7 @@ func TestWrittenReportsMetric(t *testing.T) {
 			time.Now(),
 			time.Now(),
 			types.KafkaOffset(i+1),
+			testdata.RequestID1,
 		)
 		helpers.FailOnError(t, err)
 	}

--- a/server/report_benchmarks_test.go
+++ b/server/report_benchmarks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,7 @@ func initTestReports(b *testing.B, n uint, mockStorage storage.Storage, reportPr
 			time.Now(),
 			time.Now(),
 			testdata.KafkaOffset,
+			testdata.RequestID1,
 		)
 		helpers.FailOnError(b, err)
 

--- a/server/server_read_report_metainfo_test.go
+++ b/server/server_read_report_metainfo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Red Hat, Inc
+// Copyright 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,6 +89,7 @@ func TestReadExistingEmptyReportMetainfo(t *testing.T) {
 		time.Now(),
 		testdata.LastCheckedAt,
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -136,6 +137,7 @@ func TestReadReportMetainfo(t *testing.T) {
 		time.Now(),
 		testdata.LastCheckedAt,
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 

--- a/server/server_read_report_test.go
+++ b/server/server_read_report_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,6 +93,7 @@ func TestHttpServer_readReportForCluster_NoRules(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -145,6 +146,7 @@ func TestReadReport(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -188,6 +190,7 @@ func TestReadRuleReport(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -228,6 +231,7 @@ func TestReadReportDisableRule(t *testing.T) {
 		testdata.LastCheckedAt,
 		now,
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -339,6 +343,7 @@ func TestReadReport_RuleDisableFeedback(t *testing.T) {
 		testdata.LastCheckedAt,
 		now,
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020, 2021, 2022  Red Hat, Inc.
+Copyright © 2020, 2021, 2022, 2023  Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -100,6 +100,7 @@ func TestListOfClustersForOrganizationOK(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -188,6 +189,7 @@ func TestListOfOrganizationsOK(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -200,6 +202,7 @@ func TestListOfOrganizationsOK(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -340,6 +343,7 @@ func TestRuleFeedbackVote(t *testing.T) {
 				testdata.LastCheckedAt,
 				time.Now(),
 				testdata.KafkaOffset,
+				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
 
@@ -454,6 +458,7 @@ func checkBadRuleFeedbackRequest(t *testing.T, message, expectedStatus string) {
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 		testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt,
 		time.Now(), testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
@@ -511,6 +516,7 @@ func TestHTTPServer_GetVoteOnRule_DBError(t *testing.T) {
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed,
 		testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -573,6 +579,7 @@ func TestHTTPServer_GetVoteOnRule(t *testing.T) {
 				testdata.LastCheckedAt,
 				time.Now(),
 				testdata.KafkaOffset,
+				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
 
@@ -625,6 +632,7 @@ func TestRuleToggle(t *testing.T) {
 				testdata.LastCheckedAt,
 				time.Now(),
 				testdata.KafkaOffset,
+				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
 
@@ -737,6 +745,7 @@ func TestHTTPServer_SaveDisableFeedback(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -785,6 +794,7 @@ func TestHTTPServer_SaveDisableFeedback_Error_CheckUserClusterPermissions(t *tes
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -822,6 +832,7 @@ func TestHTTPServer_SaveDisableFeedback_Error_BadBody(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -848,6 +859,7 @@ func TestHTTPServer_SaveDisableFeedback_Error_DBError(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1638,6 +1650,7 @@ func TestHTTPServer_ListOfDisabledClusters_OneDisabled(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1677,6 +1690,7 @@ func TestHTTPServer_ListOfDisabledClusters_JustificationTests(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 

--- a/server/vote_endpoints_benchmarks_test.go
+++ b/server/vote_endpoints_benchmarks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -162,6 +162,7 @@ func prepareVoteEndpointArgs(tb testing.TB, numberOfEndpointArgs uint, mockStora
 			time.Now(),
 			time.Now(),
 			testdata.KafkaOffset,
+			testdata.RequestID1,
 		)
 		helpers.FailOnError(tb, err)
 

--- a/storage/info_rule_test.go
+++ b/storage/info_rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Red Hat, Inc
+// Copyright 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,6 +97,7 @@ func TestDBStorageReadClusterListRecommendationsNoRecommendationsWithVersion(t *
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, []ctypes.ReportItem{},
 		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -128,6 +129,7 @@ func TestDBStorageReadClusterListRecommendationsWithVersion(t *testing.T) {
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, []ctypes.ReportItem{},
 		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -79,6 +79,7 @@ func (*NoopStorage) GetLatestKafkaOffset() (types.KafkaOffset, error) {
 // WriteReportForCluster noop
 func (*NoopStorage) WriteReportForCluster(
 	types.OrgID, types.ClusterName, types.ClusterReport, []types.ReportItem, time.Time, time.Time, time.Time, types.KafkaOffset,
+	types.RequestID,
 ) error {
 	return nil
 }

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ func TestNoopStorage_Methods(t *testing.T) {
 	_, _ = noopStorage.ReadReportInfoForCluster(0, "")
 	_, _, _ = noopStorage.ReadReportForClusterByClusterName("")
 	_, _ = noopStorage.GetLatestKafkaOffset()
-	_ = noopStorage.WriteReportForCluster(0, "", "", []types.ReportItem{}, time.Now(), time.Now(), time.Now(), 0)
+	_ = noopStorage.WriteReportForCluster(0, "", "", []types.ReportItem{}, time.Now(), time.Now(), time.Now(), 0, "")
 	_, _ = noopStorage.ReportsCount()
 	_ = noopStorage.VoteOnRule("", "", "", 0, "", 0, "")
 	_ = noopStorage.AddOrUpdateFeedbackOnRule("", "", "", 0, "", "")

--- a/storage/redis_storage.go
+++ b/storage/redis_storage.go
@@ -85,6 +85,7 @@ func (*RedisStorage) GetLatestKafkaOffset() (types.KafkaOffset, error) {
 // WriteReportForCluster noop
 func (*RedisStorage) WriteReportForCluster(
 	types.OrgID, types.ClusterName, types.ClusterReport, []types.ReportItem, time.Time, time.Time, time.Time, types.KafkaOffset,
+	types.RequestID,
 ) error {
 	return nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -84,6 +84,7 @@ type Storage interface {
 		gatheredAtTime time.Time,
 		storedAtTime time.Time,
 		kafkaOffset types.KafkaOffset,
+		requestID types.RequestID,
 	) error
 	WriteReportInfoForCluster(
 		types.OrgID,
@@ -1097,6 +1098,7 @@ func (storage DBStorage) WriteReportForCluster(
 	gatheredAt time.Time,
 	storedAtTime time.Time,
 	kafkaOffset types.KafkaOffset,
+	requestID types.RequestID,
 ) error {
 	// Skip writing the report if it isn't newer than a report
 	// that is already in the database for the same cluster.

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -39,14 +39,14 @@ import (
 
 func mustWriteReport3Rules(t *testing.T, mockStorage storage.Storage) {
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset, testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 }
 
 func mustWriteReport3RulesForCluster(t *testing.T, mockStorage storage.Storage, clusterName types.ClusterName) {
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, clusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
+		testdata.OrgID, clusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset, testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -79,7 +79,9 @@ func writeReportForCluster(
 	clusterReport types.ClusterReport,
 	rules []types.ReportItem,
 ) {
-	err := storageImpl.WriteReportForCluster(orgID, clusterName, clusterReport, rules, time.Now(), time.Now(), time.Now(), testdata.KafkaOffset)
+	err := storageImpl.WriteReportForCluster(orgID, clusterName, clusterReport,
+		rules, time.Now(), time.Now(), time.Now(), testdata.KafkaOffset,
+		testdata.RequestID1)
 	helpers.FailOnError(t, err)
 }
 
@@ -279,6 +281,7 @@ func TestDBStorageWriteReportForClusterClosedStorage(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "sql: database is closed")
 }
@@ -297,6 +300,7 @@ func TestDBStorageWriteReportForClusterUnsupportedDriverError(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "writing report with DB -1 is not supported")
 }
@@ -320,6 +324,7 @@ func TestDBStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -333,6 +338,7 @@ func TestDBStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	assert.Equal(t, types.ErrOldReport, err)
 }
@@ -406,7 +412,9 @@ func TestDBStorageWriteReportForClusterDroppedReportTable(t *testing.T) {
 	helpers.FailOnError(t, err)
 
 	err = mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.ClusterReportEmpty, testdata.ReportEmptyRulesParsed, time.Now(), time.Now(), time.Now(), testdata.KafkaOffset,
+		testdata.OrgID, testdata.ClusterName, testdata.ClusterReportEmpty,
+		testdata.ReportEmptyRulesParsed, time.Now(), time.Now(), time.Now(), testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "no such table: report")
 }
@@ -418,7 +426,9 @@ func TestDBStorageWriteReportForClusterExecError(t *testing.T) {
 	createReportTableWithBadClusterField(t, mockStorage)
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(), testdata.KafkaOffset,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
+		testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(), testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	assert.Error(t, err)
 
@@ -457,8 +467,9 @@ func TestDBStorageWriteReportForClusterFakePostgresOK(t *testing.T) {
 	expects.ExpectClose()
 
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(), testdata.KafkaOffset,
-	)
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
+		testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(),
+		testdata.KafkaOffset, testdata.RequestID1)
 	helpers.FailOnError(t, mockStorage.Close())
 	helpers.FailOnError(t, err)
 }
@@ -705,6 +716,7 @@ func TestDBStorageDeleteReports(t *testing.T) {
 				time.Now(),
 				time.Now(),
 				testdata.KafkaOffset,
+				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
 
@@ -850,6 +862,7 @@ func TestDBStorage_GetLatestKafkaOffset_ZeroOffset(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		types.KafkaOffset(0),
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1421,6 +1434,7 @@ func TestDBStorageReadClusterListRecommendationsNoRecommendations(t *testing.T) 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, []ctypes.ReportItem{},
 		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -1473,6 +1487,7 @@ func TestDBStorageReadClusterListRecommendationsGet1Cluster(t *testing.T) {
 		err := mockStorage.WriteReportForCluster(
 			testdata.OrgID, randomClusterID, testdata.Report3Rules, testdata.Report3RulesParsed,
 			testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+			testdata.RequestID1,
 		)
 		helpers.FailOnError(t, err)
 
@@ -1514,6 +1529,7 @@ func TestDBStorageReadClusterListRecommendationsGetMoreClusters(t *testing.T) {
 		err := mockStorage.WriteReportForCluster(
 			testdata.OrgID, randomClusterID, testdata.Report3Rules, testdata.Report3RulesParsed,
 			testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+			testdata.RequestID1,
 		)
 		helpers.FailOnError(t, err)
 
@@ -1561,6 +1577,7 @@ func TestDBStorageWriteReportForClusterWithZeroGatheredTime(t *testing.T) {
 		zeroTime,
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 }
@@ -1582,6 +1599,7 @@ func TestDoesClusterExist(t *testing.T) {
 		time.Time{},
 		time.Now(),
 		testdata.KafkaOffset,
+		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 	exist, err = mockStorage.DoesClusterExist(testdata.ClusterName)

--- a/storage/storage_write_recommendations_benchmark_test.go
+++ b/storage/storage_write_recommendations_benchmark_test.go
@@ -509,7 +509,9 @@ func BenchmarkWriteReportAndRecommendationsNoConflict(b *testing.B) {
 
 	for benchIter := 0; benchIter < b.N; benchIter++ {
 		for id := range clusterIDSet.content {
-			err := storageImpl.WriteReportForCluster(types.OrgID(1), types.ClusterName(id), testdata.Report2Rules, testdata.Report2RulesParsed, time.Now(), time.Now(), time.Now(), types.KafkaOffset(0))
+			err := storageImpl.WriteReportForCluster(types.OrgID(1), types.ClusterName(id),
+				testdata.Report2Rules, testdata.Report2RulesParsed,
+				time.Now(), time.Now(), time.Now(), types.KafkaOffset(0), testdata.RequestID1)
 			helpers.FailOnError(b, err)
 			err = storageImpl.WriteRecommendationsForCluster(types.OrgID(1), types.ClusterName(id), Report20Rules, RecommendationCreatedAtTimestamp)
 			helpers.FailOnError(b, err)


### PR DESCRIPTION
# Description

Pass `RequestID` to store report method in all implemented interfaces

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
