### PR TITLE
 fix `reported_at` and `last_checked_at` mixed up 

### DIFF
--- a/server/dvo_handlers_test.go
+++ b/server/dvo_handlers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -61,6 +62,10 @@ func TestProcessSingleDVONamespace_MustProcessEscapedString(t *testing.T) {
 	assert.Equal(t, namespaceID, processedWorkload.Namespace.UUID)
 	assert.Equal(t, 1, processedWorkload.Metadata.Objects)
 	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
+
+	samples, err := json.Marshal(processedWorkload.Recommendations[0].TemplateData["samples"])
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(string(samples)), 1)
 }
 
 // TestProcessSingleDVONamespace_MustProcessCorrectString tests the behavior of the ProcessSingleDVONamespace with a
@@ -91,4 +96,8 @@ func TestProcessSingleDVONamespace_MustProcessCorrectString(t *testing.T) {
 	assert.Equal(t, namespaceID, processedWorkload.Namespace.UUID)
 	assert.Equal(t, 1, processedWorkload.Metadata.Objects)
 	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
+
+	samples, err := json.Marshal(processedWorkload.Recommendations[0].TemplateData["samples"])
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(string(samples)), 1)
 }

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -456,8 +456,8 @@ func (storage DVORecommendationsDBStorage) ReadWorkloadsForOrganization(orgID ty
 			&dvoReport.NamespaceName,
 			&dvoReport.Recommendations,
 			&dvoReport.Objects,
-			&lastCheckedAtDB,
 			&reportedAtDB,
+			&lastCheckedAtDB,
 		)
 		if err != nil {
 			log.Error().Err(err).Msg("ReadWorkloadsForOrganization")


### PR DESCRIPTION
# Description
the two timestamps were retrieved incorrectly which propagated into the smart-proxy API. This PR fixes it and adds a reproducer UT.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
local

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
