### PR TITLE
[CCXDEV-12388] Use prod ref env for dvo-writer

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -20,9 +20,7 @@ set -exv
 # Options that must be configured by app owner
 # --------------------------------------------
 APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
-# TODO set it to "insights-stage" once we have dvo-writer/dvo-extractor stage deploy config
-# TODO set it back to "insights-production" once we have dvo deployed to prod
-REF_ENV="insights-stage"
+REF_ENV="insights-production"
 # NOTE: insights-results-aggregator contains deployment for multiple services
 #       for pull requests we need latest git PR version of these components to be
 #       deployed to ephemeral env and overriding resource template --set-template-ref.


### PR DESCRIPTION
# Description

Use prod ref env for dvo-writer as it's already working in prod.

## Type of change

- Configuration update

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
