### PR TITLE
Revert "Skip processing of already read messages"

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -225,8 +225,6 @@ func (consumer *KafkaConsumer) ConsumeClaim(session sarama.ConsumerGroupSession,
 			log.Warn().
 				Int64(offsetKey, message.Offset).
 				Msg("this offset was already processed by aggregator")
-
-			continue
 		}
 
 		err = consumer.HandleMessage(message)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -860,7 +860,7 @@ func (storage DBStorage) ReadReportForClusterByClusterName(
 // GetLatestKafkaOffset returns latest kafka offset from report table
 func (storage DBStorage) GetLatestKafkaOffset() (types.KafkaOffset, error) {
 	var offset types.KafkaOffset
-	err := storage.connection.QueryRow("SELECT COALESCE(MAX(kafka_offset), -1) FROM report;").Scan(&offset)
+	err := storage.connection.QueryRow("SELECT COALESCE(MAX(kafka_offset), 0) FROM report;").Scan(&offset)
 	return offset, err
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -832,7 +832,7 @@ func TestDBStorage_GetLatestKafkaOffset(t *testing.T) {
 	offset, err := mockStorage.GetLatestKafkaOffset()
 	helpers.FailOnError(t, err)
 
-	assert.Equal(t, types.KafkaOffset(-1), offset)
+	assert.Equal(t, types.KafkaOffset(0), offset)
 
 	mustWriteReport3Rules(t, mockStorage)
 
@@ -849,7 +849,7 @@ func TestDBStorage_GetLatestKafkaOffset_ZeroOffset(t *testing.T) {
 	offset, err := mockStorage.GetLatestKafkaOffset()
 	helpers.FailOnError(t, err)
 
-	assert.Equal(t, types.KafkaOffset(-1), offset)
+	assert.Equal(t, types.KafkaOffset(0), offset)
 
 	err = mockStorage.WriteReportForCluster(
 		testdata.OrgID,


### PR DESCRIPTION
Reverts RedHatInsights/insights-results-aggregator#1824 because it looks like stage was broken by this.