### PR TITLE
[CCXDEV-11595][dvo-writer] Fix port

### DIFF
--- a/deploy/dvo-writer.yaml
+++ b/deploy/dvo-writer.yaml
@@ -271,9 +271,9 @@ objects:
   spec:
     ports:
       - name: web
-        port: 9001
+        port: 9000
         protocol: TCP
-        targetPort: 9001
+        targetPort: 9000
     selector:
       app: dvo-writer
       pod: dvo-writer-instance


### PR DESCRIPTION
# Description

I found out the metrics were not being scraped because the scraped port is 9000 but the service was configured to use 9001.

## Type of change

- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
