### PR TITLE
reduce 'lookback' limit for retrieving cluster list on ClustersForOrganizationEndpoint because of timeouts

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -249,7 +249,7 @@ objects:
             - name: INSIGHTS_RESULTS_AGGREGATOR__SERVER__MAXIMUM_FEEDBACK_MESSAGE_LENGTH
               value: "255"
             - name: INSIGHTS_RESULTS_AGGREGATOR__SERVER__ORG_OVERVIEW_LIMIT_HOURS
-              value: "168"
+              value: "24"
             - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE__DB_DRIVER
               value: postgres
             - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE__PG_PARAMS


### PR DESCRIPTION
# Description
- this endpoint times out for larger organizations on prod
- it was used before we introduced AMS to smart-proxy to generate org_overview and for other uses
- reduce # of hours to look back from 168 to 24, hopefully will fix timeouts (will be checked on prod with the larges org)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
