### PR TITLE
[CCXDEV-12475[debug] Try to find the cause of a parse time error

### DIFF
--- a/consumer/dvo_processing.go
+++ b/consumer/dvo_processing.go
@@ -65,12 +65,14 @@ func (DVORulesProcessor) deserializeMessage(messageValue []byte) (incomingMessag
 // It should be the first method called within ProcessMessage in order
 // to convert the message into a struct that can be worked with
 func (DVORulesProcessor) parseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (incomingMessage, error) {
+	log.Debug().Bytes("msg", msg.Value).Msg("message before being deserialized")
 	message, err := consumer.MessageProcessor.deserializeMessage(msg.Value)
 	if err != nil {
 		consumer.logMsgForFurtherAnalysis(msg)
 		logUnparsedMessageError(consumer, msg, "Error parsing message from Kafka", err)
 		return message, err
 	}
+	log.Debug().Interface("msg", message).Msg("message deserialized")
 	consumer.updatePayloadTracker(message.RequestID, time.Now(), message.Organization, message.Account, producer.StatusReceived)
 
 	if err := consumer.MessageProcessor.shouldProcess(consumer, msg, &message); err != nil {
@@ -81,7 +83,7 @@ func (DVORulesProcessor) parseMessage(consumer *KafkaConsumer, msg *sarama.Consu
 		consumer.logReportStructureError(err, msg)
 		return message, err
 	}
-
+	log.Debug().Interface("msg", message).Msg("message with DVO content parsed")
 	return message, nil
 }
 

--- a/consumer/dvo_processing.go
+++ b/consumer/dvo_processing.go
@@ -29,6 +29,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const msgKey = "msg"
+
 // DVORulesProcessor satisfies MessageProcessor interface
 type DVORulesProcessor struct {
 }
@@ -65,14 +67,14 @@ func (DVORulesProcessor) deserializeMessage(messageValue []byte) (incomingMessag
 // It should be the first method called within ProcessMessage in order
 // to convert the message into a struct that can be worked with
 func (DVORulesProcessor) parseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (incomingMessage, error) {
-	log.Debug().Bytes("msg", msg.Value).Msg("message before being deserialized")
+	log.Debug().Bytes(msgKey, msg.Value).Msg("message before being deserialized")
 	message, err := consumer.MessageProcessor.deserializeMessage(msg.Value)
 	if err != nil {
 		consumer.logMsgForFurtherAnalysis(msg)
 		logUnparsedMessageError(consumer, msg, "Error parsing message from Kafka", err)
 		return message, err
 	}
-	log.Debug().Interface("msg", message).Msg("message deserialized")
+	log.Debug().Interface(msgKey, message).Msg("message deserialized")
 	consumer.updatePayloadTracker(message.RequestID, time.Now(), message.Organization, message.Account, producer.StatusReceived)
 
 	if err := consumer.MessageProcessor.shouldProcess(consumer, msg, &message); err != nil {
@@ -83,7 +85,7 @@ func (DVORulesProcessor) parseMessage(consumer *KafkaConsumer, msg *sarama.Consu
 		consumer.logReportStructureError(err, msg)
 		return message, err
 	}
-	log.Debug().Interface("msg", message).Msg("message with DVO content parsed")
+	log.Debug().Interface(msgKey, message).Msg("message with DVO content parsed")
 	return message, nil
 }
 

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -265,6 +265,7 @@ func (consumer *KafkaConsumer) logReportStructureError(err error, msg *sarama.Co
 }
 
 func (consumer *KafkaConsumer) retrieveLastCheckedTime(msg *sarama.ConsumerMessage, parsedMsg *incomingMessage) (time.Time, error) {
+	log.Debug().Str("lastCheckedTime", parsedMsg.LastChecked).Msg("Retrieving last checked time")
 	lastCheckedTime, err := time.Parse(time.RFC3339Nano, parsedMsg.LastChecked)
 	if err != nil {
 		logMessageError(consumer, msg, parsedMsg, "Error parsing date from message", err)


### PR DESCRIPTION
# Description

We are constantly seeing an error like

```
{"level":"error","error":"parsing time \"\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \"\" as \"2006\"","time":"2024-02-13T08:20:02Z","message":"Problem while handling the message"}
```

on stage. It looks like the incoming message is wrongly constructed or we are not deserializing it the right way. Let's add some debug logging so that we can find the cause.

## Type of change

Just debugging

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
