### PR TITLE
[CCXDEV-12475] Insert workload recommendation in DB

### DIFF
--- a/consumer/dvo_processing.go
+++ b/consumer/dvo_processing.go
@@ -135,7 +135,7 @@ func (consumer *KafkaConsumer) writeDVOReport(
 	msg *sarama.ConsumerMessage, message incomingMessage,
 	reportAsBytes []byte, lastCheckedTime time.Time,
 ) error {
-	if dvoStorage, ok := consumer.Storage.(storage.DVORecommendationsDBStorage); ok {
+	if dvoStorage, ok := consumer.Storage.(storage.DVORecommendationsStorage); ok {
 		// timestamp when the report is about to be written into database
 		storedAtTime := time.Now()
 
@@ -143,7 +143,7 @@ func (consumer *KafkaConsumer) writeDVOReport(
 			*message.Organization,
 			*message.ClusterName,
 			types.ClusterReport(reportAsBytes),
-			message.ParsedHits,
+			message.ParsedWorkloads,
 			lastCheckedTime,
 			message.Metadata.GatheredAt,
 			storedAtTime,

--- a/consumer/dvo_rules_consumer_test.go
+++ b/consumer/dvo_rules_consumer_test.go
@@ -417,21 +417,7 @@ func TestProcessingEmptyMetricsMissingAttributesWithClosedStorage(t *testing.T) 
 	helpers.FailOnError(t, err, "empty report should not be considered an error at HandleMessage level")
 }
 
-func TestProcessingValidDVOMessageEmptyReportWithRequiredAttributesWithClosedStorage(t *testing.T) {
-	// TODO: Unskip
-	t.Skip("not implemented yet")
-	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
-
-	mockConsumer := dummyDVOConsumer(mockStorage, true)
-	closer()
-
-	err := consumerProcessMessage(mockConsumer, messageReportNoDVOMetrics)
-	assert.EqualError(t, err, "sql: database is closed")
-}
-
 func TestProcessingCorrectDVOMessageWithClosedStorage(t *testing.T) {
-	// TODO: Unskip
-	t.Skip("not implemented yet")
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 
 	mockConsumer := dummyDVOConsumer(mockStorage, true)
@@ -441,21 +427,7 @@ func TestProcessingCorrectDVOMessageWithClosedStorage(t *testing.T) {
 	assert.EqualError(t, err, "sql: database is closed")
 }
 
-func TestProcessingDVOMessageWithWrongDateFormatAndEmptyReport(t *testing.T) {
-	// TODO: Unskip
-	t.Skip("not implemented yet")
-	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
-
-	mockConsumer := dummyDVOConsumer(mockStorage, true)
-	closer()
-
-	err := consumerProcessMessage(mockConsumer, messageReportNoDVOMetrics)
-	assert.Nil(t, err, "Message with empty metrics should not be processed")
-}
-
 func TestProcessingDVOMessageWithWrongDateFormatReportNotEmpty(t *testing.T) {
-	// TODO: Unskip
-	t.Skip("not implemented yet")
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
 

--- a/consumer/dvo_rules_consumer_test.go
+++ b/consumer/dvo_rules_consumer_test.go
@@ -408,8 +408,6 @@ func TestProcessCorrectDVOMessage(t *testing.T) {
 }
 
 func TestProcessingEmptyMetricsMissingAttributesWithClosedStorage(t *testing.T) {
-	// TODO: Unskip
-	t.Skip("not implemented yet")
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 
 	mockConsumer := dummyDVOConsumer(mockStorage, true)

--- a/consumer/dvo_rules_consumer_test.go
+++ b/consumer/dvo_rules_consumer_test.go
@@ -388,8 +388,6 @@ func TestProcessEmptyDVOMessage(t *testing.T) {
 }
 
 func TestProcessCorrectDVOMessage(t *testing.T) {
-	// TODO: Unskip
-	t.Skip("not implemented yet")
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 
 	defer closer()

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -357,7 +357,6 @@ func mapWorkloadRecommendations(recommendations *[]types.WorkloadRecommendation)
 	nRecommendations := len(*recommendations)
 
 	for _, recommendation := range *recommendations {
-		log.Warn().Interface("workload", recommendation).Msg("reading workload")
 		for _, workload := range recommendation.Workloads {
 			if _, ok := namespaceMap[workload.NamespaceUID]; !ok {
 				// store the namespace name in the namespaceMap if it's not already there

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -294,15 +294,15 @@ func (storage DVORecommendationsDBStorage) updateReport(
 	recommendations []types.WorkloadRecommendation,
 	lastCheckedTime time.Time,
 ) error {
+	if len(recommendations) == 0 {
+		return nil
+	}
+
 	// Get reported_at if present before deletion
 	reportedAtMap, err := storage.getReportedAtMap(orgID, clusterName)
 	if err != nil {
 		log.Error().Err(err).Msgf("Unable to get dvo report reported_at")
 		reportedAtMap = make(map[string]types.Timestamp) // create empty map
-	}
-
-	if len(recommendations) == 0 {
-		return nil
 	}
 
 	namespaceMap, objectsMap, nRecommendations := mapWorkloadRecommendations(&recommendations)

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -75,7 +75,7 @@ func NewDVORecommendationsStorage(configuration Configuration) (DVORecommendatio
 		return newNoopDVOStorage(configuration)
 	default:
 		// error to be thrown
-		err := fmt.Errorf("unknown storage type '%s'", configuration.Type)
+		err := fmt.Errorf("Unknown storage type '%s'", configuration.Type)
 		log.Error().Err(err).Msg("Init failure")
 		return nil, err
 	}

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -84,12 +84,3 @@ func TestNewDVOStorageReturnedImplementation(t *testing.T) {
 	})
 	assert.Nil(t, s, "redis type is not supported for DVO storage")
 }
-
-func TestDBStorage_getWorkloadsInsertStatement(t *testing.T) {
-	fakeStorage := storage.NewDVORecommendationsFromConnection(nil, -1)
-	r := fakeStorage.GetWorkloadsInsertStatement(3)
-
-	// 5*3 placeholders expected
-	const expected = "INSERT INTO dvo.dvo_report(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9),($10,$11,$12,$13,$14,$15,$16,$17,$18),($19,$20,$21,$22,$23,$24,$25,$26,$27)"
-	assert.Equal(t, expected, r)
-}

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -84,3 +84,12 @@ func TestNewDVOStorageReturnedImplementation(t *testing.T) {
 	})
 	assert.Nil(t, s, "redis type is not supported for DVO storage")
 }
+
+func TestDBStorage_getWorkloadsInsertStatement(t *testing.T) {
+	fakeStorage := storage.NewDVORecommendationsFromConnection(nil, -1)
+	r := fakeStorage.GetWorkloadsInsertStatement(3)
+
+	// 5*3 placeholders expected
+	const expected = "INSERT INTO dvo.dvo_report(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9),($10,$11,$12,$13,$14,$15,$16,$17,$18),($19,$20,$21,$22,$23,$24,$25,$26,$27)"
+	assert.Equal(t, expected, r)
+}

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -292,6 +292,6 @@ func TestDVOStorageWriteReportForClusterCheckItIsStored(t *testing.T) {
 	assert.Equal(t, validDVORecommendation, gotWorkloads.WorkloadRecommendations, "the column report is different than expected")
 	assert.Equal(t, 1, recommendations, "the column recommendations is different than expected")
 	assert.Equal(t, 1, objects, "the column objects is different than expected")
-	assert.Equal(t, now, lastChecked.UTC(), "the column reported_at is different than expected")
-	assert.Equal(t, now, reportedAt.UTC(), "the column last_checked_at is different than expected")
+	assert.Equal(t, now.Truncate(time.Millisecond), lastChecked.UTC().Truncate(time.Millisecond), "the column reported_at is different than expected")
+	assert.Equal(t, now.Truncate(time.Millisecond), reportedAt.UTC().Truncate(time.Millisecond), "the column last_checked_at is different than expected")
 }

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -51,6 +51,10 @@ func GetConnection(storage *OCPRecommendationsDBStorage) *sql.DB {
 	return storage.connection
 }
 
+func GetConnectionDVO(storage *DVORecommendationsDBStorage) *sql.DB {
+	return storage.connection
+}
+
 func GetClustersLastChecked(storage *OCPRecommendationsDBStorage) map[types.ClusterName]time.Time {
 	return storage.clustersLastChecked
 }

--- a/storage/noop_dvo_recommendations_storage.go
+++ b/storage/noop_dvo_recommendations_storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/RedHatInsights/insights-results-aggregator/migration"
 	"github.com/RedHatInsights/insights-results-aggregator/types"
@@ -67,4 +68,12 @@ func (*NoopDVOStorage) MigrateToLatest() error {
 // ReportsCount noop
 func (*NoopDVOStorage) ReportsCount() (int, error) {
 	return 0, nil
+}
+
+// WriteReportForCluster noop
+func (*NoopDVOStorage) WriteReportForCluster(
+	types.OrgID, types.ClusterName, types.ClusterReport, []types.WorkloadRecommendation, time.Time, time.Time, time.Time,
+	types.RequestID,
+) error {
+	return nil
 }

--- a/storage/queries.go
+++ b/storage/queries.go
@@ -31,3 +31,12 @@ func (storage OCPRecommendationsDBStorage) getReportInfoUpsertQuery() string {
 		DO UPDATE SET org_id = $1, version_info = $3
 	`
 }
+
+func (storage DVORecommendationsDBStorage) getReportUpsertQuery() string {
+	return `
+		INSERT INTO dvo.dvo_report(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (org_id, cluster_id, namespace_id)
+		DO UPDATE SET namespace_name = $4, report = $5, recommendations = $6, objects = $7, reported_at = $8, last_checked_at = $9
+	`
+}

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -31,7 +31,10 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
-const postgres = "postgres"
+const (
+	postgres                = "postgres"
+	unfulfilledExpectations = "there were unfulfilled expectations: %s"
+)
 
 // MustGetMockStorageWithExpects returns mock db storage
 // with a driver "github.com/DATA-DOG/go-sqlmock" which requires you to write expect
@@ -80,7 +83,7 @@ func MustCloseMockStorageWithExpects(
 	t *testing.T, mockStorage storage.OCPRecommendationsStorage, expects sqlmock.Sqlmock,
 ) {
 	if err := expects.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expectations: %s", err)
+		t.Errorf(unfulfilledExpectations, err)
 	}
 
 	expects.ExpectClose()
@@ -92,7 +95,7 @@ func MustCloseMockStorageWithExpectsDVO(
 	t *testing.T, mockStorage storage.DVORecommendationsStorage, expects sqlmock.Sqlmock,
 ) {
 	if err := expects.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expectations: %s", err)
+		t.Errorf(unfulfilledExpectations, err)
 	}
 
 	expects.ExpectClose()
@@ -104,7 +107,7 @@ func MustCloseMockDBWithExpects(
 	t *testing.T, db *sql.DB, expects sqlmock.Sqlmock,
 ) {
 	if err := expects.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expectations: %s", err)
+		t.Errorf(unfulfilledExpectations, err)
 	}
 
 	expects.ExpectClose()

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -54,6 +54,16 @@ func MustGetMockStorageWithExpectsForDriver(
 	return storage.NewOCPRecommendationsFromConnection(db, driverType), expects
 }
 
+// MustGetMockStorageWithExpectsForDriverDVO same as MustGetMockStorageWithExpectsForDriver
+// but for DVO
+func MustGetMockStorageWithExpectsForDriverDVO(
+	t *testing.T, driverType types.DBDriver,
+) (storage.DVORecommendationsStorage, sqlmock.Sqlmock) {
+	db, expects := MustGetMockDBWithExpects(t)
+
+	return storage.NewDVORecommendationsFromConnection(db, driverType), expects
+}
+
 // MustGetMockDBWithExpects returns mock db
 // with a driver "github.com/DATA-DOG/go-sqlmock" which requires you to write expect
 // before each query, so first try to use MustGetPostgresStorage
@@ -68,6 +78,18 @@ func MustGetMockDBWithExpects(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 // MustCloseMockStorageWithExpects closes mock storage with expects and panics if it wasn't successful
 func MustCloseMockStorageWithExpects(
 	t *testing.T, mockStorage storage.OCPRecommendationsStorage, expects sqlmock.Sqlmock,
+) {
+	if err := expects.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+
+	expects.ExpectClose()
+	helpers.FailOnError(t, mockStorage.Close())
+}
+
+// MustCloseMockStorageWithExpectsDVO same asMustCloseMockStorageWithExpects
+func MustCloseMockStorageWithExpectsDVO(
+	t *testing.T, mockStorage storage.DVORecommendationsStorage, expects sqlmock.Sqlmock,
 ) {
 	if err := expects.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)


### PR DESCRIPTION
# Description

This is the code for inserting the workload recommendations (DVO) into the `dvo.dvo_report` table.

Note that the message we receive is a JSON that relates recommendations with namespaces whereas in the DB we are storing namespaces and the number of recommendations each has. This made me use that for loop and create a map of namespaces so that we don't have to change the DB nor the dvo-extractor.

This is how the DB is populated:

```
org_id          INTEGER NOT NULL, -> same as OCP, we get it from the message
cluster_id      VARCHAR NOT NULL, -> same ^
namespace_id    VARCHAR NOT NULL, -> we get it from each workload under workload_recommendations
namespace_name  VARCHAR,          -> same as above, but can be missing
report          TEXT,             -> we store the complete report, even for the workloads from other namespaces
recommendations INTEGER NOT NULL, -> number of recommendations in the complete report
objects         INTEGER NOT NULL, -> number of workloads for this namespace
reported_at     TIMESTAMP,        -> TODO: I'm not sure what to put here
last_checked_at TIMESTAMP,        -> last time we received an archive
```

We need to revisit the `report` column once the feature is working as it's duplicated in each row for the same cluster.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Locally + CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
