### PR TITLE
remove problematic log messages 

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -606,7 +606,7 @@ func parseRuleRows(rows *sql.Rows) ([]types.RuleOnReport, error) {
 		report = append(report, rule)
 	}
 
-	log.Info().Msgf("parseRuleRows final report %v", report)
+	log.Debug().Msgf("parseRuleRows final report %v", report)
 
 	return report, nil
 }
@@ -1396,7 +1396,7 @@ func (storage DBStorage) ReadClusterListRecommendations(
 		}
 	}
 
-	log.Info().Msgf("Filling metadata for clustermap %v", clusterMap)
+	log.Debug().Msgf("Filling metadata for clustermap %v", clusterMap)
 	storage.fillInMetadata(orgID, clusterMap)
 	return clusterMap, nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -606,8 +606,6 @@ func parseRuleRows(rows *sql.Rows) ([]types.RuleOnReport, error) {
 		report = append(report, rule)
 	}
 
-	log.Debug().Msgf("parseRuleRows final report %v", report)
-
 	return report, nil
 }
 
@@ -1396,7 +1394,6 @@ func (storage DBStorage) ReadClusterListRecommendations(
 		}
 	}
 
-	log.Debug().Msgf("Filling metadata for clustermap %v", clusterMap)
 	storage.fillInMetadata(orgID, clusterMap)
 	return clusterMap, nil
 }


### PR DESCRIPTION
# Description
These log messages are causing problems with `zerolog: log message event too large`, causing problems with logs getting to CloudWatch

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
