### PR TITLE
CI: don't shallow clone in BDD test stage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # retrieve the latest tag set in repository
-version=$(git describe --tags --abbrev=0)
+version=$(git describe --always --tags --abbrev=0)
 
 buildtime=$(date)
 branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
# Description

version info is not obtained with `git describe --always --tags --abbrev=0`. So it can either be a tag or a full commit SHA, but not an empty string.

## Type of change

Fix for CI

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
