### PR TITLE
add functionality for multple DB schemas, add support for both storages at once (aggregator case)

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -122,23 +122,15 @@ func createStorage() (storage.OCPRecommendationsStorage, storage.DVORecommendati
 	var dvoStorage storage.DVORecommendationsStorage
 	var err error
 
-	// try to initialize connection to storage
-	backend := conf.GetStorageBackendConfiguration().Use
-	switch backend {
-	case types.OCPRecommendationsStorage:
-		ocpStorage, err = storage.NewOCPRecommendationsStorage(ocpStorageCfg)
-		if err != nil {
-			log.Error().Err(err).Msg("storage.NewOCPRecommendationsStorage")
-			return nil, nil, err
-		}
-	case types.DVORecommendationsStorage:
-		dvoStorage, err = storage.NewDVORecommendationsStorage(dvoStorageCfg)
-		if err != nil {
-			log.Error().Err(err).Msg("storage.NewDVORecommendationsStorage")
-			return nil, nil, err
-		}
-	default:
-		return nil, nil, fmt.Errorf("Unknown storage backend %s", backend)
+	ocpStorage, err = storage.NewOCPRecommendationsStorage(ocpStorageCfg)
+	if err != nil {
+		log.Error().Err(err).Msg("storage.NewOCPRecommendationsStorage")
+		return nil, nil, err
+	}
+	dvoStorage, err = storage.NewDVORecommendationsStorage(dvoStorageCfg)
+	if err != nil {
+		log.Error().Err(err).Msg("storage.NewDVORecommendationsStorage")
+		return nil, nil, err
 	}
 
 	return ocpStorage, dvoStorage, nil
@@ -163,6 +155,16 @@ func prepareDBMigrations(dbStorage storage.Storage) int {
 		log.Info().Msg("Skipping migration for non-SQL database type")
 		return ExitStatusOK
 	}
+
+	dbConn, dbSchema := dbStorage.GetConnection(), dbStorage.GetDBSchema()
+
+	// ensure DB schema exists
+	if err := migration.InitDBSchema(dbConn, dbSchema); err != nil {
+		closeStorage(dbStorage)
+		log.Error().Err(err).Msg("Unable to initialize DB schema")
+		return ExitStatusPrepareDbError
+	}
+
 	// This is only used by some unit tests.
 	if autoMigrate {
 		if err := dbStorage.MigrateToLatest(); err != nil {
@@ -192,28 +194,39 @@ func prepareDB() int {
 	// TODO: when aggregator supports both storages at once, update the code below
 	// task to support both storages at once: https://issues.redhat.com/browse/CCXDEV-12316
 
-	ocpRecommendationsStorage, _, err := createStorage()
-
+	ocpRecommendationsStorage, dvoRecommendationsStorage, err := createStorage()
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating storage")
 		return ExitStatusPrepareDbError
 	}
-	defer closeStorage(ocpRecommendationsStorage)
 
-	// Ensure that the DB is at the latest migration version.
-	if exitCode := prepareDBMigrations(ocpRecommendationsStorage); exitCode != ExitStatusOK {
-		return exitCode
+	if ocpRecommendationsStorage != nil {
+		defer closeStorage(ocpRecommendationsStorage)
+
+		// Ensure that the DB is at the latest migration version.
+		if exitCode := prepareDBMigrations(ocpRecommendationsStorage); exitCode != ExitStatusOK {
+			return exitCode
+		}
+
+		// Initialize the database.
+		err = ocpRecommendationsStorage.Init()
+		if err != nil {
+			log.Error().Err(err).Msg("DB initialization error")
+			return ExitStatusPrepareDbError
+		}
+
+		// temporarily print some information from DB because of limited access to DB
+		ocpRecommendationsStorage.PrintRuleDisableDebugInfo()
 	}
 
-	// Initialize the database.
-	err = ocpRecommendationsStorage.Init()
-	if err != nil {
-		log.Error().Err(err).Msg("DB initialization error")
-		return ExitStatusPrepareDbError
-	}
+	if dvoRecommendationsStorage != nil {
+		defer closeStorage(dvoRecommendationsStorage)
 
-	// temporarily print some information from DB because of limited access to DB
-	ocpRecommendationsStorage.PrintRuleDisableDebugInfo()
+		// Ensure that the DB is at the latest migration version.
+		if exitCode := prepareDBMigrations(dvoRecommendationsStorage); exitCode != ExitStatusOK {
+			return exitCode
+		}
+	}
 
 	return ExitStatusOK
 }
@@ -385,6 +398,7 @@ func getDBForMigrations() (storage.Storage, *sql.DB, int) {
 		return nil, nil, ExitStatusPrepareDbError
 	}
 
+	// migrations are allowed only if a single storage backend is selected
 	backend := conf.GetStorageBackendConfiguration().Use
 	switch backend {
 	case types.OCPRecommendationsStorage:
@@ -397,6 +411,13 @@ func getDBForMigrations() (storage.Storage, *sql.DB, int) {
 	}
 
 	dbConn := db.GetConnection()
+
+	// ensure DB schema is created
+	if err := migration.InitDBSchema(dbConn, db.GetDBSchema()); err != nil {
+		closeStorage(db)
+		log.Error().Err(err).Msg("Unable to initialize DB schema")
+		return nil, nil, ExitStatusPrepareDbError
+	}
 
 	if err := migration.InitInfoTable(dbConn, db.GetDBSchema()); err != nil {
 		closeStorage(db)

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -192,6 +192,21 @@ func TestLoadStorageBackendConfigurationChangedFromEnvVar(t *testing.T) {
 	assert.Equal(t, "dvo_recommendations", storageCfg.Use)
 }
 
+// TestLoadStorageBackendConfigurationChangedFromEnvVar tests loading the
+// storage backend configuration subtree doesn't change from empty
+func TestLoadStorageBackendConfigurationNotChangedWhenEmpty(t *testing.T) {
+	os.Clearenv()
+
+	const configPath = "../tests/config1"
+
+	mustSetEnv(t, "INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE", "")
+
+	mustLoadConfiguration(configPath)
+
+	storageCfg := conf.GetStorageBackendConfiguration()
+	assert.Equal(t, "", storageCfg.Use)
+}
+
 // TestLoadOCPRecommendationsStorageConfiguration tests loading the OCP
 // recommendations storage configuration subtree
 func TestLoadOCPRecommendationsStorageConfiguration(t *testing.T) {

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -45,7 +45,7 @@ pg_password = "postgres"
 pg_host = "localhost"
 pg_port = 5432
 pg_db_name = "dvo"
-pg_params = ""
+pg_params = "sslmode=disable"
 log_sql_queries = true
 type = "sql"
 

--- a/config.toml
+++ b/config.toml
@@ -44,13 +44,13 @@ pg_username = "user"
 pg_password = "password"
 pg_host = "localhost"
 pg_port = 5432
-pg_db_name = "dvo"
+pg_db_name = "aggregator"
 pg_params = ""
 log_sql_queries = true
 type = "sql"
 
 [storage_backend]
-use = "ocp_recommendations"
+use = ""
 
 [redis]
 database = 0

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -57,6 +57,8 @@ objects:
             - name: execute-migrations
               image: ${IMAGE}:${IMAGE_TAG}
               env:
+                - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE
+                  value: "ocp_recommendations"
                 - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ENABLED
                   value: "false"
                 - name: INSIGHTS_RESULTS_AGGREGATOR__METRICS__ENABLED
@@ -113,6 +115,8 @@ objects:
                 - migration
                 - latest
           env:
+            - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE
+              value: "ocp_recommendations"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS
               value: "${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__TIMEOUT

--- a/server.go
+++ b/server.go
@@ -35,7 +35,6 @@ var (
 func startServer() error {
 	defer finishServerInstanceInitialization()
 
-	// right now, just the OCP recommendations storage are handled properly
 	ocpRecommendationsStorage, _, err := createStorage()
 	if err != nil {
 		return err

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -41,7 +41,7 @@ pg_params = ""
 type = "sql"
 
 [storage_backend]
-use = "ocp_recommendations"
+use = ""
 
 [redis]
 database = 0

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -32,6 +32,12 @@ type = "sql"
 
 [dvo_recommendations_storage]
 db_driver = "postgres"
+pg_username = "postgres"
+pg_password = "postgres"
+pg_host = "localhost"
+pg_port = 5432
+pg_db_name = "aggregator"
+pg_params = "sslmode=disable"
 type = "sql"
 
 [storage_backend]


### PR DESCRIPTION
# Description
- "empty" `storage_backend.use` is now supported -- uses both storagesa t once (aggregator)
- both aggregator commands now support multiple DB schemas
  - `migrate` command and `start-service` command
- existing UTs cover most of the behavior, adding more to cover new functionality
- the internal logic will need to be improved, because the logic relies on the server running (meaning that db-writer, cache-writer and dvo-writer have a server running for no reason)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Unit tests (no changes in the code)
- Configuration update

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
