### PR TITLE
[DVO] Use shared DB

### DIFF
--- a/deploy/dvo-writer.yaml
+++ b/deploy/dvo-writer.yaml
@@ -227,6 +227,8 @@ objects:
               memory: ${DVO_WRITER_MEMORY_REQUEST}
     database:
       sharedDbAppName: ccx-insights-results
+    dependencies:
+      - ccx-insights-results
     kafkaTopics:
       - replicas: 3
         partitions: 1

--- a/deploy/dvo-writer.yaml
+++ b/deploy/dvo-writer.yaml
@@ -226,10 +226,7 @@ objects:
               cpu: ${DVO_WRITER_CPU_REQUEST}
               memory: ${DVO_WRITER_MEMORY_REQUEST}
     database:
-      # the DB name should match to app-interface DB name without specifying environment
-      # https://gitlab.cee.redhat.com/service/app-interface/-/blob/ddd85c2ad79b40047391405b2d909eb38667bc43/data/services/insights/ccx-data-pipeline/namespaces/stage-ccx-data-pipeline-stage.yml#L60
-      name: ccx-data-pipeline
-      version: 15
+      sharedDbAppName: ccx-insights-results
     kafkaTopics:
       - replicas: 3
         partitions: 1


### PR DESCRIPTION
# Description

When deploying this on ephemeral there are 2 databases: looking at the pods, there is a [ccx-insights-results-db](https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/ns/ephemeral-hzjj6p/deployments/ccx-insights-results-db) and [dvo-writer-db](https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/ns/ephemeral-hzjj6p/deployments/dvo-writer-db). This is making the deployment fail. This change makes use of [sharedDbAppName](https://redhatinsights.github.io/clowder/clowder/dev/providers/database.html#_using_a_shared_database_across_multiple_clowdapps) to fix it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
