### PR TITLE
Don't repeat the same message twice

### DIFF
--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -247,7 +247,6 @@ func (consumer *KafkaConsumer) writeRecommendations(
 	}
 	tStored := time.Now()
 	logMessageDebug(consumer, msg, &message, "Stored recommendations")
-	logClusterInfo(&message)
 	return tStored, nil
 }
 
@@ -386,6 +385,7 @@ func (consumer *KafkaConsumer) processMessage(msg *sarama.ConsumerMessage) (type
 		return message.RequestID, message, err
 	}
 
+	// rule hits has been stored into database - time to log all these great info
 	logClusterInfo(&message)
 
 	infoStoredAtTime := time.Now()


### PR DESCRIPTION
# Description

How logs used to look:

```
8:07AM DBG rule hits for 11789772.5d5892d3-1f74-4ccf-91af-548dfc9767aa (request ID missing):
        rule: ccx_rules_ocp.ocs.operator_phase_check.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.pvc_phase_check.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.check_pods_scc.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.check_ocs_version.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.external.rules.nodes_requirements_check.report; error key: NODES_MINIMUM_REQUIREMENTS_NOT_MET
        rule: ccx_rules_ocp.external.bug_rules.bug_1766907.report; error key: BUGZILLA_BUG_1766907
        rule: ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report; error key: NODE_KUBELET_VERSION
        rule: ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report; error key: SAMPLES_FAILED_IMAGE_IMPORT_ERR
        rule: ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report; error key: AUTH_OPERATOR_PROXY_ERROR
8:07AM DBG rule hits for 11789772.5d5892d3-1f74-4ccf-91af-548dfc9767aa (request ID missing):
        rule: ccx_rules_ocp.ocs.operator_phase_check.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.pvc_phase_check.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.ceph_check_mon_clock_skew.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.check_pods_scc.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.ocs.check_ocs_version.report; error key: ERROR_KEY
        rule: ccx_rules_ocp.external.rules.nodes_requirements_check.report; error key: NODES_MINIMUM_REQUIREMENTS_NOT_MET
        rule: ccx_rules_ocp.external.bug_rules.bug_1766907.report; error key: BUGZILLA_BUG_1766907
        rule: ccx_rules_ocp.external.rules.nodes_kubelet_version_check.report; error key: NODE_KUBELET_VERSION
        rule: ccx_rules_ocp.external.rules.samples_op_failed_image_import_check.report; error key: SAMPLES_FAILED_IMAGE_IMPORT_ERR
        rule: ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report; error key: AUTH_OPERATOR_PROXY_ERROR
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
