### PR TITLE
Remove kafka_offset mechanism from code

### DIFF
--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -688,7 +688,7 @@ func TestKafkaConsumer_ConsumeClaim_DBError(t *testing.T) {
 	err := kafkaConsumer.ConsumeClaim(mockConsumerGroupSession, mockConsumerGroupClaim)
 	helpers.FailOnError(t, err)
 
-	assert.Contains(t, buf.String(), "unable to get latest offset")
+	assert.Contains(t, buf.String(), "starting messages loop")
 }
 
 func TestKafkaConsumer_ConsumeClaim_OKMessage(t *testing.T) {

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -313,7 +313,6 @@ func (consumer *KafkaConsumer) processMessage(msg *sarama.ConsumerMessage) (type
 		lastCheckedTime,
 		message.Metadata.GatheredAt,
 		storedAtTime,
-		types.KafkaOffset(msg.Offset),
 		message.RequestID,
 	)
 	if err == types.ErrOldReport {

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -129,7 +129,6 @@ func TestWrittenReportsMetric(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		time.Now(),
-		0,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -145,7 +144,6 @@ func TestWrittenReportsMetric(t *testing.T) {
 			testdata.LastCheckedAt.Add(time.Duration(i+1)*time.Second),
 			time.Now(),
 			time.Now(),
-			types.KafkaOffset(i+1),
 			testdata.RequestID1,
 		)
 		helpers.FailOnError(t, err)

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 	"github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
-	ctypes "github.com/RedHatInsights/insights-results-types"
 	types "github.com/RedHatInsights/insights-results-types"
 )
 
@@ -99,10 +98,10 @@ func TestBadOrganizationID(t *testing.T) {
 		Endpoint:     server.ClustersForOrganizationEndpoint,
 		EndpointArgs: []interface{}{providedOrgID},
 		XRHIdentity: helpers.MakeXRHTokenString(t, &types.Token{
-			Identity: ctypes.Identity{
+			Identity: types.Identity{
 				AccountNumber: testdata.UserID,
-				OrgID:         ctypes.OrgID(orgIDInXRH),
-				User: ctypes.User{
+				OrgID:         types.OrgID(orgIDInXRH),
+				User: types.User{
 					UserID: testdata.UserID,
 				},
 			},

--- a/server/report_benchmarks_test.go
+++ b/server/report_benchmarks_test.go
@@ -144,7 +144,6 @@ func initTestReports(b *testing.B, n uint, mockStorage storage.Storage, reportPr
 			time.Now(),
 			time.Now(),
 			time.Now(),
-			testdata.KafkaOffset,
 			testdata.RequestID1,
 		)
 		helpers.FailOnError(b, err)

--- a/server/server_read_report_metainfo_test.go
+++ b/server/server_read_report_metainfo_test.go
@@ -88,7 +88,6 @@ func TestReadExistingEmptyReportMetainfo(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.LastCheckedAt,
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -136,7 +135,6 @@ func TestReadReportMetainfo(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		testdata.LastCheckedAt,
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)

--- a/server/server_read_report_test.go
+++ b/server/server_read_report_test.go
@@ -92,7 +92,6 @@ func TestHttpServer_readReportForCluster_NoRules(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -144,7 +143,6 @@ func TestReadReport(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -188,7 +186,6 @@ func TestReadRuleReport(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -228,7 +225,6 @@ func TestReadReportDisableRule(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		now,
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -339,7 +335,6 @@ func TestReadReport_RuleDisableFeedback(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		now,
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -99,7 +99,6 @@ func TestListOfClustersForOrganizationOK(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -188,7 +187,6 @@ func TestListOfOrganizationsOK(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -201,7 +199,6 @@ func TestListOfOrganizationsOK(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -342,7 +339,6 @@ func TestRuleFeedbackVote(t *testing.T) {
 				testdata.LastCheckedAt,
 				testdata.LastCheckedAt,
 				time.Now(),
-				testdata.KafkaOffset,
 				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
@@ -457,8 +453,7 @@ func checkBadRuleFeedbackRequest(t *testing.T, message, expectedStatus string) {
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 		testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt,
-		time.Now(), testdata.KafkaOffset,
-		testdata.RequestID1,
+		time.Now(), testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 	helpers.AssertAPIRequest(t, mockStorage, nil, &helpers.APIRequest{
@@ -515,8 +510,7 @@ func TestHTTPServer_GetVoteOnRule_DBError(t *testing.T) {
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed,
-		testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset,
-		testdata.RequestID1,
+		testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -578,7 +572,6 @@ func TestHTTPServer_GetVoteOnRule(t *testing.T) {
 				testdata.LastCheckedAt,
 				testdata.LastCheckedAt,
 				time.Now(),
-				testdata.KafkaOffset,
 				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
@@ -631,7 +624,6 @@ func TestRuleToggle(t *testing.T) {
 				testdata.LastCheckedAt,
 				testdata.LastCheckedAt,
 				time.Now(),
-				testdata.KafkaOffset,
 				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
@@ -744,7 +736,6 @@ func TestHTTPServer_SaveDisableFeedback(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -793,7 +784,6 @@ func TestHTTPServer_SaveDisableFeedback_Error_CheckUserClusterPermissions(t *tes
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -831,7 +821,6 @@ func TestHTTPServer_SaveDisableFeedback_Error_BadBody(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -858,7 +847,6 @@ func TestHTTPServer_SaveDisableFeedback_Error_DBError(t *testing.T) {
 		testdata.LastCheckedAt,
 		testdata.LastCheckedAt,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -1649,7 +1637,6 @@ func TestHTTPServer_ListOfDisabledClusters_OneDisabled(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -1689,7 +1676,6 @@ func TestHTTPServer_ListOfDisabledClusters_JustificationTests(t *testing.T) {
 		testdata.LastCheckedAt,
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)

--- a/server/vote_endpoints_benchmarks_test.go
+++ b/server/vote_endpoints_benchmarks_test.go
@@ -152,7 +152,6 @@ func prepareVoteEndpointArgs(tb testing.TB, numberOfEndpointArgs uint, mockStora
 			time.Now(),
 			time.Now(),
 			time.Now(),
-			testdata.KafkaOffset,
 			testdata.RequestID1,
 		)
 		helpers.FailOnError(tb, err)

--- a/storage/info_rule_test.go
+++ b/storage/info_rule_test.go
@@ -188,8 +188,7 @@ func TestDBStorageReadClusterListRecommendationsNoRecommendationsWithVersion(t *
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, []ctypes.ReportItem{},
-		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
-		testdata.RequestID1,
+		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
@@ -220,8 +219,7 @@ func TestDBStorageReadClusterListRecommendationsWithVersion(t *testing.T) {
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, []ctypes.ReportItem{},
-		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
-		testdata.RequestID1,
+		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 

--- a/storage/noop_storage.go
+++ b/storage/noop_storage.go
@@ -78,14 +78,9 @@ func (*NoopStorage) ReadReportForClusterByClusterName(
 	return []types.RuleOnReport{}, "", nil
 }
 
-// GetLatestKafkaOffset noop
-func (*NoopStorage) GetLatestKafkaOffset() (types.KafkaOffset, error) {
-	return 0, nil
-}
-
 // WriteReportForCluster noop
 func (*NoopStorage) WriteReportForCluster(
-	types.OrgID, types.ClusterName, types.ClusterReport, []types.ReportItem, time.Time, time.Time, time.Time, types.KafkaOffset,
+	types.OrgID, types.ClusterName, types.ClusterReport, []types.ReportItem, time.Time, time.Time, time.Time,
 	types.RequestID,
 ) error {
 	return nil

--- a/storage/noop_storage_test.go
+++ b/storage/noop_storage_test.go
@@ -50,7 +50,6 @@ func TestNoopStorageEmptyMethods1(_ *testing.T) {
 	_ = noopStorage.DeleteReportsForOrg(orgID)
 	_ = noopStorage.DeleteReportsForCluster(clusterName)
 
-	_, _ = noopStorage.GetLatestKafkaOffset()
 	_ = noopStorage.MigrateToLatest()
 	_ = noopStorage.GetConnection()
 	noopStorage.PrintRuleDisableDebugInfo()
@@ -120,6 +119,6 @@ func TestNoopStorageEmptyMethods3(_ *testing.T) {
 	_, _ = noopStorage.ListOfReasons(userID)
 	_, _ = noopStorage.ListOfDisabledRulesForClusters([]string{""}, orgID)
 	_ = noopStorage.WriteConsumerError(nil, nil)
-	_ = noopStorage.WriteReportForCluster(0, "", "", []types.ReportItem{}, time.Now(), time.Now(), time.Now(), 0, "")
+	_ = noopStorage.WriteReportForCluster(0, "", "", []types.ReportItem{}, time.Now(), time.Now(), time.Now(), "")
 	_, _ = noopStorage.ReadReportsForClusters([]types.ClusterName{})
 }

--- a/storage/redis_storage.go
+++ b/storage/redis_storage.go
@@ -110,18 +110,13 @@ func (*RedisStorage) ReadReportForClusterByClusterName(
 	return []types.RuleOnReport{}, "", nil
 }
 
-// GetLatestKafkaOffset noop
-func (*RedisStorage) GetLatestKafkaOffset() (types.KafkaOffset, error) {
-	return 0, nil
-}
-
 // WriteReportForCluster method writes rule hits and other information about
 // new report into Redis storage
 func (storage *RedisStorage) WriteReportForCluster(
 	orgID types.OrgID, clusterName types.ClusterName, _ types.ClusterReport,
 	reportItems []types.ReportItem,
 	_ time.Time, gatheredAtTime time.Time, storedAtTime time.Time,
-	_ types.KafkaOffset, requestID types.RequestID,
+	requestID types.RequestID,
 ) error {
 	// retrieve context
 	ctx := context.Background()

--- a/storage/redis_storage_test.go
+++ b/storage/redis_storage_test.go
@@ -197,7 +197,7 @@ func TestRedisWriteReportForCluster(t *testing.T) {
 		testdata.OrgID, testdata.ClusterName,
 		testdata.Report3Rules, testdata.Report3RulesParsed,
 		testdata.LastCheckedAt, testdata.LastCheckedAt, timestamp,
-		testdata.KafkaOffset, testdata.RequestID1)
+		testdata.RequestID1)
 
 	assert.NoError(t, err)
 	assertRedisExpectationsMet(t, server)
@@ -236,7 +236,7 @@ func TestWriteEmptyReport(t *testing.T) {
 		testdata.OrgID, testdata.ClusterName,
 		testdata.Report3Rules, []types.ReportItem{},
 		testdata.LastCheckedAt, testdata.LastCheckedAt, timestamp,
-		testdata.KafkaOffset, testdata.RequestID1)
+		testdata.RequestID1)
 
 	assert.NoError(t, err)
 	assertRedisExpectationsMet(t, server)
@@ -265,7 +265,7 @@ func TestRedisWriteReportForClusterErrorHandling1(t *testing.T) {
 		testdata.OrgID, testdata.ClusterName,
 		testdata.Report3Rules, []types.ReportItem{},
 		testdata.LastCheckedAt, testdata.LastCheckedAt, timestamp,
-		testdata.KafkaOffset, testdata.RequestID1)
+		testdata.RequestID1)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, errorMessage)
@@ -307,7 +307,7 @@ func TestRedisWriteReportForClusterErrorHandling2(t *testing.T) {
 		testdata.OrgID, testdata.ClusterName,
 		testdata.Report3Rules, []types.ReportItem{},
 		testdata.LastCheckedAt, testdata.LastCheckedAt, timestamp,
-		testdata.KafkaOffset, testdata.RequestID1)
+		testdata.RequestID1)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, errorMessage)
@@ -350,7 +350,7 @@ func TestRedisWriteReportForClusterErrorHandling3(t *testing.T) {
 		testdata.OrgID, testdata.ClusterName,
 		testdata.Report3Rules, []types.ReportItem{},
 		testdata.LastCheckedAt, testdata.LastCheckedAt, timestamp,
-		testdata.KafkaOffset, testdata.RequestID1)
+		testdata.RequestID1)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, errorMessage)
@@ -380,7 +380,6 @@ func TestRedisStorageEmptyMethods1(_ *testing.T) {
 	_ = RedisStorage.DeleteReportsForOrg(orgID)
 	_ = RedisStorage.DeleteReportsForCluster(clusterName)
 
-	_, _ = RedisStorage.GetLatestKafkaOffset()
 	_ = RedisStorage.MigrateToLatest()
 	_ = RedisStorage.GetConnection()
 	RedisStorage.PrintRuleDisableDebugInfo()

--- a/storage/storage_rules_test.go
+++ b/storage/storage_rules_test.go
@@ -39,14 +39,16 @@ import (
 
 func mustWriteReport3Rules(t *testing.T, mockStorage storage.Storage) {
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset, testdata.RequestID1,
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules, testdata.Report3RulesParsed,
+		testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 }
 
 func mustWriteReport3RulesForCluster(t *testing.T, mockStorage storage.Storage, clusterName types.ClusterName) {
 	err := mockStorage.WriteReportForCluster(
-		testdata.OrgID, clusterName, testdata.Report3Rules, testdata.Report3RulesParsed, testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.KafkaOffset, testdata.RequestID1,
+		testdata.OrgID, clusterName, testdata.Report3Rules, testdata.Report3RulesParsed,
+		testdata.LastCheckedAt, testdata.LastCheckedAt, time.Now(), testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -80,8 +80,7 @@ func writeReportForCluster(
 	rules []types.ReportItem,
 ) {
 	err := storageImpl.WriteReportForCluster(orgID, clusterName, clusterReport,
-		rules, time.Now(), time.Now(), time.Now(), testdata.KafkaOffset,
-		testdata.RequestID1)
+		rules, time.Now(), time.Now(), time.Now(), testdata.RequestID1)
 	helpers.FailOnError(t, err)
 }
 
@@ -279,7 +278,6 @@ func TestDBStorageWriteReportForClusterClosedStorage(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "sql: database is closed")
@@ -298,7 +296,6 @@ func TestDBStorageWriteReportForClusterUnsupportedDriverError(t *testing.T) {
 		time.Now(),
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "writing report with DB -1 is not supported")
@@ -322,7 +319,6 @@ func TestDBStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 		newerTime,
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -336,7 +332,6 @@ func TestDBStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 		olderTime,
 		time.Now(),
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	assert.Equal(t, types.ErrOldReport, err)
@@ -412,7 +407,7 @@ func TestDBStorageWriteReportForClusterDroppedReportTable(t *testing.T) {
 
 	err = mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.ClusterReportEmpty,
-		testdata.ReportEmptyRulesParsed, time.Now(), time.Now(), time.Now(), testdata.KafkaOffset,
+		testdata.ReportEmptyRulesParsed, time.Now(), time.Now(), time.Now(),
 		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "no such table: report")
@@ -426,7 +421,7 @@ func TestDBStorageWriteReportForClusterExecError(t *testing.T) {
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
-		testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(), testdata.KafkaOffset,
+		testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(),
 		testdata.RequestID1,
 	)
 	assert.Error(t, err)
@@ -468,7 +463,7 @@ func TestDBStorageWriteReportForClusterFakePostgresOK(t *testing.T) {
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
 		testdata.Report3RulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(),
-		testdata.KafkaOffset, testdata.RequestID1)
+		testdata.RequestID1)
 	helpers.FailOnError(t, mockStorage.Close())
 	helpers.FailOnError(t, err)
 }
@@ -714,7 +709,6 @@ func TestDBStorageDeleteReports(t *testing.T) {
 				testdata.LastCheckedAt,
 				time.Now(),
 				time.Now(),
-				testdata.KafkaOffset,
 				testdata.RequestID1,
 			)
 			helpers.FailOnError(t, err)
@@ -823,51 +817,6 @@ func TestDBStorageWriteConsumerError(t *testing.T) {
 	assert.Equal(t, testProducedAt.Unix(), storageProducedAt.Unix())
 	assert.True(t, time.Now().UTC().After(storageConsumedAt))
 	assert.Equal(t, testError.Error(), storageError)
-}
-
-func TestDBStorage_GetLatestKafkaOffset(t *testing.T) {
-	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
-	defer closer()
-
-	offset, err := mockStorage.GetLatestKafkaOffset()
-	helpers.FailOnError(t, err)
-
-	assert.Equal(t, types.KafkaOffset(-1), offset)
-
-	mustWriteReport3Rules(t, mockStorage)
-
-	offset, err = mockStorage.GetLatestKafkaOffset()
-	helpers.FailOnError(t, err)
-
-	assert.Equal(t, types.KafkaOffset(1), offset)
-}
-
-func TestDBStorage_GetLatestKafkaOffset_ZeroOffset(t *testing.T) {
-	mockStorage, closer := ira_helpers.MustGetMockStorage(t, true)
-	defer closer()
-
-	offset, err := mockStorage.GetLatestKafkaOffset()
-	helpers.FailOnError(t, err)
-
-	assert.Equal(t, types.KafkaOffset(-1), offset)
-
-	err = mockStorage.WriteReportForCluster(
-		testdata.OrgID,
-		testdata.ClusterName,
-		testdata.Report3Rules,
-		testdata.Report3RulesParsed,
-		testdata.LastCheckedAt,
-		time.Now(),
-		time.Now(),
-		types.KafkaOffset(0),
-		testdata.RequestID1,
-	)
-	helpers.FailOnError(t, err)
-
-	offset, err = mockStorage.GetLatestKafkaOffset()
-	helpers.FailOnError(t, err)
-
-	assert.Equal(t, types.KafkaOffset(0), offset)
 }
 
 func TestDBStorage_Init(t *testing.T) {
@@ -1431,7 +1380,7 @@ func TestDBStorageReadClusterListRecommendationsNoRecommendations(t *testing.T) 
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.Report0Rules, []ctypes.ReportItem{},
-		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+		testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -1484,7 +1433,7 @@ func TestDBStorageReadClusterListRecommendationsGet1Cluster(t *testing.T) {
 
 		err := mockStorage.WriteReportForCluster(
 			testdata.OrgID, randomClusterID, testdata.Report3Rules, testdata.Report3RulesParsed,
-			testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+			testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt,
 			testdata.RequestID1,
 		)
 		helpers.FailOnError(t, err)
@@ -1526,7 +1475,7 @@ func TestDBStorageReadClusterListRecommendationsGetMoreClusters(t *testing.T) {
 
 		err := mockStorage.WriteReportForCluster(
 			testdata.OrgID, randomClusterID, testdata.Report3Rules, testdata.Report3RulesParsed,
-			testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt, 0,
+			testdata.LastCheckedAt, testdata.LastCheckedAt, testdata.LastCheckedAt,
 			testdata.RequestID1,
 		)
 		helpers.FailOnError(t, err)
@@ -1574,7 +1523,6 @@ func TestDBStorageWriteReportForClusterWithZeroGatheredTime(t *testing.T) {
 		time.Now(),
 		zeroTime,
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -1596,7 +1544,6 @@ func TestDoesClusterExist(t *testing.T) {
 		time.Now(),
 		time.Time{},
 		time.Now(),
-		testdata.KafkaOffset,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)

--- a/storage/storage_write_recommendations_benchmark_test.go
+++ b/storage/storage_write_recommendations_benchmark_test.go
@@ -489,7 +489,7 @@ func BenchmarkWriteReportAndRecommendationsNoConflict(b *testing.B) {
 		for id := range clusterIDSet.content {
 			err := storageImpl.WriteReportForCluster(types.OrgID(1), types.ClusterName(id),
 				testdata.Report2Rules, testdata.Report2RulesParsed,
-				time.Now(), time.Now(), time.Now(), types.KafkaOffset(0), testdata.RequestID1)
+				time.Now(), time.Now(), time.Now(), testdata.RequestID1)
 			helpers.FailOnError(b, err)
 			err = storageImpl.WriteRecommendationsForCluster(types.OrgID(1), types.ClusterName(id), Report20Rules, RecommendationCreatedAtTimestamp)
 			helpers.FailOnError(b, err)

--- a/types/types.go
+++ b/types/types.go
@@ -84,8 +84,6 @@ type (
 	RuleWithContent = types.RuleWithContent
 	// Version represents the version of the cluster
 	Version = types.Version
-	// KafkaOffset type for kafka offset
-	KafkaOffset = types.KafkaOffset
 	// DBDriver type for db driver enum
 	DBDriver = types.DBDriver
 	// Identity contains internal user info


### PR DESCRIPTION
# Description

The kafka_offset mechanism is not filtering any message, as its only function is to print a warning message. In addition, the mechanism is not implemented correctly as it can only work on single-partition topics and it relies in offset being always incresing, but it can be reset for many reasons.

Fixes #[CCXDEV-11690](https://issues.redhat.com/browse/CCXDEV-11690)

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Regular local tests

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
