### PR TITLE
[CCXDEV-12529][dvo-writer] Use DELETE -> INSERT instead of upsert

### DIFF
--- a/consumer/dvo_rules_consumer_test.go
+++ b/consumer/dvo_rules_consumer_test.go
@@ -446,3 +446,24 @@ func TestProcessingDVOMessageWithWrongDateFormatReportNotEmpty(t *testing.T) {
 		))
 	}
 }
+
+func TestDVOKafkaConsumerMockOK(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(t testing.TB) {
+		mockConsumer, closer := ira_helpers.MustGetMockDVOConsumerWithExpectedMessages(
+			t,
+			testTopicName,
+			testOrgAllowlist,
+			[]string{messageReportWithDVOHits},
+		)
+
+		go mockConsumer.Serve()
+
+		// wait for message processing
+		ira_helpers.WaitForMockConsumerToHaveNConsumedMessages(mockConsumer, 1)
+
+		closer()
+
+		assert.Equal(t, uint64(1), mockConsumer.KafkaConsumer.GetNumberOfSuccessfullyConsumedMessages())
+		assert.Equal(t, uint64(0), mockConsumer.KafkaConsumer.GetNumberOfErrorsConsumingMessages())
+	}, testCaseTimeLimit)
+}

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -45,7 +45,7 @@ type DVORecommendationsStorage interface {
 		clusterName types.ClusterName,
 		report types.ClusterReport,
 		workloads []types.WorkloadRecommendation,
-		collectedAtTime time.Time,
+		lastCheckedTime time.Time,
 		gatheredAtTime time.Time,
 		storedAtTime time.Time,
 		requestID types.RequestID,
@@ -307,6 +307,13 @@ func (storage DVORecommendationsDBStorage) updateReport(
 	}
 
 	namespaceMap, objectsMap, nRecommendations := mapWorkloadRecommendations(&recommendations)
+
+	// Delete previous reports (CCXDEV-12529)
+	_, err = tx.Exec("DELETE FROM dvo.dvo_report WHERE org_id = $1 AND cluster_id = $2;", orgID, clusterName)
+	if err != nil {
+		log.Err(err).Msgf("Unable to remove previous cluster DVO reports (org: %v, cluster: %v)", orgID, clusterName)
+		return err
+	}
 
 	// Get the INSERT statement for writing a workload into the database.
 	workloadInsertStatement := storage.getReportUpsertQuery()

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -316,7 +316,7 @@ func (storage DVORecommendationsDBStorage) updateReport(
 	}
 
 	// Get the INSERT statement for writing a workload into the database.
-	workloadInsertStatement := storage.getReportUpsertQuery()
+	workloadInsertStatement := storage.getReportInsertQuery()
 
 	// Get values to be stored in dvo.dvo_report table
 	values := make([]interface{}, 9)

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -50,6 +50,7 @@ type DVORecommendationsStorage interface {
 		storedAtTime time.Time,
 		requestID types.RequestID,
 	) error
+	DeleteReportsForOrg(orgID types.OrgID) error
 }
 
 // dvoDBSchema represents the name of the DB schema used by DVO-related queries/migrations
@@ -401,4 +402,10 @@ func (storage DVORecommendationsDBStorage) getReportedAtMap(orgID types.OrgID, c
 		reportedAtMap[namespaceID] = types.Timestamp(reportedAt.UTC().Format(time.RFC3339))
 	}
 	return reportedAtMap, err
+}
+
+// DeleteReportsForOrg deletes all reports related to the specified organization from the storage.
+func (storage DVORecommendationsDBStorage) DeleteReportsForOrg(orgID types.OrgID) error {
+	_, err := storage.connection.Exec("DELETE FROM dvo.dvo_report WHERE org_id = $1;", orgID)
+	return err
 }

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"database/sql"
 	"database/sql/driver"
 
 	"github.com/rs/zerolog"
@@ -35,6 +36,24 @@ import (
 )
 
 var (
+	now             = time.Now().UTC()
+	nowAfterOneHour = now.Add(1 * time.Hour).UTC()
+	dummyTime       = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	namespaceAWorkload = types.DVOWorkload{
+		Namespace:    "namespace-name-A",
+		NamespaceUID: "NAMESPACE-UID-A",
+		Kind:         "DaemonSet",
+		Name:         "test-name-0099",
+		UID:          "UID-0099",
+	}
+	namespaceBWorkload = types.DVOWorkload{
+		Namespace:    "namespace-name-B",
+		NamespaceUID: "NAMESPACE-UID-B",
+		Kind:         "NotDaemonSet",
+		Name:         "test-name-1199",
+		UID:          "UID-1199",
+	}
 	validDVORecommendation = []types.WorkloadRecommendation{
 		{
 			ResponseID: "an_issue|DVO_AN_ISSUE",
@@ -44,20 +63,27 @@ var (
 				Jira:                 []string{"https://issues.redhat.com/browse/AN_ISSUE"},
 				ProductDocumentation: []string{},
 			},
-			Details: types.DVODetails{CheckName: "", CheckURL: ""},
-			Tags:    []string{},
-			Workloads: []types.DVOWorkload{
-				{
-					Namespace:    "namespace-name-A",
-					NamespaceUID: "NAMESPACE-UID-A",
-					Kind:         "DaemonSet",
-					Name:         "test-name-0099",
-					UID:          "UID-0099",
-				},
-			},
+			Details:   types.DVODetails{CheckName: "", CheckURL: ""},
+			Tags:      []string{},
+			Workloads: []types.DVOWorkload{namespaceAWorkload},
 		},
 	}
 	validReport = `{"system":{"metadata":{},"hostname":null},"fingerprints":[],"version":1,"analysis_metadata":{},"workload_recommendations":[{"response_id":"an_issue|DVO_AN_ISSUE","component":"ccx_rules_ocp.external.dvo.an_issue_pod.recommendation","key":"DVO_AN_ISSUE","details":{},"tags":[],"links":{"jira":["https://issues.redhat.com/browse/AN_ISSUE"],"product_documentation":[]},"workloads":[{"namespace":"namespace-name-A","namespace_uid":"NAMESPACE-UID-A","kind":"DaemonSet","name":"test-name-0099","uid":"UID-0099"}]}]}`
+
+	twoNamespacesRecommendation = []types.WorkloadRecommendation{
+		{
+			ResponseID: "an_issue|DVO_AN_ISSUE",
+			Component:  "ccx_rules_ocp.external.dvo.an_issue_pod.recommendation",
+			Key:        "DVO_AN_ISSUE",
+			Links: types.DVOLinks{
+				Jira:                 []string{"https://issues.redhat.com/browse/AN_ISSUE"},
+				ProductDocumentation: []string{},
+			},
+			Details:   types.DVODetails{CheckName: "", CheckURL: ""},
+			Tags:      []string{},
+			Workloads: []types.DVOWorkload{namespaceAWorkload, namespaceBWorkload},
+		},
+	}
 )
 
 func init() {
@@ -141,9 +167,9 @@ func TestDVOStorageWriteReportForClusterClosedStorage(t *testing.T) {
 		testdata.ClusterName,
 		testdata.ClusterReportEmpty,
 		validDVORecommendation,
-		time.Now(),
-		time.Now(),
-		time.Now(),
+		now,
+		dummyTime,
+		dummyTime,
 		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "sql: database is closed")
@@ -159,9 +185,9 @@ func TestDVOStorageWriteReportForClusterUnsupportedDriverError(t *testing.T) {
 		testdata.ClusterName,
 		testdata.ClusterReportEmpty,
 		validDVORecommendation,
-		time.Now(),
-		time.Now(),
-		time.Now(),
+		now,
+		dummyTime,
+		dummyTime,
 		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "writing workloads with DB -1 is not supported")
@@ -173,7 +199,7 @@ func TestDVOStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
 
-	newerTime := time.Now().UTC()
+	newerTime := now.UTC()
 	olderTime := newerTime.Add(-time.Hour)
 
 	// Insert newer report.
@@ -183,8 +209,8 @@ func TestDVOStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 		testdata.ClusterReportEmpty,
 		validDVORecommendation,
 		newerTime,
-		time.Now(),
-		time.Now(),
+		dummyTime,
+		dummyTime,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
@@ -196,8 +222,8 @@ func TestDVOStorageWriteReportForClusterMoreRecentInDB(t *testing.T) {
 		testdata.ClusterReportEmpty,
 		validDVORecommendation,
 		olderTime,
-		time.Now(),
-		time.Now(),
+		now,
+		now,
 		testdata.RequestID1,
 	)
 	assert.Equal(t, types.ErrOldReport, err)
@@ -218,7 +244,7 @@ func TestDVOStorageWriteReportForClusterDroppedReportTable(t *testing.T) {
 
 	err = mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, testdata.ClusterReportEmpty,
-		validDVORecommendation, time.Now(), time.Now(), time.Now(),
+		validDVORecommendation, now, now, now,
 		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "no such table: dvo.dvo_report")
@@ -234,6 +260,9 @@ func TestDVOStorageWriteReportForClusterFakePostgresOK(t *testing.T) {
 		WillReturnRows(expects.NewRows([]string{"last_checked_at"})).
 		RowsWillBeClosed()
 
+	expects.ExpectExec("DELETE FROM dvo.dvo_report").
+		WillReturnResult(driver.ResultNoRows)
+
 	expects.ExpectExec("INSERT INTO dvo.dvo_report").
 		WillReturnResult(driver.ResultNoRows)
 
@@ -243,7 +272,7 @@ func TestDVOStorageWriteReportForClusterFakePostgresOK(t *testing.T) {
 
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID, testdata.ClusterName, `{"test": "report"}`,
-		validDVORecommendation, testdata.LastCheckedAt, time.Now(), time.Now(),
+		validDVORecommendation, testdata.LastCheckedAt, now, now,
 		testdata.RequestID1)
 	helpers.FailOnError(t, mockStorage.Close())
 	helpers.FailOnError(t, err)
@@ -253,19 +282,90 @@ func TestDVOStorageWriteReportForClusterCheckItIsStored(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
 
-	now := time.Now().UTC()
-	err := mockStorage.WriteReportForCluster(
+	err := mockStorage.DeleteReportsForOrg(testdata.OrgID)
+	helpers.FailOnError(t, err)
+
+	err = mockStorage.WriteReportForCluster(
 		testdata.OrgID,
 		testdata.ClusterName,
 		types.ClusterReport(validReport),
 		validDVORecommendation,
 		now,
-		now,
-		now,
+		dummyTime,
+		dummyTime,
 		testdata.RequestID1,
 	)
 	helpers.FailOnError(t, err)
 
+	row := mockStorage.GetConnection().QueryRow(
+		"SELECT namespace_id, namespace_name, report, recommendations, objects, last_checked_at, reported_at FROM dvo.dvo_report WHERE org_id = $1 AND cluster_id = $2;",
+		testdata.OrgID, testdata.ClusterName,
+	)
+	checkStoredReport(t, row, namespaceAWorkload, 1, now, now)
+}
+
+func TestDVOStorageWriteReportForClusterCheckPreviousIsDeleted(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
+	defer closer()
+
+	err := mockStorage.DeleteReportsForOrg(testdata.OrgID)
+	helpers.FailOnError(t, err)
+
+	err = mockStorage.WriteReportForCluster(
+		testdata.OrgID,
+		testdata.ClusterName,
+		types.ClusterReport(validReport),
+		twoNamespacesRecommendation,
+		now,
+		dummyTime,
+		dummyTime,
+		testdata.RequestID1,
+	)
+	helpers.FailOnError(t, err)
+
+	// Check both namespaces are stored in the DB
+	row := mockStorage.GetConnection().QueryRow(`
+		SELECT namespace_id, namespace_name, report, recommendations, objects, last_checked_at, reported_at
+		FROM dvo.dvo_report WHERE org_id = $1 AND cluster_id = $2 AND namespace_id = $3;`,
+		testdata.OrgID, testdata.ClusterName, namespaceAWorkload.NamespaceUID,
+	)
+	checkStoredReport(t, row, namespaceAWorkload, 1, now, now)
+	row = mockStorage.GetConnection().QueryRow(`
+		SELECT namespace_id, namespace_name, report, recommendations, objects, last_checked_at, reported_at
+		FROM dvo.dvo_report WHERE org_id = $1 AND cluster_id = $2 AND namespace_id = $3;`,
+		testdata.OrgID, testdata.ClusterName, namespaceBWorkload.NamespaceUID,
+	)
+	checkStoredReport(t, row, namespaceBWorkload, 1, now, now)
+
+	// Now receive a report with just one namespace for the same cluster
+	err = mockStorage.WriteReportForCluster(
+		testdata.OrgID,
+		testdata.ClusterName,
+		types.ClusterReport(validReport),
+		validDVORecommendation,
+		nowAfterOneHour,
+		dummyTime,
+		dummyTime,
+		testdata.RequestID1,
+	)
+	helpers.FailOnError(t, err)
+
+	// Make sure just one namespace is in the DB now
+	row = mockStorage.GetConnection().QueryRow(`
+		SELECT namespace_id, namespace_name, report, recommendations, objects, last_checked_at, reported_at
+		FROM dvo.dvo_report WHERE org_id = $1 AND cluster_id = $2 AND namespace_id = $3;`,
+		testdata.OrgID, testdata.ClusterName, namespaceAWorkload.NamespaceUID,
+	)
+	checkStoredReport(t, row, namespaceAWorkload, 1, nowAfterOneHour, now)
+	row = mockStorage.GetConnection().QueryRow(`
+		SELECT namespace_id, namespace_name, report, recommendations, objects, last_checked_at, reported_at
+		FROM dvo.dvo_report WHERE org_id = $1 AND cluster_id = $2 AND namespace_id = $3;`,
+		testdata.OrgID, testdata.ClusterName, namespaceBWorkload.NamespaceUID,
+	)
+	checkRowDoesntExist(t, row)
+}
+
+func checkStoredReport(t *testing.T, row *sql.Row, want types.DVOWorkload, wantObjects int, wantLastChecked, wantReportedAt time.Time) {
 	var (
 		namespaceID     string
 		namespaceName   string
@@ -275,10 +375,8 @@ func TestDVOStorageWriteReportForClusterCheckItIsStored(t *testing.T) {
 		lastChecked     time.Time
 		reportedAt      time.Time
 	)
-	err = mockStorage.GetConnection().QueryRow(
-		"SELECT namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at FROM dvo.dvo_report WHERE org_id = $1 AND cluster_id = $2;",
-		testdata.OrgID, testdata.ClusterName,
-	).Scan(&namespaceID, &namespaceName, &report, &recommendations, &objects, &lastChecked, &reportedAt)
+
+	err := row.Scan(&namespaceID, &namespaceName, &report, &recommendations, &objects, &lastChecked, &reportedAt)
 	helpers.FailOnError(t, err)
 
 	unquotedReport, err := strconv.Unquote(string(report))
@@ -287,11 +385,26 @@ func TestDVOStorageWriteReportForClusterCheckItIsStored(t *testing.T) {
 	err = json.Unmarshal([]byte(unquotedReport), &gotWorkloads)
 	helpers.FailOnError(t, err)
 
-	assert.Equal(t, "NAMESPACE-UID-A", namespaceID, "the column namespace_id is different than expected")
-	assert.Equal(t, "namespace-name-A", namespaceName, "the column namespace_name is different than expected")
+	assert.Equal(t, want.NamespaceUID, namespaceID, "the column namespace_id is different than expected")
+	assert.Equal(t, want.Namespace, namespaceName, "the column namespace_name is different than expected")
 	assert.Equal(t, validDVORecommendation, gotWorkloads.WorkloadRecommendations, "the column report is different than expected")
 	assert.Equal(t, 1, recommendations, "the column recommendations is different than expected")
-	assert.Equal(t, 1, objects, "the column objects is different than expected")
-	assert.Equal(t, now.Truncate(time.Millisecond), lastChecked.UTC().Truncate(time.Millisecond), "the column reported_at is different than expected")
-	assert.Equal(t, now.Truncate(time.Millisecond), reportedAt.UTC().Truncate(time.Millisecond), "the column last_checked_at is different than expected")
+	assert.Equal(t, wantObjects, objects, "the column objects is different than expected")
+	assert.Equal(t, wantLastChecked.Truncate(time.Second), lastChecked.UTC().Truncate(time.Second), "the column reported_at is different than expected")
+	assert.Equal(t, wantReportedAt.Truncate(time.Second), reportedAt.UTC().Truncate(time.Second), "the column last_checked_at is different than expected")
+}
+
+func checkRowDoesntExist(t *testing.T, row *sql.Row) {
+	var (
+		namespaceID     string
+		namespaceName   string
+		report          types.ClusterReport
+		recommendations int
+		objects         int
+		lastChecked     time.Time
+		reportedAt      time.Time
+	)
+
+	err := row.Scan(&namespaceID, &namespaceName, &report, &recommendations, &objects, &lastChecked, &reportedAt)
+	assert.ErrorIs(t, err, sql.ErrNoRows, "a row was found for this queryß")
 }

--- a/storage/noop_dvo_recommendations_storage.go
+++ b/storage/noop_dvo_recommendations_storage.go
@@ -77,3 +77,8 @@ func (*NoopDVOStorage) WriteReportForCluster(
 ) error {
 	return nil
 }
+
+// DeleteReportsForOrg noop
+func (*NoopDVOStorage) DeleteReportsForOrg(types.OrgID) error {
+	return nil
+}

--- a/storage/noop_dvo_recommendations_storage_test.go
+++ b/storage/noop_dvo_recommendations_storage_test.go
@@ -1,0 +1,43 @@
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/insights-results-aggregator/storage"
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+// Don't decrease code coverage by non-functional and not covered code.
+
+// TestDVONoopStorageEmptyMethods1 calls empty methods that just needs to be
+// defined in order for NoopStorage to satisfy Storage interface.
+func TestDVONoopStorageEmptyMethods(_ *testing.T) {
+	noopStorage := storage.NoopDVOStorage{}
+	orgID := types.OrgID(1)
+
+	_ = noopStorage.Init()
+	_ = noopStorage.Close()
+	_, _ = noopStorage.ReportsCount()
+	_ = noopStorage.DeleteReportsForOrg(orgID)
+	_ = noopStorage.MigrateToLatest()
+	_ = noopStorage.GetConnection()
+	_ = noopStorage.GetDBDriverType()
+
+	_ = noopStorage.WriteReportForCluster(0, "", "", validDVORecommendation, time.Now(), time.Now(), time.Now(), "")
+
+}

--- a/storage/noop_dvo_recommendations_storage_test.go
+++ b/storage/noop_dvo_recommendations_storage_test.go
@@ -39,5 +39,4 @@ func TestDVONoopStorageEmptyMethods(_ *testing.T) {
 	_ = noopStorage.GetDBDriverType()
 
 	_ = noopStorage.WriteReportForCluster(0, "", "", validDVORecommendation, time.Now(), time.Now(), time.Now(), "")
-
 }

--- a/storage/queries.go
+++ b/storage/queries.go
@@ -32,11 +32,9 @@ func (storage OCPRecommendationsDBStorage) getReportInfoUpsertQuery() string {
 	`
 }
 
-func (storage DVORecommendationsDBStorage) getReportUpsertQuery() string {
+func (storage DVORecommendationsDBStorage) getReportInsertQuery() string {
 	return `
 		INSERT INTO dvo.dvo_report(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		ON CONFLICT (org_id, cluster_id, namespace_id)
-		DO UPDATE SET namespace_name = $4, report = $5, recommendations = $6, objects = $7, reported_at = $8, last_checked_at = $9
 	`
 }

--- a/tests/helpers/mock_consumer.go
+++ b/tests/helpers/mock_consumer.go
@@ -125,7 +125,7 @@ func GetMockDVOConsumerWithExpectedMessages(
 	mockConsumer := &MockKafkaConsumer{
 		KafkaConsumer: consumer.KafkaConsumer{
 			Configuration: broker.Configuration{
-				Address:      "",
+				Addresses:    "",
 				Topic:        topic,
 				Group:        "",
 				Enabled:      true,


### PR DESCRIPTION
# Description

This fix the situation where

1. you have a cluster123, the cluster has 2 namespaces (namespace_A, namespace_B)
2. we process it, store it, when someone requests it, we display that cluster123 has namespace_A and namespace_B
3. in a few hours, we get another archive from cluster123, but this time, it ONLY has namespace_A because the other namespace got finished/deleted/whatever
4. since we were only doing UPDATE .. ON CONFLICT (org_id, cluster_id, namespace_id), this means that namespace_A will be updated, but namespace_B is still going to be in the database
5. when someone requests the data, we're still going to be showing both namespace_A and namespace_B  for 30 days (until next cleanup) or until the cluster disappears from the AMS API

with these changes we make sure outdated reports aren't stored.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Unit tests.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
