### PR TITLE
Consuming messages on debug level

### DIFF
--- a/consumer/logging.go
+++ b/consumer/logging.go
@@ -30,6 +30,18 @@ func printableRequestID(message *incomingMessage) string {
 	return string(requestID)
 }
 
+func logMessageDebug(consumer *KafkaConsumer, originalMessage *sarama.ConsumerMessage, parsedMessage incomingMessage, event string) {
+	log.Debug().
+		Int(offsetKey, int(originalMessage.Offset)).
+		Int(partitionKey, int(originalMessage.Partition)).
+		Str(topicKey, consumer.Configuration.Topic).
+		Int(organizationKey, int(*parsedMessage.Organization)).
+		Str(clusterKey, string(*parsedMessage.ClusterName)).
+		Int(versionKey, int(parsedMessage.Version)).
+		Str(requestIDKey, printableRequestID(&parsedMessage)).
+		Msg(event)
+}
+
 func logMessageInfo(consumer *KafkaConsumer, originalMessage *sarama.ConsumerMessage, parsedMessage incomingMessage, event string) {
 	log.Info().
 		Int(offsetKey, int(originalMessage.Offset)).
@@ -57,9 +69,9 @@ func logClusterInfo(message *incomingMessage) {
 			newLine := fmt.Sprintf("\n\trule: %s; error key: %s", ph.Module, ph.ErrorKey)
 			logMessage += newLine
 		}
-		log.Info().Msg(logMessage)
+		log.Debug().Msg(logMessage)
 	} else {
-		log.Info().Msg("no rule hits found")
+		log.Debug().Msg("no rule hits found")
 	}
 }
 
@@ -95,5 +107,5 @@ func logMessageWarning(consumer *KafkaConsumer, originalMessage *sarama.Consumer
 
 func logDuration(tStart, tEnd time.Time, offset int64, key string) {
 	duration := tEnd.Sub(tStart)
-	log.Info().Int64(durationKey, duration.Microseconds()).Int64(offsetKey, offset).Msg(key)
+	log.Debug().Int64(durationKey, duration.Microseconds()).Int64(offsetKey, offset).Msg(key)
 }

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -65,7 +65,7 @@ func (consumer *KafkaConsumer) HandleMessage(msg *sarama.ConsumerMessage) error 
 	consumer.updatePayloadTracker(requestID, startTime, message.Organization, message.Account, producer.StatusReceived)
 	consumer.updatePayloadTracker(requestID, timeAfterProcessingMessage, message.Organization, message.Account, producer.StatusMessageProcessed)
 
-	log.Info().
+	log.Debug().
 		Int64(offsetKey, msg.Offset).
 		Int32(partitionKey, msg.Partition).
 		Str(topicKey, msg.Topic).
@@ -142,10 +142,10 @@ func checkMessageOrgInAllowList(consumer *KafkaConsumer, message *incomingMessag
 			return false, cause
 		}
 
-		logMessageInfo(consumer, msg, *message, "Organization is in allow list")
+		logMessageDebug(consumer, msg, *message, "Organization is in allow list")
 
 	} else {
-		logMessageInfo(consumer, msg, *message, "Organization allow listing disabled")
+		logMessageDebug(consumer, msg, *message, "Organization allow listing disabled")
 	}
 	return true, ""
 }
@@ -164,7 +164,7 @@ func (consumer *KafkaConsumer) writeRecommendations(
 		return time.Time{}, err
 	}
 	tStored := time.Now()
-	logMessageInfo(consumer, msg, message, "Stored recommendations")
+	logMessageDebug(consumer, msg, message, "Stored recommendations")
 	logClusterInfo(&message)
 	return tStored, nil
 }
@@ -221,7 +221,7 @@ func (consumer *KafkaConsumer) processMessage(msg *sarama.ConsumerMessage) (type
 		return message.RequestID, message, err
 	}
 
-	logMessageInfo(consumer, msg, message, "Marshalled")
+	logMessageDebug(consumer, msg, message, "Marshalled")
 	tMarshalled := time.Now()
 
 	lastCheckedTime, err := time.Parse(time.RFC3339Nano, message.LastChecked)
@@ -237,7 +237,7 @@ func (consumer *KafkaConsumer) processMessage(msg *sarama.ConsumerMessage) (type
 
 	metrics.LastCheckedTimestampLagMinutes.Observe(lastCheckedTimestampLagMinutes)
 
-	logMessageInfo(consumer, msg, message, "Time ok")
+	logMessageDebug(consumer, msg, message, "Time ok")
 	tTimeCheck := time.Now()
 
 	// timestamp when the report is about to be written into database
@@ -261,7 +261,7 @@ func (consumer *KafkaConsumer) processMessage(msg *sarama.ConsumerMessage) (type
 		logMessageError(consumer, msg, message, "Error writing report to database", err)
 		return message.RequestID, message, err
 	}
-	logMessageInfo(consumer, msg, message, "Stored report")
+	logMessageDebug(consumer, msg, message, "Stored report")
 	tStored := time.Now()
 
 	tRecommendationsStored, err := consumer.writeRecommendations(msg, message, reportAsBytes)


### PR DESCRIPTION
# Description

Consuming messages on debug level

Now it looks like (log level is set to INFO):

```
1:26PM INF started processing message message_timestamp=2023-07-26T13:26:54+02:00 offset=7 partition=0 topic=ccx.ocp.results
1:26PM INF Consumed group=aggregator offset=7 topic=ccx.ocp.results
1:26PM INF Read cluster=5d5892d3-1f74-4ccf-91af-548dfc9767aa offset=7 organization=11789772 partition=0 request ID=missing topic=ccx.ocp.results version=2
1:26PM WRN Received data with unexpected version. cluster=5d5892d3-1f74-4ccf-91af-548dfc9767aa offset=7 organization=11789772 partition=0 topic=ccx.ocp.results version=2
1:26PM INF Stored info report cluster=5d5892d3-1f74-4ccf-91af-548dfc9767aa offset=7 organization=11789772 partition=0 request ID=missing topic=ccx.ocp.results version=2
1:26PM WRN request ID is missing, null or empty Operation=TrackPayload
1:26PM WRN request ID is missing, null or empty Operation=TrackPayload
1:26PM WRN request ID is missing, null or empty Operation=TrackPayload
1:26PM INF Message consumed duration=3 offset=7
```

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Configuration update

## Testing steps

To be tested on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
