### PR TITLE
fix cache-writer not initializing redis storage because it's created as part of OCP storage

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -122,8 +122,8 @@ func createStorage() (storage.OCPRecommendationsStorage, storage.DVORecommendati
 	var dvoStorage storage.DVORecommendationsStorage
 	var err error
 
-	// create any storage we have credentials for
-	if ocpStorageCfg.Driver != "" {
+	// create any storage we have configured
+	if ocpStorageCfg.Type != "" {
 		ocpStorage, err = storage.NewOCPRecommendationsStorage(ocpStorageCfg)
 		if err != nil {
 			log.Error().Err(err).Msg("storage.NewOCPRecommendationsStorage")
@@ -131,7 +131,7 @@ func createStorage() (storage.OCPRecommendationsStorage, storage.DVORecommendati
 		}
 	}
 
-	if dvoStorageCfg.Driver != "" {
+	if dvoStorageCfg.Type != "" {
 		dvoStorage, err = storage.NewDVORecommendationsStorage(dvoStorageCfg)
 		if err != nil {
 			log.Error().Err(err).Msg("storage.NewDVORecommendationsStorage")


### PR DESCRIPTION
# Description
Redis is a part of the OCP recommendations storage (this made a little bit of sense when we only had one storage `Storage`) and it was switching which connection to create based on this [config option](https://github.com/RedHatInsights/insights-results-aggregator/blob/master/storage/ocp_recommendations_storage.go#L251)

with this change, `storage.NewOCPRecommendationsStorage` will be called even if we don't have the configuration to connect to OCP SQL storage.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
