### PR TITLE
strip .report suffix from rule module when inserting rule hits to Redis

### DIFF
--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -44,6 +44,7 @@ var (
 	ArgsWithClusterNames    = argsWithClusterNames
 	ValuesForRuleHitsInsert = valuesForRuleHitsInsert
 	NewRedisStorage         = newRedisStorage
+	GetRuleHitsCSV          = getRuleHitsCSV
 )
 
 func GetConnection(storage *DBStorage) *sql.DB {

--- a/storage/redis_storage.go
+++ b/storage/redis_storage.go
@@ -489,7 +489,8 @@ func getRuleHitsCSV(reportItems []types.ReportItem) string {
 		if i > 0 {
 			output.WriteRune(',')
 		}
-		output.WriteString(string(reportItem.Module))
+		// strip .report suffix from rule module added automatically by running insights evaluation
+		output.WriteString(strings.TrimSuffix(string(reportItem.Module), ReportSuffix))
 		output.WriteRune('|')
 		output.WriteString(string(reportItem.ErrorKey))
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -223,6 +223,9 @@ type Storage interface {
 	GetDBDriverType() types.DBDriver
 }
 
+// ReportSuffix is used to strip away .report suffix from rule module names
+const ReportSuffix = ".report"
+
 // DBStorage is an implementation of Storage interface that use selected SQL like database
 // like SQLite, PostgreSQL, MariaDB, RDS etc. That implementation is based on the standard
 // sql package. It is possible to configure connection via Configuration structure.
@@ -990,7 +993,7 @@ func prepareInsertRecommendationsStatement(
 	selectors = make([]string, len(report.HitRules))
 
 	for idx, rule := range report.HitRules {
-		ruleFqdn := strings.TrimSuffix(string(rule.Module), ".report")
+		ruleFqdn := strings.TrimSuffix(string(rule.Module), ReportSuffix)
 		ruleID := ruleFqdn + "|" + string(rule.ErrorKey)
 		impactedSince, ok := impactedSinceMap[ruleFqdn+string(rule.ErrorKey)]
 		if !ok {


### PR DESCRIPTION
# Description
- strip .report suffix from rule module when inserting rule hits to Redis

https://issues.redhat.com/browse/CCXDEV-11329

Fixes # (issue)

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps


## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
