### PR TITLE
Revert "[CCXDEV-12475[debug] Try to find the cause of a parse time error"

### DIFF
--- a/consumer/dvo_processing.go
+++ b/consumer/dvo_processing.go
@@ -29,8 +29,6 @@ import (
 	"github.com/google/uuid"
 )
 
-const msgKey = "msg"
-
 // DVORulesProcessor satisfies MessageProcessor interface
 type DVORulesProcessor struct {
 }
@@ -67,14 +65,12 @@ func (DVORulesProcessor) deserializeMessage(messageValue []byte) (incomingMessag
 // It should be the first method called within ProcessMessage in order
 // to convert the message into a struct that can be worked with
 func (DVORulesProcessor) parseMessage(consumer *KafkaConsumer, msg *sarama.ConsumerMessage) (incomingMessage, error) {
-	log.Debug().Bytes(msgKey, msg.Value).Msg("message before being deserialized")
 	message, err := consumer.MessageProcessor.deserializeMessage(msg.Value)
 	if err != nil {
 		consumer.logMsgForFurtherAnalysis(msg)
 		logUnparsedMessageError(consumer, msg, "Error parsing message from Kafka", err)
 		return message, err
 	}
-	log.Debug().Interface(msgKey, message).Msg("message deserialized")
 	consumer.updatePayloadTracker(message.RequestID, time.Now(), message.Organization, message.Account, producer.StatusReceived)
 
 	if err := consumer.MessageProcessor.shouldProcess(consumer, msg, &message); err != nil {
@@ -85,7 +81,7 @@ func (DVORulesProcessor) parseMessage(consumer *KafkaConsumer, msg *sarama.Consu
 		consumer.logReportStructureError(err, msg)
 		return message, err
 	}
-	log.Debug().Interface(msgKey, message).Msg("message with DVO content parsed")
+
 	return message, nil
 }
 

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -265,7 +265,6 @@ func (consumer *KafkaConsumer) logReportStructureError(err error, msg *sarama.Co
 }
 
 func (consumer *KafkaConsumer) retrieveLastCheckedTime(msg *sarama.ConsumerMessage, parsedMsg *incomingMessage) (time.Time, error) {
-	log.Debug().Str("lastCheckedTime", parsedMsg.LastChecked).Msg("Retrieving last checked time")
 	lastCheckedTime, err := time.Parse(time.RFC3339Nano, parsedMsg.LastChecked)
 	if err != nil {
 		logMessageError(consumer, msg, parsedMsg, "Error parsing date from message", err)


### PR DESCRIPTION
Reverts RedHatInsights/insights-results-aggregator#1956 because we already found the issue.