### PR TITLE
Fix valid empty reports not being processed

### DIFF
--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -465,13 +465,19 @@ func checkReportStructure(r Report) error {
 	// 'skips' key is now optional, we should not expect it anymore:
 	// https://github.com/RedHatInsights/insights-results-aggregator/issues/1206
 	keysNotFound := make([]string, 0, numberOfExpectedKeysInReport)
-
+	keysFound := 0
 	// check if the structure contains all expected keys
 	for _, expectedKey := range expectedKeysInReport {
 		_, found := r[expectedKey]
 		if !found {
 			keysNotFound = append(keysNotFound, expectedKey)
+		} else {
+			keysFound++
 		}
+	}
+
+	if keysFound == numberOfExpectedKeysInReport {
+		return nil
 	}
 
 	// empty reports mean that this message should not be processed further


### PR DESCRIPTION
# Description

Fix bug that was introduced while refactoring the code. It is important to process the *valid* empty reports, as they indicate a cluster where detected issues are no longer happening.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Updated UTs that would otherwise fail as they were using a valid empty report

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
