### PR TITLE
Update cache-writer.yaml with a valid log stream

### DIFF
--- a/deploy/cache-writer.yaml
+++ b/deploy/cache-writer.yaml
@@ -636,7 +636,7 @@ parameters:
   value: "true"
   required: true
 - name: CW_LOG_STREAM
-  value: $HOSTNAME
+  value: "cache-writer"
 - name: CREATE_STREAM_IF_NOT_EXISTS
   value: "true"
 - name: CACHE_WRITER_CPU_LIMIT


### PR DESCRIPTION
# Description

The "$HOSTNAME" is never populated thus we cannot see the cache-writer logs in Kibana.

## Type of change

- Configuration update

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
