### PR TITLE
[CCXDEV-12206] Add PG_PARAMS: "sslmode=disable" to test-dvo-writer.yaml

### DIFF
--- a/deploy/test-dvo-writer.yaml
+++ b/deploy/test-dvo-writer.yaml
@@ -32,3 +32,4 @@ apps:
       parameters:
         ENV_NAME: env-ocm
         IMAGE_TAG: latest
+        PG_PARAMS: "sslmode=disable"


### PR DESCRIPTION
# Description

We need to use `PG_PARAMS: "sslmode=disable"` in order to deploy the app in ephemeral as the ephemeral DB is not a proper RDS instance but a pod running Postgres without SSL configured.

## Type of change

- Documentation update

## Testing steps

Locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
