### PR TITLE
fix v2/clusters and v2/rule/{rule_selector}/clusters_detail performance issues

### DIFF
--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -59,6 +59,13 @@ func (*NoopStorage) ReadReportInfoForCluster(types.OrgID, types.ClusterName) (ty
 	return "", nil
 }
 
+// ReadClusterVersionsForClusterList noop
+func (*NoopStorage) ReadClusterVersionsForClusterList(
+	types.OrgID, []string,
+) (map[types.ClusterName]types.Version, error) {
+	return nil, nil
+}
+
 // ReadSingleRuleTemplateData noop
 func (*NoopStorage) ReadSingleRuleTemplateData(types.OrgID, types.ClusterName, types.RuleID, types.ErrorKey) (interface{}, error) {
 	return "", nil

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -45,6 +45,7 @@ func TestNoopStorageEmptyMethods1(t *testing.T) {
 
 	_, _, _, _, _ = noopStorage.ReadReportForCluster(orgID, clusterName)
 	_, _ = noopStorage.ReadReportInfoForCluster(orgID, clusterName)
+	_, _ = noopStorage.ReadClusterVersionsForClusterList(orgID, []string{string(clusterName)})
 	_, _, _ = noopStorage.ReadReportForClusterByClusterName(clusterName)
 	_ = noopStorage.DeleteReportsForOrg(orgID)
 	_ = noopStorage.DeleteReportsForCluster(clusterName)

--- a/storage/redis_storage.go
+++ b/storage/redis_storage.go
@@ -91,6 +91,13 @@ func (*RedisStorage) ReadReportInfoForCluster(types.OrgID, types.ClusterName) (t
 	return "", nil
 }
 
+// ReadClusterVersionsForClusterList noop
+func (*RedisStorage) ReadClusterVersionsForClusterList(
+	types.OrgID, []string,
+) (map[types.ClusterName]types.Version, error) {
+	return nil, nil
+}
+
 // ReadSingleRuleTemplateData noop
 func (*RedisStorage) ReadSingleRuleTemplateData(types.OrgID, types.ClusterName, types.RuleID, types.ErrorKey) (interface{}, error) {
 	return "", nil

--- a/storage/redis_storage_test.go
+++ b/storage/redis_storage_test.go
@@ -375,6 +375,7 @@ func TestRedisStorageEmptyMethods1(t *testing.T) {
 
 	_, _, _, _, _ = RedisStorage.ReadReportForCluster(orgID, clusterName)
 	_, _ = RedisStorage.ReadReportInfoForCluster(orgID, clusterName)
+	_, _ = RedisStorage.ReadClusterVersionsForClusterList(orgID, []string{string(clusterName)})
 	_, _, _ = RedisStorage.ReadReportForClusterByClusterName(clusterName)
 	_ = RedisStorage.DeleteReportsForOrg(orgID)
 	_ = RedisStorage.DeleteReportsForCluster(clusterName)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -66,6 +66,9 @@ type Storage interface {
 		types.OrgID, types.ClusterName) (
 		types.Version, error,
 	)
+	ReadClusterVersionsForClusterList(
+		types.OrgID, []string,
+	) (map[types.ClusterName]types.Version, error)
 	ReadReportsForClusters(
 		clusterNames []types.ClusterName) (map[types.ClusterName]types.ClusterReport, error)
 	ReadOrgIDsForClusters(


### PR DESCRIPTION
# Description
- fixes v2/clusters performance issue (current worst case scenario of 27k clusters meant 27k+1 queries to RDS, with this approach it's down to 2 queries for any number of clusters)
- fixes v2/rule/{rule_selector}/clusters_detail performance issue
- functionality wasn't changed, so existing UTs need not be modified

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
local DB with millions of records

## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
