### PR TITLE
fix wrong param name in DVO endpoints

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -91,9 +91,9 @@ const (
 	ClustersRecommendationsListEndpoint = "clusters/organizations/{org_id}/users/{user_id}/recommendations"
 
 	// DVOWorkloadRecommendations returns a list of cluster + namespace workloads for given organization ID.
-	DVOWorkloadRecommendations = "organization/{organization}/workloads"
+	DVOWorkloadRecommendations = "organization/{org_id}/workloads"
 	// DVOWorkloadRecommendationsSingleNamespace returns workloads for a single cluster + namespace ID.
-	DVOWorkloadRecommendationsSingleNamespace = "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads"
+	DVOWorkloadRecommendationsSingleNamespace = "organization/{org_id}/namespace/{namespace}/cluster/{cluster}/workloads"
 
 	// Rating accepts a list of ratings in the request body and store them in the database for the given user
 	Rating = "rules/organizations/{org_id}/rating"


### PR DESCRIPTION
# Description
oversight `organization` -> `org_id`, I didn't catch this earlier because the URLs were hardcoded

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
