### PR TITLE
[CCXDEV-11763] Refactor parseMessage and skip processing of incoming messages with empty reports

### DIFF
--- a/consumer/attribute_checker.go
+++ b/consumer/attribute_checker.go
@@ -1,0 +1,36 @@
+package consumer
+
+import (
+	"encoding/json"
+)
+
+// AttributeChecker is an interface for checking if an attribute is empty.
+type AttributeChecker interface {
+	IsEmpty() bool
+}
+
+// JSONAttributeChecker is an implementation of Checker for JSON data.
+type JSONAttributeChecker struct {
+	data []byte
+}
+
+// IsEmpty returns whether the data of the JSON data is empty
+func (j *JSONAttributeChecker) IsEmpty() bool {
+	if j.data == nil {
+		return true
+	}
+
+	var jsonData interface{}
+	if err := json.Unmarshal(j.data, &jsonData); err != nil {
+		return false
+	}
+
+	switch v := jsonData.(type) {
+	case []interface{}:
+		return len(v) == 0
+	case map[string]interface{}:
+		return len(v) == 0
+	default:
+		return false
+	}
+}

--- a/consumer/benchmark_test.go
+++ b/consumer/benchmark_test.go
@@ -102,7 +102,7 @@ func getMessagesFromDir(b *testing.B, dataDir string) []string {
 				helpers.FailOnError(b, err)
 
 				zerolog.SetGlobalLevel(zerolog.Disabled)
-				parsedMessage, err := consumer.ParseMessage(fileBytes)
+				parsedMessage, err := consumer.DeserializeMessage(fileBytes)
 				zerolog.SetGlobalLevel(zerolog.WarnLevel)
 				if err != nil {
 					log.Warn().Msgf("skipping file %+v because it has bad structure", file.Name())

--- a/consumer/benchmark_test.go
+++ b/consumer/benchmark_test.go
@@ -102,14 +102,14 @@ func getMessagesFromDir(b *testing.B, dataDir string) []string {
 				helpers.FailOnError(b, err)
 
 				zerolog.SetGlobalLevel(zerolog.Disabled)
-				parsedMessage, err := consumer.ParseMessage(false, fileBytes)
+				parsedMessage, err := consumer.ParseMessage(fileBytes)
 				zerolog.SetGlobalLevel(zerolog.WarnLevel)
 				if err != nil {
 					log.Warn().Msgf("skipping file %+v because it has bad structure", file.Name())
 					continue
 				}
-				err = consumer.CheckReportStructure(*parsedMessage.Report)
-				if err != nil {
+				canProcess, err := consumer.CheckReportStructure(*parsedMessage.Report)
+				if canProcess == false || err != nil {
 					log.Warn().Msgf("skipping file %+v because its report has bad structure", file.Name())
 					continue
 				}

--- a/consumer/benchmark_test.go
+++ b/consumer/benchmark_test.go
@@ -108,8 +108,8 @@ func getMessagesFromDir(b *testing.B, dataDir string) []string {
 					log.Warn().Msgf("skipping file %+v because it has bad structure", file.Name())
 					continue
 				}
-				canProcess, err := consumer.CheckReportStructure(*parsedMessage.Report)
-				if canProcess == false || err != nil {
+				err = consumer.CheckReportStructure(*parsedMessage.Report)
+				if err != nil {
 					log.Warn().Msgf("skipping file %+v because its report has bad structure", file.Name())
 					continue
 				}

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -216,7 +216,7 @@ func (consumer *KafkaConsumer) ConsumeClaim(session sarama.ConsumerGroupSession,
 	for message := range claim.Messages() {
 		err := consumer.HandleMessage(message)
 		if err != nil {
-			// already hanadled in HandleMessage, just log
+			// already handled in HandleMessage, just log
 			log.Error().Err(err).Msg("Problem while handling the message")
 		}
 		session.MarkMessage(message, "")

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -398,8 +398,8 @@ func TestCheckReportStructureReportWithAllAttributesPresentAndEmpty(t *testing.T
 
 	shouldProcess, err := consumer.CheckReportStructure(*parsed.Report)
 	assert.Nil(t, err, "checkReportStructure should return err = nil for empty reports")
-	assert.True(t, shouldProcess, "checkReportStructure should return"+
-		" shouldProcess = true for empty reports where all expected attributes are present")
+	assert.False(t, shouldProcess, "checkReportStructure should return"+
+		" shouldProcess = false for empty reports where all expected attributes are present")
 }
 
 // If some atributes are missing, but all the present attributes are empty, we just

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -21,14 +21,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/RedHatInsights/insights-operator-utils/tests/saramahelpers"
-	"github.com/RedHatInsights/insights-results-aggregator/producer"
-	ira_helpers "github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
-	zerolog_log "github.com/rs/zerolog/log"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/RedHatInsights/insights-operator-utils/tests/saramahelpers"
+	"github.com/RedHatInsights/insights-results-aggregator/producer"
+	ira_helpers "github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
+	zerolog_log "github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
@@ -527,6 +528,7 @@ func TestParseProperMessageReportWithEmptyAttributes(t *testing.T) {
 	c := consumer.KafkaConsumer{}
 	message := sarama.ConsumerMessage{Value: []byte(testdata.ConsumerMessage)}
 	parsed, shouldProcess, err := consumer.ParseMessage(&c, &message)
+	helpers.FailOnError(t, err)
 
 	assert.False(t, shouldProcess, "this message is valid but empty and should not be processed")
 	assert.Equal(t, types.OrgID(1), *parsed.Organization)
@@ -567,6 +569,7 @@ func TestParseProperMessageWithInfoReport(t *testing.T) {
 	c := consumer.KafkaConsumer{}
 	message := sarama.ConsumerMessage{Value: []byte(createConsumerMessage(consumerReport))}
 	parsed, shouldProcess, err := consumer.ParseMessage(&c, &message)
+	helpers.FailOnError(t, err)
 
 	assert.True(t, shouldProcess, "this message is valid and should be processed")
 	assert.Equal(t, types.OrgID(1), *parsed.Organization)

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -256,13 +256,13 @@ func TestIsReportWithEmptyAttributesAllEmpty(t *testing.T) {
 		"skips":        unmarshall("[]"),
 		"info":         unmarshall("[]"),
 	}
-	isEmpty := consumer.IsReportWithEmptyAttributes(r, consumer.ExpectedKeysInReport)
+	isEmpty := consumer.IsReportWithEmptyAttributes(r)
 	assert.True(t, isEmpty, "IsReportWithEmptyAttributes should return isEmpty = true for this report")
 }
 
 func TestIsReportWithEmptyAttributesEmptyReport(t *testing.T) {
 	r := consumer.Report{}
-	isEmpty := consumer.IsReportWithEmptyAttributes(r, consumer.ExpectedKeysInReport)
+	isEmpty := consumer.IsReportWithEmptyAttributes(r)
 	assert.True(t, isEmpty, "IsReportWithEmptyAttributes should return isEmpty = true for this report")
 }
 
@@ -274,7 +274,7 @@ func TestIsReportWithEmptyAttributesSystemDataIsPresent(t *testing.T) {
 		"skips":        unmarshall("[]"),
 		"info":         unmarshall("[]"),
 	}
-	isEmpty := consumer.IsReportWithEmptyAttributes(r, consumer.ExpectedKeysInReport)
+	isEmpty := consumer.IsReportWithEmptyAttributes(r)
 	assert.False(t, isEmpty, "IsReportWithEmptyAttributes should return isEmpty = false for this report")
 }
 
@@ -286,7 +286,7 @@ func TestIsReportWithEmptyAttributesLessAttributes(t *testing.T) {
 		"reports":      unmarshall("[]"),
 		"fingerprints": unmarshall("[]"),
 	}
-	isEmpty := consumer.IsReportWithEmptyAttributes(r, consumer.ExpectedKeysInReport)
+	isEmpty := consumer.IsReportWithEmptyAttributes(r)
 	assert.False(t, isEmpty, "IsReportWithEmptyAttributes should return isEmpty = false for this report")
 }
 
@@ -297,7 +297,7 @@ func TestIsReportWithEmptyAttributesInfoIsNotPresent(t *testing.T) {
 		"fingerprints": unmarshall("[]"),
 		"skips":        unmarshall("[]"),
 	}
-	isEmpty := consumer.IsReportWithEmptyAttributes(r, consumer.ExpectedKeysInReport)
+	isEmpty := consumer.IsReportWithEmptyAttributes(r)
 	assert.True(t, isEmpty, "IsReportWithEmptyAttributes should return isEmpty = true for this report")
 }
 
@@ -315,7 +315,7 @@ func TestIsReportWithEmptyAttributesReportsIsPresent(t *testing.T) {
 		"fingerprints": unmarshall("[]"),
 		"skips":        unmarshall("[]"),
 	}
-	isEmpty := consumer.IsReportWithEmptyAttributes(r, consumer.ExpectedKeysInReport)
+	isEmpty := consumer.IsReportWithEmptyAttributes(r)
 	assert.False(t, isEmpty, "IsReportWithEmptyAttributes should return isEmpty = false for this report")
 }
 

--- a/consumer/export_test.go
+++ b/consumer/export_test.go
@@ -26,7 +26,7 @@ package consumer
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd
 // to see why this trick is needed.
 var (
-	ParseMessage                = parseMessage
+	ParseMessage                = deserializeMessage
 	ParseReportContent          = parseReportContent
 	CheckReportStructure        = checkReportStructure
 	IsReportWithEmptyAttributes = isReportWithEmptyAttributes

--- a/consumer/export_test.go
+++ b/consumer/export_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package consumer
 
 import (
-	"github.com/Shopify/sarama"
 	"time"
+
+	"github.com/Shopify/sarama"
 )
 
 // Export for testing
@@ -41,6 +42,13 @@ var (
 
 var ParseMessageTestStartTime = time.Now()
 
-func ParseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (incomingMessage, bool, error) {
-	return consumer.parseMessage(msg, ParseMessageTestStartTime)
+// Inc type is a trick to get golint to work for the ParseMessage defined below...
+type Inc struct {
+	incomingMessage
+}
+
+// ParseMessage reproduces the functionality of the private parseMessage function for testing
+func ParseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (Inc, bool, error) {
+	incomingMessage, process, err := consumer.parseMessage(msg, ParseMessageTestStartTime)
+	return Inc{incomingMessage}, process, err
 }

--- a/consumer/export_test.go
+++ b/consumer/export_test.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package consumer
 
+import (
+	"github.com/Shopify/sarama"
+	"time"
+)
+
 // Export for testing
 //
 // This source file contains name aliases of all package-private functions
@@ -26,11 +31,16 @@ package consumer
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd
 // to see why this trick is needed.
 var (
-	ParseMessage                = deserializeMessage
-	ParseReportContent          = parseReportContent
-	CheckReportStructure        = checkReportStructure
-	IsReportWithEmptyAttributes = isReportWithEmptyAttributes
-
+	DeserializeMessage           = deserializeMessage
+	ParseReportContent           = parseReportContent
+	CheckReportStructure         = checkReportStructure
+	IsReportWithEmptyAttributes  = isReportWithEmptyAttributes
 	NumberOfExpectedKeysInReport = numberOfExpectedKeysInReport
 	ExpectedKeysInReport         = expectedKeysInReport
 )
+
+var ParseMessageTestStartTime = time.Now()
+
+func ParseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (incomingMessage, bool, error) {
+	return consumer.parseMessage(msg, ParseMessageTestStartTime)
+}

--- a/consumer/export_test.go
+++ b/consumer/export_test.go
@@ -48,7 +48,7 @@ type Inc struct {
 }
 
 // ParseMessage reproduces the functionality of the private parseMessage function for testing
-func ParseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (Inc, bool, error) {
-	incomingMessage, process, err := consumer.parseMessage(msg, ParseMessageTestStartTime)
-	return Inc{incomingMessage}, process, err
+func ParseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (Inc, error) {
+	incomingMessage, err := consumer.parseMessage(msg, ParseMessageTestStartTime)
+	return Inc{incomingMessage}, err
 }

--- a/consumer/export_test.go
+++ b/consumer/export_test.go
@@ -26,6 +26,11 @@ package consumer
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd
 // to see why this trick is needed.
 var (
-	ParseMessage         = parseMessage
-	CheckReportStructure = checkReportStructure
+	ParseMessage                = parseMessage
+	ParseReportContent          = parseReportContent
+	CheckReportStructure        = checkReportStructure
+	IsReportWithEmptyAttributes = isReportWithEmptyAttributes
+
+	NumberOfExpectedKeysInReport = numberOfExpectedKeysInReport
+	ExpectedKeysInReport         = expectedKeysInReport
 )

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -273,6 +273,12 @@ func (consumer *KafkaConsumer) writeInfoReport(
 	return nil
 }
 
+func (consumer *KafkaConsumer) logMsgForFurtherAnalysis(msg *sarama.ConsumerMessage) {
+	if consumer.Configuration.DisplayMessageWithWrongStructure {
+		log.Info().Str("unparsed message", string(msg.Value)).Msg("Message for further analysis")
+	}
+}
+
 func (consumer *KafkaConsumer) logReportStructureError(err error, msg *sarama.ConsumerMessage) {
 	if consumer.Configuration.DisplayMessageWithWrongStructure {
 		log.Err(err).Msgf(improperIncomeMessageError+"%v", string(msg.Value))
@@ -551,6 +557,7 @@ func parseReportContent(message *incomingMessage) error {
 func (consumer *KafkaConsumer) parseMessage(msg *sarama.ConsumerMessage, tStart time.Time) (incomingMessage, bool, error) {
 	message, err := deserializeMessage(msg.Value)
 	if err != nil {
+		consumer.logMsgForFurtherAnalysis(msg)
 		logUnparsedMessageError(consumer, msg, "Error parsing message from Kafka", err)
 		return message, false, err
 	}

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -411,19 +411,16 @@ func verifySystemAttributeIsEmpty(r Report) bool {
 	return true
 }
 
-func verifyJSONArrayAttributeIsEmpty[T any](attr string, r Report) bool {
-	if _, exist := r[attr]; exist && r[attr] != nil {
-		var arr []T
-		if err := json.Unmarshal(*r[attr], &arr); err != nil {
-			fmt.Println("unmarshalling")
+func verifyJSONArrayAttributeIsEmpty(attr string, r Report) bool {
+	if val, exist := r[attr]; exist && val != nil {
+		var arr []interface{}
+		if err := json.Unmarshal(*val, &arr); err != nil {
 			return false
 		}
 		if len(arr) != 0 {
-			fmt.Println("len is not 0", arr)
 			return false
 		}
 	}
-	fmt.Println("returning true")
 	return true
 }
 
@@ -436,26 +433,19 @@ func isReportWithEmptyAttributes(r Report, keysToCheck [numberOfExpectedKeysInRe
 	for _, key := range keysToCheck {
 		switch key {
 		case "system":
-			//if _, exist := r["system"]; !exist {
-			//	break
-			//}
-			//if _, exist := r["system"]; exist && !verifySystemAttributeIsEmpty(r) {
 			if !verifySystemAttributeIsEmpty(r) {
 				return false
 			}
 		case "reports":
-			//if _, exist := r["reports"]; exist && !verifyJSONArrayAttributeIsEmpty[types.ReportItem]("reports", r) {
-			if !verifyJSONArrayAttributeIsEmpty[types.ReportItem]("reports", r) {
+			if !verifyJSONArrayAttributeIsEmpty("reports", r) {
 				return false
 			}
 		case "fingerprints":
-			//if _, exist := r["fingerprints"]; exist && !verifyJSONArrayAttributeIsEmpty[json.RawMessage]("fingerprints", r) {
-			if !verifyJSONArrayAttributeIsEmpty[json.RawMessage]("fingerprints", r) {
+			if !verifyJSONArrayAttributeIsEmpty("fingerprints", r) {
 				return false
 			}
 		case "info":
-			//if _, exist := r["info"]; exist && !verifyJSONArrayAttributeIsEmpty[types.InfoItem]("info", r) {
-			if !verifyJSONArrayAttributeIsEmpty[types.InfoItem]("info", r) {
+			if !verifyJSONArrayAttributeIsEmpty("info", r) {
 				return false
 			}
 		}
@@ -486,7 +476,7 @@ func checkReportStructure(r Report) (shouldProcess bool, err error) {
 	// empty reports mean that this message should not be processed further
 	isEmpty := len(r) == 0 || isReportWithEmptyAttributes(r, keysFound)
 	if isEmpty {
-		log.Debug().Msg("Empty report or report with empty attributes. Processing of this message will be skipped.")
+		log.Debug().Msg("Empty report or report with only empty attributes. Processing of this message will be skipped.")
 		return false, nil
 	}
 

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -297,7 +297,6 @@ func (consumer *KafkaConsumer) shouldProcess(consumed *sarama.ConsumerMessage, p
 }
 
 func (consumer *KafkaConsumer) retrieveLastCheckedTime(msg *sarama.ConsumerMessage, parsedMsg *incomingMessage) (time.Time, error) {
-
 	lastCheckedTime, err := time.Parse(time.RFC3339Nano, parsedMsg.LastChecked)
 	if err != nil {
 		logMessageError(consumer, msg, *parsedMsg, "Error parsing date from message", err)
@@ -529,7 +528,6 @@ func deserializeMessage(messageValue []byte) (incomingMessage, error) {
 		return deserialized, errors.New("cluster name is not a UUID")
 	}
 	return deserialized, nil
-
 }
 
 // parseReportContent verifies the content of the Report structure and parses it into

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -281,7 +281,7 @@ func (consumer *KafkaConsumer) logMsgForFurtherAnalysis(msg *sarama.ConsumerMess
 
 func (consumer *KafkaConsumer) logReportStructureError(err error, msg *sarama.ConsumerMessage) {
 	if consumer.Configuration.DisplayMessageWithWrongStructure {
-		log.Err(err).Msgf(improperIncomeMessageError+"%v", string(msg.Value))
+		log.Err(err).Str("unparsed message", string(msg.Value)).Msg(improperIncomeMessageError+)
 	} else {
 		log.Err(err).Msg(improperIncomeMessageError)
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,6 +21,9 @@ limitations under the License.
 //
 // consuming_errors - total number of errors during consuming messages from selected broker
 //
+// messages_with_empty_rule_execution_result - total number of consumed messages not
+// processed as rule execution result is an empty report
+//
 // successful_messages_processing_time - time to process successfully message
 //
 // failed_messages_processing_time - time to process message fail
@@ -56,6 +59,12 @@ var ConsumedMessages = promauto.NewCounter(prometheus.CounterOpts{
 var ConsumingErrors = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "consuming_errors",
 	Help: "The total number of errors during consuming messages from Kafka",
+})
+
+// SkippedEmptyReports shows the total number of consumed messages not processed as the rule execution resulted in an empty report
+var SkippedEmptyReports = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "messages_with_empty_rule_execution_result",
+	Help: "The total number of consumed messages not processed as the rule execution resulted in an empty report",
 })
 
 // SuccessfulMessagesProcessingTime collects the time to process message successfully
@@ -133,6 +142,7 @@ func AddMetricsWithNamespace(namespace string) {
 
 	prometheus.Unregister(ConsumedMessages)
 	prometheus.Unregister(ConsumingErrors)
+	prometheus.Unregister(SkippedEmptyReports)
 	prometheus.Unregister(SuccessfulMessagesProcessingTime)
 	prometheus.Unregister(FailedMessagesProcessingTime)
 	prometheus.Unregister(LastCheckedTimestampLagMinutes)
@@ -153,6 +163,11 @@ func AddMetricsWithNamespace(namespace string) {
 		Namespace: namespace,
 		Name:      "consuming_errors",
 		Help:      "The total number of errors during consuming messages from Kafka",
+	})
+	SkippedEmptyReports = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "messages_with_empty_rule_execution_result",
+		Help:      "The total number of consumed messages not processed as the rule execution resulted in an empty report",
 	})
 	SuccessfulMessagesProcessingTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespace,

--- a/types/errors.go
+++ b/types/errors.go
@@ -41,6 +41,10 @@ type (
 // exists on the storage while attempting to write a report for a cluster.
 var ErrOldReport = types.ErrOldReport
 
+// ErrEmptyReport is an error returned if an empty report or a report with
+// only empty attributes is found in the parsed message
+var ErrEmptyReport = errors.New("empty report found in deserialized message")
+
 // TableNotFoundError table not found error
 type TableNotFoundError struct {
 	tableName string


### PR DESCRIPTION
# Description

- Change how the `processMessage` function behaves so when a message with empty report or with report with only empty attributes is received, it is discarded without being considered a consumer error.
- The PR is mainly refactored code to achieve that, and a lot of unit testing to cover the new functions created:
    - `parseMessage` has been split into `deserializeMessage`, `shouldProcess` and `parseReportContent`, which calls `checkReportStructure`.
    - `checkReportStructure` verifies if the report is empty using the new `AttributeChecker` interface, and if so, we stop processing the message without returning an error. In any other case, the report is processed as before.
   

Fixes #1834 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Unit tests

## Testing steps

- UTs
- Test in stage with `Molodec` uploading some of the archives that are currently making our service report the consuming errors

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
