### PR TITLE
[CCXDEV-12250] Try to unzip incoming DVO-related messages when deserializing

### DIFF
--- a/consumer/dvo_processing.go
+++ b/consumer/dvo_processing.go
@@ -34,7 +34,12 @@ type DVORulesProcessor struct {
 func (DVORulesProcessor) deserializeMessage(messageValue []byte) (incomingMessage, error) {
 	var deserialized incomingMessage
 
-	err := json.Unmarshal(messageValue, &deserialized)
+	received, err := DecompressMessage(messageValue)
+	if err != nil {
+		return deserialized, err
+	}
+
+	err = json.Unmarshal(received, &deserialized)
 	if err != nil {
 		return deserialized, err
 	}

--- a/consumer/dvo_rules_consumer_test.go
+++ b/consumer/dvo_rules_consumer_test.go
@@ -200,6 +200,24 @@ func TestDeserializeDVOMessageNullMetrics(t *testing.T) {
 	assert.EqualError(t, err, "missing required attribute 'Metrics'")
 }
 
+func TestDeserializeCompressedDVOMessage(t *testing.T) {
+	consumerMessage := `{
+		"OrgID": ` + fmt.Sprint(testdata.OrgID) + `,
+		"ClusterName": "` + string(testdata.ClusterName) + `",
+		"LastChecked": "` + testdata.LastCheckedAt.Format(time.RFC3339) + `",
+		"Metrics": {
+			"we_dont_know_yet": "what_format_it_will_have",
+            "but": "this should be deserialized properly"
+		}
+	}`
+	compressed := compressConsumerMessage([]byte(consumerMessage))
+	c := consumer.KafkaConsumer{MessageProcessor: consumer.DVORulesProcessor{}}
+	message, err := consumer.DeserializeMessage(&c, compressed)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, types.OrgID(1), *message.Organization)
+	assert.Equal(t, testdata.ClusterName, *message.ClusterName)
+}
+
 func TestParseEmptyDVOMessage(t *testing.T) {
 	message := sarama.ConsumerMessage{}
 	_, err := consumer.ParseMessage(&dvoConsumer, &message)


### PR DESCRIPTION
# Description

Call `DecompressMessage` when deserializing incoming DVO-related message 

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Updated UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
