### PR TITLE
do not initialize last_checked_at map if running as dvo-writer

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -219,11 +219,14 @@ func prepareDB() int {
 			return exitCode
 		}
 
-		// Initialize the database.
-		err = ocpRecommendationsStorage.Init()
-		if err != nil {
-			log.Error().Err(err).Msg("DB initialization error")
-			return ExitStatusPrepareDbError
+		// do not initialize last_checked_at map if we're running as dvo-writer
+		if conf.GetStorageBackendConfiguration().Use != types.DVORecommendationsStorage {
+			// Initialize the database.
+			err = ocpRecommendationsStorage.Init()
+			if err != nil {
+				log.Error().Err(err).Msg("DB initialization error")
+				return ExitStatusPrepareDbError
+			}
 		}
 
 		// temporarily print some information from DB because of limited access to DB

--- a/aggregator.go
+++ b/aggregator.go
@@ -185,12 +185,14 @@ func prepareDBMigrations(dbStorage storage.Storage) int {
 			log.Error().Err(err).Msg("unable to check DB migration version")
 			return ExitStatusPrepareDbError
 		}
+		log.Debug().Msgf("%v DB schema current migration %v", dbSchema, currentVersion)
 
 		maxVersion := dbStorage.GetMaxVersion()
 		if currentVersion != maxVersion {
 			log.Error().Msgf("old DB migration version (current: %d, latest: %d)", currentVersion, maxVersion)
 			return ExitStatusPrepareDbError
 		}
+		log.Debug().Msgf("%v DB schema maximum migration %v", dbSchema, maxVersion)
 	}
 
 	return ExitStatusOK

--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -415,6 +415,7 @@ func (storage OCPRecommendationsDBStorage) Init() error {
 		return err
 	}
 
+	log.Debug().Msg("executing last_checked_at query")
 	for rows.Next() {
 		var (
 			clusterName types.ClusterName


### PR DESCRIPTION
# Description
we will need the same funcitonality for dvo-writer, but it'll have to read from dvo.report table, not the old report table

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Configuration update

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
