### PR TITLE
Update the service port name

### DIFF
--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -159,9 +159,11 @@ objects:
     name: ccx-cache-writer-prometheus-exporter
     labels:
       app: ccx-cache-writer
+      app.kubernetes.io/instance: cache-writer
+      app.kubernetes.io/name: db-writer
   spec:
     ports:
-      - name: web
+      - name: ccx-cache-writer-port-metrics
         port: 9000
         protocol: TCP
         targetPort: 9000
@@ -343,7 +345,7 @@ objects:
     name: ccx-redis-metrics
   spec:
     ports:
-    - name: http-metrics
+    - name: ccx-redis-port-metrics
       port: 9121
       protocol: TCP
       targetPort: metrics


### PR DESCRIPTION
# Description

The port name was a left over due to copy pasting. We need to add a proper name and labels to be used in the [servicemonitors](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/70763).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
