### PR TITLE
Avoid running tests in master, as nobody is able to push directly to it

### DIFF
--- a/.github/workflows/bdd.yaml
+++ b/.github/workflows/bdd.yaml
@@ -1,9 +1,6 @@
 name: BDD tests
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,16 +1,12 @@
 name: golangci-lint
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-      - main
   pull_request:
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
+
 jobs:
   golangci:
     name: lint
@@ -31,7 +27,7 @@ jobs:
           args: >
             --enable=goimports,gosimple,nilerr,prealloc,revive,staticcheck,unconvert,unused,whitespace,zerologlint
             --timeout=3m
-          
+
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
 

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -1,9 +1,6 @@
 name: Go tests
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,9 +1,6 @@
 name: Go linters
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,9 +1,6 @@
 name: Shell check
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
# Description

Remove the execution of most CI tests for pushes to "master" branch. Nobody is pushing directly to "master", so all the merges are already tested in the PR.

I won't merge this commit until all the team agrees with it, so please approve and/or comment.

## Type of change

- Configuration update

## Testing steps

Not tested, only CI configuration change

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
