### PR TITLE
Update checkMessageVersion to accept messages with known versions

### DIFF
--- a/consumer/consts.go
+++ b/consumer/consts.go
@@ -14,10 +14,6 @@
 
 package consumer
 
-import (
-	"github.com/RedHatInsights/insights-results-aggregator/types"
-)
-
 const (
 	// key for topic name used in structured log messages
 	topicKey = "topic"
@@ -37,6 +33,4 @@ const (
 	versionKey = "version"
 	// key for request ID
 	requestIDKey = "request ID"
-	// CurrentSchemaVersion represents the currently supported data schema version
-	CurrentSchemaVersion = types.SchemaVersion(1)
 )

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -47,6 +47,11 @@ type incomingMessage struct {
 	ParsedInfo  []types.InfoItem
 }
 
+var currentSchemaVersion = types.AllowedVersions{
+	types.SchemaVersion(1): struct{}{},
+	types.SchemaVersion(2): struct{}{},
+}
+
 // HandleMessage handles the message and does all logging, metrics, etc.
 //
 // Log message is written for every step made during processing, but in order to
@@ -182,10 +187,10 @@ func (consumer KafkaConsumer) sendDeadLetter(msg *sarama.ConsumerMessage) {
 	}
 }
 
-// checkMessageVersion - verifies incoming data's version is the expected one
+// checkMessageVersion - verifies incoming data's version is expected
 func checkMessageVersion(consumer *KafkaConsumer, message *incomingMessage, msg *sarama.ConsumerMessage) {
-	if message.Version != CurrentSchemaVersion {
-		warning := fmt.Sprintf("Received data with unexpected version %d (expected %d).", message.Version, CurrentSchemaVersion)
+	if _, ok := currentSchemaVersion[message.Version]; !ok {
+		warning := fmt.Sprintf("Received data with unexpected version %d.", message.Version)
 		logMessageWarning(consumer, msg, *message, warning)
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -131,8 +131,11 @@ type InfoItem struct {
 // errors and dictionary with results per cluster.
 type ClusterReports = types.ClusterReports
 
-// SchemaVersion represents the current version of data schema
+// SchemaVersion represents the received message's version of data schema
 type SchemaVersion = types.SchemaVersion
+
+// AllowedVersions represents the currently allowed versions of data schema
+type AllowedVersions = map[SchemaVersion]struct{}
 
 // RuleRating represents a rule rating element sent by the user
 type RuleRating = types.RuleRating


### PR DESCRIPTION
# Description

The consumer produces warnings when receiving messages with version "2", which we've been using for a long time. This changes the check to take into account all the expected/allowed versions.

Fixes CCXDEV-11542

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Updated UTs

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
