### PR TITLE
[CCXDEV-12473] Generalisation of storage in kafka consumer

### DIFF
--- a/consumer/dvo_rules_consumer.go
+++ b/consumer/dvo_rules_consumer.go
@@ -22,6 +22,6 @@ import (
 )
 
 // NewDVORulesConsumer constructs new implementation of Consumer interface
-func NewDVORulesConsumer(brokerCfg broker.Configuration, storage storage.OCPRecommendationsStorage) (*KafkaConsumer, error) {
+func NewDVORulesConsumer(brokerCfg broker.Configuration, storage storage.DVORecommendationsStorage) (*KafkaConsumer, error) {
 	return NewKafkaConsumer(brokerCfg, storage, DVORulesProcessor{})
 }

--- a/consumer/dvo_rules_consumer_test.go
+++ b/consumer/dvo_rules_consumer_test.go
@@ -75,7 +75,7 @@ func TestDVORulesConsumer_New(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		sarama.Logger = log.New(os.Stdout, saramaLogPrefix, log.LstdFlags)
 
-		mockStorage, closer := ira_helpers.MustGetPostgresStorage(t, true)
+		mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 		defer closer()
 
 		mockBroker := sarama.NewMockBroker(t, 0)
@@ -295,7 +295,7 @@ func TestParseDVOMessageWithImproperJSON(t *testing.T) {
 //func TestParseMessageWithImproperMetrics(t *testing.T) {}
 
 func TestProcessEmptyDVOMessage(t *testing.T) {
-	mockStorage, closer := ira_helpers.MustGetPostgresStorage(t, true)
+	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
 
 	c := dummyDVOConsumer(mockStorage, true)
@@ -304,15 +304,4 @@ func TestProcessEmptyDVOMessage(t *testing.T) {
 	// message is empty -> nothing should be written into storage
 	err := c.HandleMessage(&message)
 	assert.EqualError(t, err, "unexpected end of JSON input")
-
-	count, err := mockStorage.ReportsCount()
-	helpers.FailOnError(t, err)
-
-	// no record should be written into database
-	assert.Equal(
-		t,
-		0,
-		count,
-		"process message shouldn't write anything into the DB",
-	)
 }

--- a/consumer/kafka_consumer.go
+++ b/consumer/kafka_consumer.go
@@ -76,14 +76,14 @@ type KafkaConsumer struct {
 var DefaultSaramaConfig *sarama.Config
 
 // NewKafkaConsumer constructs new implementation of Consumer interface
-func NewKafkaConsumer(brokerCfg broker.Configuration, storage storage.OCPRecommendationsStorage, processor MessageProcessor) (*KafkaConsumer, error) {
+func NewKafkaConsumer(brokerCfg broker.Configuration, storage storage.Storage, processor MessageProcessor) (*KafkaConsumer, error) {
 	return NewKafkaConsumerWithSaramaConfig(brokerCfg, storage, DefaultSaramaConfig, processor)
 }
 
 // NewKafkaConsumerWithSaramaConfig constructs new implementation of Consumer interface with custom sarama config
 func NewKafkaConsumerWithSaramaConfig(
 	brokerCfg broker.Configuration,
-	storage storage.OCPRecommendationsStorage,
+	storage storage.Storage,
 	saramaConfig *sarama.Config,
 	processor MessageProcessor,
 ) (*KafkaConsumer, error) {


### PR DESCRIPTION
# Description

Storage was generalised from OCPRecommendationsStorage to make sure that OCP consumer creates OCP storage and DVO consumer creates DVO storage

Fixes # [CCXDEV-12473]

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- 
## Testing steps
Tested by running unit tests

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
