### PR TITLE
[CCXDEV-11196][CCXDEV-11195][ccx-redis] CPU and Memory limits to metrics container

### DIFF
--- a/dashboards/grafana-dashboard-ccx-redis.yaml
+++ b/dashboards/grafana-dashboard-ccx-redis.yaml
@@ -217,7 +217,7 @@ data:
               },
               "editorMode": "code",
               "expr": "sum (container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"ccx-redis.*\", container!=\"\"}) by (pod, container)",
-              "legendFormat": "__auto",
+              "legendFormat": "{{pod}}: {{container}}",
               "range": true,
               "refId": "A"
             }

--- a/dashboards/grafana-dashboard-ccx-redis.yaml
+++ b/dashboards/grafana-dashboard-ccx-redis.yaml
@@ -123,8 +123,8 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum (rate (container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"ccx-redis.*\"}[1m])) by (pod)",
-              "legendFormat": "__auto",
+              "expr": "sum (rate (container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"ccx-redis.*\", container!=\"\"}[1m])) by (pod, container)",
+              "legendFormat": "{{pod}}: {{container}}",
               "range": true,
               "refId": "A"
             }
@@ -216,7 +216,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum (container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"ccx-redis.*\"}) by (pod)",
+              "expr": "sum (container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"ccx-redis.*\", container!=\"\"}) by (pod, container)",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"

--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -316,8 +316,12 @@ objects:
           - containerPort: 9121
             name: metrics
           resources:
-            limits: {}
-            requests: {}
+            limits:
+              cpu: ${REDIS_METRICS_CPU_LIMIT}
+              memory: ${REDIS_METRICS_MEMORY_LIMIT}
+            requests:
+              cpu: ${REDIS_METRICS_CPU_REQUEST}
+              memory: ${REDIS_METRICS_MEMORY_REQUEST}
           securityContext:
             runAsNonRoot: true
           volumeMounts: null
@@ -662,3 +666,11 @@ parameters:
   value: 100m
 - name: REDIS_MEMORY_REQUEST
   value: 1000Mi
+- name: REDIS_METRICS_CPU_LIMIT
+  value: 5m
+- name: REDIS_METRICS_MEMORY_LIMIT
+  value: 100Mi
+- name: REDIS_METRICS_CPU_REQUEST
+  value: 10m
+- name: REDIS_METRICS_MEMORY_REQUEST
+  value: 50Mi


### PR DESCRIPTION
# Description

I forgot to add the resource limits for the "metrics" container in https://github.com/RedHatInsights/insights-results-aggregator/pull/1798.

## Type of change

- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
