### PR TITLE
Support for multiple broker addresses

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,7 +33,7 @@ jobs:
             --timeout=3m
           
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 
           # Optional: if set to true then the action will use pre-installed Go.
           # skip-go-installation: true

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -207,8 +207,8 @@ func TestStartConsumer_BadBrokerAddress(t *testing.T) {
 		"INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__TYPE":      "sql",
 		"INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE":                   "ocp_recommendations",
 
-		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS": "non-existing-host:999999",
-		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ENABLED": "true",
+		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESSES": "non-existing-host:999999",
+		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ENABLED":   "true",
 	})
 
 	err := main.StartConsumer(conf.GetBrokerConfiguration())
@@ -259,8 +259,8 @@ func TestStartService_BadBrokerAndServerAddress(t *testing.T) {
 	os.Clearenv()
 	mustLoadConfiguration("./tests/tests")
 	setEnvSettings(t, map[string]string{
-		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS": "non-existing-host:1",
-		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ENABLED": "true",
+		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESSES": "non-existing-host:1",
+		"INSIGHTS_RESULTS_AGGREGATOR__BROKER__ENABLED":   "true",
 
 		"INSIGHTS_RESULTS_AGGREGATOR__SERVER__ADDRESS":       "non-existing-host:1",
 		"INSIGHTS_RESULTS_AGGREGATOR__SERVER__API_SPEC_FILE": "openapi.json",

--- a/broker/configuration.go
+++ b/broker/configuration.go
@@ -31,7 +31,7 @@ import (
 
 // Configuration represents configuration of Kafka broker
 type Configuration struct {
-	Address                          string        `mapstructure:"address" toml:"address"`
+	Addresses                        string        `mapstructure:"addresses" toml:"addresses"`
 	SecurityProtocol                 string        `mapstructure:"security_protocol" toml:"security_protocol"`
 	CertPath                         string        `mapstructure:"cert_path" toml:"cert_path"`
 	SaslMechanism                    string        `mapstructure:"sasl_mechanism" toml:"sasl_mechanism"`

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -55,7 +55,7 @@ func removeFile(t *testing.T, filename string) {
 func setEnvVariables(t *testing.T) {
 	os.Clearenv()
 
-	mustSetEnv(t, "INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS", "localhost:9093")
+	mustSetEnv(t, "INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESSES", "localhost:9093")
 	mustSetEnv(t, "INSIGHTS_RESULTS_AGGREGATOR__BROKER__TOPIC", "platform.results.ccx")
 	mustSetEnv(t, "INSIGHTS_RESULTS_AGGREGATOR__BROKER__GROUP", "aggregator")
 	mustSetEnv(t, "INSIGHTS_RESULTS_AGGREGATOR__BROKER__ENABLED", "true")
@@ -152,7 +152,7 @@ func TestLoadBrokerConfiguration(t *testing.T) {
 
 	brokerCfg := conf.GetBrokerConfiguration()
 
-	assert.Equal(t, "localhost:29092", brokerCfg.Address)
+	assert.Equal(t, "localhost:29092", brokerCfg.Addresses)
 	assert.Equal(t, "platform.results.ccx", brokerCfg.Topic)
 	assert.Equal(t, "aggregator", brokerCfg.Group)
 	assert.Equal(t, expectedTimeout, brokerCfg.Timeout)
@@ -350,7 +350,7 @@ str
 
 func TestLoadConfigurationFromFile(t *testing.T) {
 	config := `[broker]
-		address = "localhost:29092"
+		Addresses = "localhost:29092"
 		topic = "platform.results.ccx"
 		group = "aggregator"
 		enabled = true
@@ -360,7 +360,7 @@ func TestLoadConfigurationFromFile(t *testing.T) {
 		org_allowlist_file = "org_allowlist.csv"
 
 		[server]
-		address = ":8080"
+		Addresses = ":8080"
 		api_prefix = "/api/v1/"
 		api_spec_file = "openapi.json"
 		debug = true
@@ -398,7 +398,7 @@ func TestLoadConfigurationFromFile(t *testing.T) {
 
 	brokerCfg := conf.GetBrokerConfiguration()
 
-	assert.Equal(t, "localhost:29092", brokerCfg.Address)
+	assert.Equal(t, "localhost:29092", brokerCfg.Addresses)
 	assert.Equal(t, "platform.results.ccx", brokerCfg.Topic)
 	assert.Equal(t, "aggregator", brokerCfg.Group)
 	assert.Equal(t, true, brokerCfg.Enabled)
@@ -460,7 +460,7 @@ func TestLoadConfigurationFromEnv(t *testing.T) {
 
 	brokerCfg := conf.GetBrokerConfiguration()
 
-	assert.Equal(t, "localhost:9093", brokerCfg.Address)
+	assert.Equal(t, "localhost:9093", brokerCfg.Addresses)
 	assert.Equal(t, "platform.results.ccx", brokerCfg.Topic)
 	assert.Equal(t, "aggregator", brokerCfg.Group)
 	assert.Equal(t, true, brokerCfg.Enabled)
@@ -595,7 +595,7 @@ func TestLoadConfigurationFromEnvVariableClowderEnabled(t *testing.T) {
 	storageCfg := conf.GetOCPRecommendationsStorageConfiguration()
 
 	// check
-	assert.Equal(t, "localhost:29092", brokerCfg.Address, "Broker doesn't match")
+	assert.Equal(t, "localhost:29092", brokerCfg.Addresses, "Broker doesn't match")
 	assert.Equal(t, "platform.results.ccx", brokerCfg.Topic, "Topic doesn't match")
 	assert.Equal(t, testDB, storageCfg.PGDBName)
 }
@@ -638,7 +638,7 @@ func TestClowderConfigForKafka(t *testing.T) {
 	conf.Config.Broker.OrgAllowlistEnabled = false
 
 	brokerCfg := conf.GetBrokerConfiguration()
-	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
+	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Addresses)
 	assert.Equal(t, newTopicName, conf.Config.Broker.Topic)
 }
 

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -1,5 +1,5 @@
 [broker]
-address = "kafka:29092"
+addresses = "kafka:29092"
 security_protocol = ""
 sasl_mechanism = "PLAIN"
 sasl_username = "username"

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 [broker]
-address = "localhost:29092"
+addresses = "localhost:29092"
 security_protocol = ""
 sasl_mechanism = "PLAIN"
 sasl_username = "username"

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -56,9 +56,9 @@ const (
 var (
 	testOrgAllowlist = mapset.NewSetWith(types.OrgID(1))
 	wrongBrokerCfg   = broker.Configuration{
-		Address: "localhost:1234",
-		Topic:   "topic",
-		Group:   "group",
+		Addresses: "localhost:1234",
+		Topic:     "topic",
+		Group:     "group",
 	}
 	messageReportWithRuleHits = `{
 		"OrgID": ` + fmt.Sprint(testdata.OrgID) + `,
@@ -159,9 +159,9 @@ func TestKafkaConsumer_New(t *testing.T) {
 		mockBroker.SetHandlerByMap(ira_helpers.GetHandlersMapForMockConsumer(t, mockBroker, testTopicName))
 
 		mockConsumer, err := consumer.NewKafkaConsumer(broker.Configuration{
-			Address: mockBroker.Addr(),
-			Topic:   testTopicName,
-			Enabled: true,
+			Addresses: mockBroker.Addr(),
+			Topic:     testTopicName,
+			Enabled:   true,
 		}, mockStorage, nil)
 		helpers.FailOnError(t, err)
 
@@ -180,9 +180,9 @@ func TestKafkaConsumer_SetupCleanup(t *testing.T) {
 	mockBroker.SetHandlerByMap(ira_helpers.GetHandlersMapForMockConsumer(t, mockBroker, testTopicName))
 
 	mockConsumer, err := consumer.NewKafkaConsumer(broker.Configuration{
-		Address: mockBroker.Addr(),
-		Topic:   testTopicName,
-		Enabled: true,
+		Addresses: mockBroker.Addr(),
+		Topic:     testTopicName,
+		Enabled:   true,
 	}, mockStorage, nil)
 	helpers.FailOnError(t, err)
 
@@ -206,11 +206,11 @@ func TestKafkaConsumer_NewDeadLetterProducer_Error(t *testing.T) {
 	}()
 
 	// Override functions for testing
-	producer.NewDeadLetterProducer = func(brokerCfg broker.Configuration) (*producer.DeadLetterProducer, error) {
+	producer.NewDeadLetterProducer = func(_ broker.Configuration) (*producer.DeadLetterProducer, error) {
 		return nil, errors.New("error happened")
 	}
 
-	producer.NewPayloadTrackerProducer = func(brokerCfg broker.Configuration) (*producer.PayloadTrackerProducer, error) {
+	producer.NewPayloadTrackerProducer = func(_ broker.Configuration) (*producer.PayloadTrackerProducer, error) {
 		return nil, nil
 	}
 
@@ -223,9 +223,9 @@ func TestKafkaConsumer_NewDeadLetterProducer_Error(t *testing.T) {
 	mockBroker.SetHandlerByMap(ira_helpers.GetHandlersMapForMockConsumer(t, mockBroker, testTopicName))
 
 	_, err := consumer.NewKafkaConsumer(broker.Configuration{
-		Address: mockBroker.Addr(),
-		Topic:   testTopicName,
-		Enabled: true,
+		Addresses: mockBroker.Addr(),
+		Topic:     testTopicName,
+		Enabled:   true,
 	}, mockStorage, nil)
 
 	assert.EqualError(t, err, "error happened")
@@ -241,11 +241,11 @@ func TestKafkaConsumer_NewPayloadTrackerProducer_Error(t *testing.T) {
 	}()
 
 	// Override functions for testing
-	producer.NewDeadLetterProducer = func(brokerCfg broker.Configuration) (*producer.DeadLetterProducer, error) {
+	producer.NewDeadLetterProducer = func(_ broker.Configuration) (*producer.DeadLetterProducer, error) {
 		return nil, nil
 	}
 
-	producer.NewPayloadTrackerProducer = func(brokerCfg broker.Configuration) (*producer.PayloadTrackerProducer, error) {
+	producer.NewPayloadTrackerProducer = func(_ broker.Configuration) (*producer.PayloadTrackerProducer, error) {
 		return nil, errors.New("error happened")
 	}
 
@@ -258,9 +258,9 @@ func TestKafkaConsumer_NewPayloadTrackerProducer_Error(t *testing.T) {
 	mockBroker.SetHandlerByMap(ira_helpers.GetHandlersMapForMockConsumer(t, mockBroker, testTopicName))
 
 	_, err := consumer.NewKafkaConsumer(broker.Configuration{
-		Address: mockBroker.Addr(),
-		Topic:   testTopicName,
-		Enabled: true,
+		Addresses: mockBroker.Addr(),
+		Topic:     testTopicName,
+		Enabled:   true,
 	}, mockStorage, nil)
 
 	assert.EqualError(t, err, "error happened")

--- a/consumer/dvo_rules_consumer_test.go
+++ b/consumer/dvo_rules_consumer_test.go
@@ -59,9 +59,9 @@ func createDVOConsumer(brokerCfg broker.Configuration, mockStorage storage.DVORe
 
 func dummyDVOConsumer(s storage.DVORecommendationsStorage, allowlist bool) consumer.Consumer {
 	brokerCfg := broker.Configuration{
-		Address: "localhost:1234",
-		Topic:   "topic",
-		Group:   "group",
+		Addresses: "localhost:1234",
+		Topic:     "topic",
+		Group:     "group",
 	}
 	if allowlist {
 		brokerCfg.OrgAllowlist = mapset.NewSetWith(types.OrgID(1))
@@ -85,9 +85,9 @@ func TestDVORulesConsumer_New(t *testing.T) {
 		mockBroker.SetHandlerByMap(ira_helpers.GetHandlersMapForMockConsumer(t, mockBroker, testTopicName))
 
 		mockConsumer, err := consumer.NewDVORulesConsumer(broker.Configuration{
-			Address: mockBroker.Addr(),
-			Topic:   testTopicName,
-			Enabled: true,
+			Addresses: mockBroker.Addr(),
+			Topic:     testTopicName,
+			Enabled:   true,
 		}, mockStorage)
 		helpers.FailOnError(t, err)
 

--- a/consumer/kafka_consumer.go
+++ b/consumer/kafka_consumer.go
@@ -32,6 +32,7 @@ package consumer
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Shopify/sarama"
 	"github.com/rs/zerolog/log"
@@ -98,11 +99,11 @@ func NewKafkaConsumerWithSaramaConfig(
 	}
 
 	log.Info().
-		Str("addr", brokerCfg.Address).
+		Str("addresses", brokerCfg.Addresses).
 		Str("group", brokerCfg.Group).
 		Msg("New consumer group")
 
-	consumerGroup, err := sarama.NewConsumerGroup([]string{brokerCfg.Address}, brokerCfg.Group, saramaConfig)
+	consumerGroup, err := sarama.NewConsumerGroup(strings.Split(brokerCfg.Addresses, ","), brokerCfg.Group, saramaConfig)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to create consumer group")
 		return nil, err

--- a/consumer/ocp_rules_consumer_test.go
+++ b/consumer/ocp_rules_consumer_test.go
@@ -63,9 +63,9 @@ func createOCPConsumer(brokerCfg broker.Configuration, mockStorage storage.OCPRe
 
 func dummyOCPConsumer(s storage.OCPRecommendationsStorage, allowlist bool) consumer.Consumer {
 	brokerCfg := broker.Configuration{
-		Address: "localhost:1234",
-		Topic:   "topic",
-		Group:   "group",
+		Addresses: "localhost:1234",
+		Topic:     "topic",
+		Group:     "group",
 	}
 	if allowlist {
 		brokerCfg.OrgAllowlist = mapset.NewSetWith(types.OrgID(1))
@@ -89,9 +89,9 @@ func TestOCPRulesConsumer_New(t *testing.T) {
 		mockBroker.SetHandlerByMap(ira_helpers.GetHandlersMapForMockConsumer(t, mockBroker, testTopicName))
 
 		mockConsumer, err := consumer.NewOCPRulesConsumer(broker.Configuration{
-			Address: mockBroker.Addr(),
-			Topic:   testTopicName,
-			Enabled: true,
+			Addresses: mockBroker.Addr(),
+			Topic:     testTopicName,
+			Enabled:   true,
 		}, mockStorage)
 		helpers.FailOnError(t, err)
 
@@ -736,7 +736,7 @@ func TestKafkaConsumer_ProcessMessageWithEmptyReport_OrganizationIsNotAllowed(t 
 	defer closer()
 
 	brokerCfg := broker.Configuration{
-		Address:             "localhost:1234",
+		Addresses:           "localhost:1234",
 		Topic:               "topic",
 		Group:               "group",
 		OrgAllowlist:        mapset.NewSetWith(types.OrgID(123)), // in testdata, OrgID = 1
@@ -753,7 +753,7 @@ func TestKafkaConsumer_ProcessMessage_OrganizationIsNotAllowed(t *testing.T) {
 	defer closer()
 
 	brokerCfg := broker.Configuration{
-		Address:             "localhost:1234",
+		Addresses:           "localhost:1234",
 		Topic:               "topic",
 		Group:               "group",
 		OrgAllowlist:        mapset.NewSetWith(types.OrgID(123)), // in testdata, OrgID = 1
@@ -770,7 +770,7 @@ func TestKafkaConsumer_ProcessMessageWithEmptyReport_OrganizationBadConfigIsNotA
 	defer closer()
 
 	brokerCfg := broker.Configuration{
-		Address:             "localhost:1234",
+		Addresses:           "localhost:1234",
 		Topic:               "topic",
 		Group:               "group",
 		OrgAllowlist:        nil,
@@ -787,7 +787,7 @@ func TestKafkaConsumer_ProcessMessage_OrganizationBadConfigIsNotAllowed(t *testi
 	defer closer()
 
 	brokerCfg := broker.Configuration{
-		Address:             "localhost:1234",
+		Addresses:           "localhost:1234",
 		Topic:               "topic",
 		Group:               "group",
 		OrgAllowlist:        nil,

--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -41,7 +41,7 @@ objects:
             enabled: true
         podSpec:
           env:
-            - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS
+            - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESSES
               value: "${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__TIMEOUT
               value: "${KAFKA_TIMEOUT}"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -117,7 +117,7 @@ objects:
           env:
             - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE
               value: "ocp_recommendations"
-            - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS
+            - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESSES
               value: "${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__TIMEOUT
               value: "${KAFKA_TIMEOUT}"

--- a/deploy/dvo-writer.yaml
+++ b/deploy/dvo-writer.yaml
@@ -127,7 +127,7 @@ objects:
           env:
             - name: INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE
               value: "dvo_recommendations"
-            - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS
+            - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESSES
               value: "${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}"
             - name: INSIGHTS_RESULTS_AGGREGATOR__BROKER__TIMEOUT
               value: "${KAFKA_TIMEOUT}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ Broker configuration is in section `[broker]` in config file
 
 ```toml
 [broker]
-address = "localhost:9092"
+addresses = "localhost:9092"
 security_protocol = ""
 cert_path = ""
 sasl_mechanism = ""
@@ -74,7 +74,7 @@ org_allowlist_file = ""
 enable_org_allowlist = false
 ```
 
-* `address` is an address of kafka broker (DEFAULT: "")
+* `addresses` is a comma separated list of addresses of Kafka brokers; e.g kafka:9093,localhost:9092,kafka_2:9092
 * `security_protocol` is a value for the `security.protocol` Kafka configuration. Defaults to ""
 * `cert_path` is a path to a file containing an SSL certificate, only used if `secutiy_protocol` is properly set to `SSL`
 * `sasl_mechanism` is the SASL authentication mechanism to use when `SASL_SSL` is set as `security_protocol`
@@ -95,7 +95,7 @@ consuming will be started from the most recent message (DEFAULT: false)
 
 Option names in env configuration:
 
-* `address` - INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESS
+* `addresses` - INSIGHTS_RESULTS_AGGREGATOR__BROKER__ADDRESSES
 * `security_protocol` - INSIGHTS_RESULTS_AGGREGATOR__BROKER__SECURITY_PROTOCOL
 * `cert_path` - INSIGHTS_RESULTS_AGGREGATOR__BROKER__CERT_PATH
 * `sasl_mechanism` - INSIGHTS_RESULTS_AGGREGATOR__BROKER__SASL_MECHANISM

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -80,7 +80,7 @@ func TestConsumedOCPMessagesMetric(t *testing.T) {
 
 func TestProducedMessagesMetric(t *testing.T) {
 	brokerCfg := broker.Configuration{
-		Address:             "localhost:1234",
+		Addresses:           "localhost:1234",
 		Topic:               "consumer-topic",
 		PayloadTrackerTopic: "payload-tracker-topic",
 		Group:               "test-group",

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -19,6 +19,8 @@ limitations under the License.
 package producer
 
 import (
+	"strings"
+
 	"github.com/Shopify/sarama"
 	"github.com/rs/zerolog/log"
 
@@ -57,7 +59,7 @@ func New(brokerCfg broker.Configuration) (*KafkaProducer, error) {
 	// needed producer parameter
 	saramaConfig.Producer.Return.Successes = true
 
-	producer, err := sarama.NewSyncProducer([]string{brokerCfg.Address}, saramaConfig)
+	producer, err := sarama.NewSyncProducer(strings.Split(brokerCfg.Addresses, ","), saramaConfig)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to create a new Kafka producer")
 		return nil, err

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -31,12 +31,11 @@ import (
 	"github.com/RedHatInsights/insights-results-aggregator/broker"
 	"github.com/RedHatInsights/insights-results-aggregator/producer"
 	ira_helpers "github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
-	"github.com/RedHatInsights/insights-results-aggregator/types"
 )
 
 var (
 	brokerCfg = broker.Configuration{
-		Address:              "localhost:1234",
+		Addresses:            "localhost:1234",
 		Topic:                "consumer-topic",
 		PayloadTrackerTopic:  "payload-tracker-topic",
 		DeadLetterQueueTopic: "dlq-topic",
@@ -50,7 +49,7 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
 }
 
-// Test Producer creation with a non accessible Kafka broker
+// Test Producer creation with a non-accessible Kafka broker
 func TestNewProducerBadBroker(t *testing.T) {
 	const expectedErr = "kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"
 
@@ -89,7 +88,7 @@ func TestProducerTrackPayloadEmptyRequestID(t *testing.T) {
 		helpers.FailOnError(t, payloadTrackerProducer.Close())
 	}()
 
-	err := payloadTrackerProducer.TrackPayload(types.RequestID(""), testTimestamp, nil, nil, producer.StatusReceived)
+	err := payloadTrackerProducer.TrackPayload("", testTimestamp, nil, nil, producer.StatusReceived)
 	assert.NoError(t, err, "payload tracking failed")
 }
 
@@ -133,7 +132,7 @@ func TestProducerNew(t *testing.T) {
 
 	prod, err := producer.New(
 		broker.Configuration{
-			Address:             mockBroker.Addr(),
+			Addresses:           mockBroker.Addr(),
 			Topic:               brokerCfg.Topic,
 			PayloadTrackerTopic: brokerCfg.PayloadTrackerTopic,
 			Enabled:             brokerCfg.Enabled,
@@ -152,7 +151,7 @@ func TestDeadLetterProducerNew(t *testing.T) {
 
 	prod, err := producer.NewDeadLetterProducer(
 		broker.Configuration{
-			Address:              mockBroker.Addr(),
+			Addresses:            mockBroker.Addr(),
 			Topic:                brokerCfg.Topic,
 			PayloadTrackerTopic:  brokerCfg.PayloadTrackerTopic,
 			Enabled:              brokerCfg.Enabled,
@@ -172,7 +171,7 @@ func TestPayloadTrackerProducerNew(t *testing.T) {
 
 	prod, err := producer.NewPayloadTrackerProducer(
 		broker.Configuration{
-			Address:             mockBroker.Addr(),
+			Addresses:           mockBroker.Addr(),
 			Topic:               brokerCfg.Topic,
 			PayloadTrackerTopic: brokerCfg.PayloadTrackerTopic,
 			Enabled:             brokerCfg.Enabled,

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -1,5 +1,5 @@
 [broker]
-address = "localhost:29092"
+addresses = "localhost:29092"
 topic = "platform.results.ccx"
 group = "aggregator"
 enabled = false

--- a/tests/helpers/mock_consumer.go
+++ b/tests/helpers/mock_consumer.go
@@ -80,7 +80,7 @@ func GetMockOCPRulesConsumerWithExpectedMessages(
 	mockConsumer := &MockKafkaConsumer{
 		KafkaConsumer: consumer.KafkaConsumer{
 			Configuration: broker.Configuration{
-				Address:      "",
+				Addresses:    "",
 				Topic:        topic,
 				Group:        "",
 				Enabled:      true,

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1,5 +1,5 @@
 [broker]
-address = "localhost:29093"
+addresses = "localhost:29093"
 topic = "ccx.ocp.results"
 group = "aggregator"
 enabled = false


### PR DESCRIPTION
# Description

This is the simplest change required to support multiple broker addresses (without refactoring common code out of the service and so on).

Now the configuration of the Kafka Broker expects the field `addresses` instead of `address`, and said field is a comma-separated list of broker addresses. For example: `kafka:9092,kafka:9093,localhost:29092`. The list does not have a minimum or maximum number of addresses, so it can be used as before with only one address: `kafka:29092`.

Unrelated to PR, I enabled an option in golangci-lint so it only fails if new issues are detected (if not, CI wouldn't pass)

Fixes CCXDEV-12462

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)
- Documentation update
- Configuration update

## Testing steps

- UTs
- BDDs

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
