### PR TITLE
Remove mention of `is_internal` as it is deprecated

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -19,7 +19,6 @@ Authentication is working through `x-rh-identity` token which is provided by 3sc
       "last_name": "Doe",
       "is_active": true,
       "is_org_admin": false,
-      "is_internal": false,
       "locale": "en_US"
     },
     "internal": {


### PR DESCRIPTION
# Description

Remove mention of `is_internal` as it is deprecated and we don't use it.

## Type of change

- Documentation update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
