### PR TITLE
allow the same connection for OCP and DVO storages in stage/prod

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -342,13 +342,19 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 		}
 	}
 
+	// get DB configuration from clowder
 	if clowder.LoadedConfig.Database != nil {
-		// get DB configuration from clowder
-		c.OCPRecommendationsStorage.PGDBName = clowder.LoadedConfig.Database.Name
-		c.OCPRecommendationsStorage.PGHost = clowder.LoadedConfig.Database.Hostname
-		c.OCPRecommendationsStorage.PGPort = clowder.LoadedConfig.Database.Port
-		c.OCPRecommendationsStorage.PGUsername = clowder.LoadedConfig.Database.Username
-		c.OCPRecommendationsStorage.PGPassword = clowder.LoadedConfig.Database.Password
+		storageConfig := storage.Configuration{
+			PGDBName:   clowder.LoadedConfig.Database.Name,
+			PGHost:     clowder.LoadedConfig.Database.Hostname,
+			PGPort:     clowder.LoadedConfig.Database.Port,
+			PGUsername: clowder.LoadedConfig.Database.Username,
+			PGPassword: clowder.LoadedConfig.Database.Password,
+		}
+
+		// we're currently using the same storage in all Clowderized envs (stage/prod)
+		c.OCPRecommendationsStorage = storageConfig
+		c.DVORecommendationsStorage = storageConfig
 	} else {
 		fmt.Println(noStorage)
 	}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -344,22 +344,22 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 
 	// get DB configuration from clowder
 	if clowder.LoadedConfig.Database != nil {
-		storageConfig := storage.Configuration{
-			PGDBName:   clowder.LoadedConfig.Database.Name,
-			PGHost:     clowder.LoadedConfig.Database.Hostname,
-			PGPort:     clowder.LoadedConfig.Database.Port,
-			PGUsername: clowder.LoadedConfig.Database.Username,
-			PGPassword: clowder.LoadedConfig.Database.Password,
-		}
-
 		// we're currently using the same storage in all Clowderized envs (stage/prod)
-		c.OCPRecommendationsStorage = storageConfig
-		c.DVORecommendationsStorage = storageConfig
+		updateStorageConfFromClowder(&c.OCPRecommendationsStorage)
+		updateStorageConfFromClowder(&c.DVORecommendationsStorage)
 	} else {
 		fmt.Println(noStorage)
 	}
 
 	return nil
+}
+
+func updateStorageConfFromClowder(conf *storage.Configuration) {
+	conf.PGDBName = clowder.LoadedConfig.Database.Name
+	conf.PGHost = clowder.LoadedConfig.Database.Hostname
+	conf.PGPort = clowder.LoadedConfig.Database.Port
+	conf.PGUsername = clowder.LoadedConfig.Database.Username
+	conf.PGPassword = clowder.LoadedConfig.Database.Password
 }
 
 func updateTopicsMapping(c *ConfigStruct) error {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -667,17 +667,23 @@ func TestClowderConfigForStorage(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	ocpStorageConf := conf.GetOCPRecommendationsStorageConfiguration()
-	assert.Equal(t, ocpStorageConf.PGDBName, name)
-	assert.Equal(t, ocpStorageConf.PGHost, hostname)
-	assert.Equal(t, ocpStorageConf.PGPort, port)
-	assert.Equal(t, ocpStorageConf.PGUsername, username)
-	assert.Equal(t, ocpStorageConf.PGPassword, password)
+	assert.Equal(t, name, ocpStorageConf.PGDBName)
+	assert.Equal(t, hostname, ocpStorageConf.PGHost)
+	assert.Equal(t, port, ocpStorageConf.PGPort)
+	assert.Equal(t, username, ocpStorageConf.PGUsername)
+	assert.Equal(t, password, ocpStorageConf.PGPassword)
+	// rest of config outside of clowder must be loaded correctly
+	assert.Equal(t, "sqlite3", ocpStorageConf.Driver)
+	assert.Equal(t, "sql", ocpStorageConf.Type)
 
 	// same config loaded for DVO storage in envs using clowder (stage/prod)
 	dvoStorageConf := conf.GetDVORecommendationsStorageConfiguration()
-	assert.Equal(t, dvoStorageConf.PGDBName, name)
-	assert.Equal(t, dvoStorageConf.PGHost, hostname)
-	assert.Equal(t, dvoStorageConf.PGPort, port)
-	assert.Equal(t, dvoStorageConf.PGUsername, username)
-	assert.Equal(t, dvoStorageConf.PGPassword, password)
+	assert.Equal(t, name, dvoStorageConf.PGDBName)
+	assert.Equal(t, hostname, dvoStorageConf.PGHost)
+	assert.Equal(t, port, dvoStorageConf.PGPort)
+	assert.Equal(t, username, dvoStorageConf.PGUsername)
+	assert.Equal(t, password, dvoStorageConf.PGPassword)
+	// rest of config outside of clowder must be loaded correctly
+	assert.Equal(t, "postgres", dvoStorageConf.Driver)
+	assert.Equal(t, "sql", dvoStorageConf.Type)
 }


### PR DESCRIPTION
# Description
this is needed to enable the migrations as we'll try to use the same database, only with a different schema.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Configuration update

## Testing steps
`make test`

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
