### PR TITLE
[CCXDEV-11763] Skip analysis_metadata attribute when checking for empty report

### DIFF
--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -338,6 +338,17 @@ func TestCheckReportStructureReportWithAllAttributesPresentAndEmpty(t *testing.T
 	assert.EqualError(t, err, "empty report found in deserialized message")
 }
 
+func TestCheckReportStructureReportWithAnalysisMetadata(t *testing.T) {
+	report := consumer.Report{
+		"system":            unmarshall(`{"metadata": {}, "hostname": null}`),
+		"reports":           unmarshall("[]"),
+		"fingerprints":      unmarshall("[]"),
+		"analysis_metadata": unmarshall(`{"start": "2023-09-11T18:33:14.527845+00:00", "finish": "2023-09-11T18:33:15.632777+00:00"}`),
+	}
+	err := consumer.CheckReportStructure(report)
+	assert.EqualError(t, err, "empty report found in deserialized message")
+}
+
 // If some attributes are missing, but all the present attributes are empty, we just
 // skip the processing of the message.
 func TestCheckReportStructureReportWithEmptyAndMissingAttributes(t *testing.T) {
@@ -356,7 +367,7 @@ func TestCheckReportStructureReportWithItems(t *testing.T) {
 		"info":         unmarshall("[]"),
 		"reports":      unmarshall(string(testdata.Report2Rules)),
 		"skips":        unmarshall("[]"),
-		"system":       unmarshall("{\"metadata\": {},\"hostname\": null}"),
+		"system":       unmarshall(`{"metadata": {},"hostname": null}`),
 	}
 	err := consumer.CheckReportStructure(report)
 	assert.Nil(t, err, "checkReportStructure should return err = nil for empty reports")

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -36,6 +36,7 @@ const (
 	reportAttributeReports       = "reports"
 	reportAttributeInfo          = "info"
 	reportAttributeFingerprints  = "fingerprints"
+	reportAttributeMetadata      = "analysis_metadata"
 	numberOfExpectedKeysInReport = 4
 )
 
@@ -437,6 +438,10 @@ func verifySystemAttributeIsEmpty(r Report) bool {
 func isReportWithEmptyAttributes(r Report) bool {
 	// Create attribute checkers for each attribute
 	for attr, attrData := range r {
+		// we don't care about the analysis_metadata attribute
+		if attr == reportAttributeMetadata {
+			continue
+		}
 		// special handling for the system attribute, as it comes with data when empty
 		if attr == reportAttributeSystem {
 			if !verifySystemAttributeIsEmpty(r) {


### PR DESCRIPTION
# Description

When checking if a report is empty, the `analysis_metadata` attribute should not be considered, as it always has information.

Fixes #1834 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Added UT

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
