### PR TITLE
[cache-writer][debug] Use same Kafka config as db-writer

### DIFF
--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -45,7 +45,7 @@ objects:
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__TOPIC
               value: "${INCOMING_TOPIC}"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__DEAD_LETTER_QUEUE_TOPIC
-              value: ""
+              value: "ccx.aggregator.dead.letter.queue"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__PAYLOAD_TRACKER_TOPIC
               value: "${PAYLOAD_TRACKER_TOPIC}"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__SERVICE_NAME
@@ -584,10 +584,10 @@ parameters:
   value: platform.payload-status
   required: true
 - name: CACHE_WRITER_SERVICE_NAME
-  value: ccx-cache-writer
+  value: insights-results-db-writer
   required: true
 - name: GROUP_ID
-  value: ccx_cache_writer_app
+  value: ccx_data_pipeline_app
   required: true
 - name: CW_API_PREFIX
   required: true

--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -18,7 +18,6 @@ kind: Template
 metadata:
   name: ccx-cache-writer
 objects:
-# TODO: Add the cache-writer deployment + services
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:


### PR DESCRIPTION
# Description

The cache-writer doesn't consume from Kafka. Let's use the same configuration as the db-writer and see what's going on.

## Type of change

- Configuration change

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
