### PR TITLE
Support for SCRAM-SHA512

### DIFF
--- a/broker/configuration_test.go
+++ b/broker/configuration_test.go
@@ -71,7 +71,8 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 
 func TestBadConfiguration(t *testing.T) {
 	cfg := broker.Configuration{
-		CertPath: "missing_path",
+		SecurityProtocol: "SSL",
+		CertPath:         "missing_path",
 	}
 
 	saramaCfg, err := broker.SaramaConfigFromBrokerConfig(cfg)

--- a/broker/configuration_test.go
+++ b/broker/configuration_test.go
@@ -67,6 +67,17 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	assert.Equal(t, "username", saramaConfig.Net.SASL.User)
 	assert.Equal(t, "password", saramaConfig.Net.SASL.Password)
 	assert.Equal(t, "foobarbaz", saramaConfig.ClientID)
+
+	cfg.SaslMechanism = "SCRAM-SHA-512"
+	saramaConfig, err = broker.SaramaConfigFromBrokerConfig(cfg)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
+	assert.True(t, saramaConfig.Net.TLS.Enable)
+	assert.True(t, saramaConfig.Net.SASL.Enable)
+	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512), saramaConfig.Net.SASL.Mechanism)
+	assert.Equal(t, "username", saramaConfig.Net.SASL.User)
+	assert.Equal(t, "password", saramaConfig.Net.SASL.Password)
+	assert.Equal(t, "foobarbaz", saramaConfig.ClientID)
 }
 
 func TestBadConfiguration(t *testing.T) {

--- a/broker/scram_client.go
+++ b/broker/scram_client.go
@@ -1,0 +1,32 @@
+package broker
+
+import "github.com/xdg/scram"
+
+// SCRAMClient implementation for the SCRAM authentication
+type SCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+// Begin prepares the client for the SCRAM exchange
+func (x *SCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+// Step steps client through the SCRAM exchange
+func (x *SCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+// Done should return true when the SCRAM conversation
+// is over.
+func (x *SCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	github.com/verdverm/frisby v0.0.0-20170604211311-b16556248a9a
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	golang.org/x/sync v0.3.0
 )
 
@@ -74,6 +75,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
+	github.com/xdg/stringprep v1.0.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect


### PR DESCRIPTION
# Description

This PR adds support for SCRAM-SHA512 in the Kafka consumer

Fixes #[CCXDEV-11961](https://issues.redhat.com/browse/CCXDEV-11961)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Changes in REST API schema
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)
- Behavioral tests (no changes in the code)
- REST API tests
- Bump-up dependent library (no changes in the code)
- Security fix in dependent library (no changes in the code)
- Security fix in dependent library (changes made in the code)
- Benchmarks (no changes in the code)
- Documentation update
- Configuration update

## Testing steps

Manual testing

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
