### PR TITLE
[CCXDEV-11494] Log level set to INFO

### DIFF
--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -613,7 +613,7 @@ parameters:
   required: true
   value: /
 - name: LOG_LEVEL
-  value: "DEBUG"
+  value: "INFO"
 - name: DEBUG
   value: "true"
 - name: AUTH


### PR DESCRIPTION
# Description

Log level of chache-writter.yaml set to INFO

Fixes # (issue)
Log level changed from DEBUG to INFO

## Type of change

Please delete options that are not relevant.

- Configuration update

## Testing steps
NA

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
