### PR TITLE
Update build image to ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.18.9 AS builder	
+FROM registry.redhat.io/ubi9/go-toolset:1.18.10 AS builder
 
 COPY . .
 


### PR DESCRIPTION
# Description

Update builder image from rhel8 to ubi9 based one.

Fixes #[CCXDEV-12545](https://issues.redhat.com/browse/CCXDEV-12545)

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Built locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
