### PR TITLE
Use --always option in git describe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # retrieve the latest tag set in repository
-version=$(git describe --tags --abbrev=0)
+version=$(git describe --always --tags --abbrev=0)
 
 buildtime=$(date)
 branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
# Description

version info is now obtained with git describe --always --tags --abbrev=0. So it can either be a tag or a full commit SHA, but not an empty string.

Fixes [CCXDEV-11824](https://issues.redhat.com/browse/CCXDEV-11824)

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

BDDs on CI 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
