### PR TITLE
[CCXDEV-11194] Ignore minimum 3 replicas alert

### DIFF
--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -23,6 +23,8 @@ objects:
   kind: ClowdApp
   metadata:
     name: ccx-cache-writer
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "This app doesn't have that much traffic"
   spec:
     envName: ${ENV_NAME}
     testing:
@@ -190,6 +192,8 @@ objects:
       app.kubernetes.io/instance: cache-writer
       app.kubernetes.io/name: redis
     name: ccx-redis
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "It can be problematic if we add more replicas and it's enough as it is now"
   spec:
     replicas: 1
     selector:


### PR DESCRIPTION
# Description

AppSRE has an automated alert system that asked us to increase the replicas to up to 3. We don't need so many replicas as our services are really stable and have more than enough resources.

## Type of change

- Configuration update

## Testing steps

None.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
