### PR TITLE
reduce org-overview limit to 3h to resolve timeout

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -251,7 +251,7 @@ objects:
             - name: INSIGHTS_RESULTS_AGGREGATOR__SERVER__MAXIMUM_FEEDBACK_MESSAGE_LENGTH
               value: "255"
             - name: INSIGHTS_RESULTS_AGGREGATOR__SERVER__ORG_OVERVIEW_LIMIT_HOURS
-              value: "24"
+              value: "3"
             - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE__DB_DRIVER
               value: postgres
             - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE__PG_PARAMS


### PR DESCRIPTION
# Description
24h is still timing out on prod for the largest organizations, let's use 3h and mention this fact in smart-proxy API spec (https://github.com/RedHatInsights/insights-results-smart-proxy/pull/1100)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Configuration update

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
