### PR TITLE
Partial revert on dropping messages by its offset

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -225,8 +225,6 @@ func (consumer *KafkaConsumer) ConsumeClaim(session sarama.ConsumerGroupSession,
 			log.Warn().
 				Int64(offsetKey, message.Offset).
 				Msg("this offset was already processed by aggregator")
-
-			continue
 		}
 
 		err = consumer.HandleMessage(message)


### PR DESCRIPTION
# Description

Partial revert of PR #1824.

If database has old records with higher offsets because some old Kafka migration, we cnanot rely just on kafka_offset to skip a record.

Currently, all messages in stage are being discarded because this problem

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Local test

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
