### PR TITLE
fix a case when we end up with 0 objects after filtering them from DVO rules

### DIFF
--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -292,6 +292,13 @@ func (server *HTTPServer) ProcessSingleDVONamespace(workload types.DVOReport) (
 			})
 		}
 
+		// because the whole report contains a list of recommendations and each rec. contains
+		// a list of objects + namespaces, it can happen that upon filtering the objects to get rid
+		// of namespaces that weren't requested, we can end up with 0 hitting objects in that namespace
+		if len(filteredObjects) == 0 {
+			continue
+		}
+
 		// recommendation.ResponseID doesn't contain the full rule ID, so smart-proxy was unable to retrieve content, we need to build it
 		compositeRuleID, err := generators.GenerateCompositeRuleID(
 			// for some unknown reason, there's a `.recommendation` suffix for each rule hit instead of the usual .report

--- a/server/dvo_handlers_test.go
+++ b/server/dvo_handlers_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 	"github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
 	"github.com/RedHatInsights/insights-results-aggregator/types"
@@ -28,11 +29,48 @@ import (
 )
 
 const (
-	currentDvoReportFromDB = `"{\"system\":{\"metadata\":{},\"hostname\":null},\"fingerprints\":[],\"version\":1,\"analysis_metadata\":{},\"workload_recommendations\":[{\"response_id\":\"an_issue|DVO_AN_ISSUE\",\"component\":\"ccx_rules_ocp.external.dvo.an_issue_pod.recommendation\",\"key\":\"DVO_AN_ISSUE\",\"details\":{\"check_name\":\"\",\"check_url\":\"\",\"samples\":[{\"namespace_uid\":\"NAMESPACE-UID-A\",\"kind\":\"DaemonSet\",\"uid\":\"193a2099-1234-5678-916a-d570c9aac158\"}]},\"tags\":[],\"links\":{\"jira\":[\"https://issues.redhat.com/browse/AN_ISSUE\"],\"product_documentation\":[]},\"workloads\":[{\"namespace\":\"namespace-name-A\",\"namespace_uid\":\"NAMESPACE-UID-A\",\"kind\":\"DaemonSet\",\"name\":\"test-name-0099\",\"uid\":\"UID-0099\"}]}]}"`
+	/*
+		test reports have following structure:
+		{
+			...
+			"workload_recommendations": [
+				{
+					"response_id": "unset_requirements|DVO_UNSET_REQUIREMENTS",
+					...
+					"workloads": [
+						{
+						"namespace": "namespace-name-A",
+						...
+						"uid": "193a2099-1234-5678-916a-d570c9aac158"
+						},
+						{
+						"namespace": "namespace-name-A",
+						...
+						"uid": "193a2099-0000-1111-916a-d570c9aac158"
+						}
+					]
+				},
+				{
+					"response_id": "excluded_pod|EXCLUDED_POD",
+					...
+					"workloads": [
+						{
+						"namespace": "namespace-name-B",
+						...
+						"uid": "12345678-1234-5678-916a-d570c9aac158"
+						}
+					]
+				}
+			]
+		}
+
+	*/
+	currentDvoReportFromDB = `"{\"system\":{\"metadata\":{},\"hostname\":null},\"fingerprints\":[],\"version\":1,\"analysis_metadata\":{},\"workload_recommendations\":[{\"response_id\":\"unset_requirements|DVO_UNSET_REQUIREMENTS\",\"component\":\"ccx_rules_ocp.external.dvo.unset_requirements.recommendation\",\"key\":\"DVO_UNSET_REQUIREMENTS\",\"details\":{\"check_name\":\"\",\"check_url\":\"\",\"samples\":[{\"namespace_uid\":\"NAMESPACE-UID-A\",\"kind\":\"DaemonSet\",\"uid\":\"193a2099-1234-5678-916a-d570c9aac158\"}]},\"tags\":[],\"links\":{\"jira\":[\"https://issues.redhat.com/browse/AN_ISSUE\"],\"product_documentation\":[]},\"workloads\":[{\"namespace\":\"namespace-name-A\",\"namespace_uid\":\"NAMESPACE-UID-A\",\"kind\":\"DaemonSet\",\"name\":\"test-name-0099\",\"uid\":\"193a2099-1234-5678-916a-d570c9aac158\"},{\"namespace\":\"namespace-name-A\",\"namespace_uid\":\"NAMESPACE-UID-A\",\"kind\":\"Pod\",\"name\":\"test-name-0001\",\"uid\":\"193a2099-0000-1111-916a-d570c9aac158\"}]},{\"response_id\":\"excluded_pod|EXCLUDED_POD\",\"component\":\"ccx_rules_ocp.external.dvo.excluded_pod.recommendation\",\"key\":\"EXCLUDED_POD\",\"details\":{\"check_name\":\"\",\"check_url\":\"\",\"samples\":[{\"namespace_uid\":\"NAMESPACE-UID-B\",\"kind\":\"DaemonSet\",\"uid\":\"12345678-1234-5678-916a-d570c9aac158\"}]},\"tags\":[],\"links\":{\"jira\":[\"https://issues.redhat.com/browse/AN_ISSUE\"],\"product_documentation\":[]},\"workloads\":[{\"namespace\":\"namespace-name-B\",\"namespace_uid\":\"NAMESPACE-UID-B\",\"kind\":\"DaemonSet\",\"name\":\"test-name-1234\",\"uid\":\"12345678-1234-5678-916a-d570c9aac158\"}]}]}"`
 	// fixedDvoReportFromDB is what the string inside the report column should look like (after we fix the encoding issues)
-	fixedDvoReportFromDB = `{"system":{"metadata":{},"hostname":null},"fingerprints":[],"version":1,"analysis_metadata":{},"workload_recommendations":[{"response_id":"an_issue|DVO_AN_ISSUE","component":"ccx_rules_ocp.external.dvo.an_issue_pod.recommendation","key":"DVO_AN_ISSUE","details":{"check_name":"","check_url":"","samples":[{"namespace_uid":"NAMESPACE-UID-A","kind":"DaemonSet","uid":"193a2099-1234-5678-916a-d570c9aac158"}]},"tags":[],"links":{"jira":["https://issues.redhat.com/browse/AN_ISSUE"],"product_documentation":[]},"workloads":[{"namespace":"namespace-name-A","namespace_uid":"NAMESPACE-UID-A","kind":"DaemonSet","name":"test-name-0099","uid":"UID-0099"}]}]}`
-	objectUID            = `UID-0099`
-	namespaceID          = "NAMESPACE-UID-A"
+	fixedDvoReportFromDB = `{"system":{"metadata":{},"hostname":null},"fingerprints":[],"version":1,"analysis_metadata":{},"workload_recommendations":[{"response_id":"unset_requirements|DVO_UNSET_REQUIREMENTS","component":"ccx_rules_ocp.external.dvo.unset_requirements.recommendation","key":"DVO_UNSET_REQUIREMENTS","details":{"check_name":"","check_url":"","samples":[{"namespace_uid":"NAMESPACE-UID-A","kind":"DaemonSet","uid":"193a2099-1234-5678-916a-d570c9aac158"}]},"tags":[],"links":{"jira":["https://issues.redhat.com/browse/AN_ISSUE"],"product_documentation":[]},"workloads":[{"namespace":"namespace-name-A","namespace_uid":"NAMESPACE-UID-A","kind":"DaemonSet","name":"test-name-0099","uid":"193a2099-1234-5678-916a-d570c9aac158"},{"namespace":"namespace-name-A","namespace_uid":"NAMESPACE-UID-A","kind":"Pod","name":"test-name-0001","uid":"193a2099-0000-1111-916a-d570c9aac158"}]},{"response_id":"excluded_pod|EXCLUDED_POD","component":"ccx_rules_ocp.external.dvo.excluded_pod.recommendation","key":"EXCLUDED_POD","details":{"check_name":"","check_url":"","samples":[{"namespace_uid":"NAMESPACE-UID-B","kind":"DaemonSet","uid":"12345678-1234-5678-916a-d570c9aac158"}]},"tags":[],"links":{"jira":["https://issues.redhat.com/browse/AN_ISSUE"],"product_documentation":[]},"workloads":[{"namespace":"namespace-name-B","namespace_uid":"NAMESPACE-UID-B","kind":"DaemonSet","name":"test-name-1234","uid":"12345678-1234-5678-916a-d570c9aac158"}]}]}`
+	objectBUID           = `12345678-1234-5678-916a-d570c9aac158`
+	namespaceAID         = "NAMESPACE-UID-A"
+	namespaceBID         = "NAMESPACE-UID-B"
 )
 
 // TestProcessSingleDVONamespace_MustProcessEscapedString tests the behavior of ProcessSingleDVONamespace with the current
@@ -44,9 +82,9 @@ func TestProcessSingleDVONamespace_MustProcessEscapedString(t *testing.T) {
 
 	dvoReport := types.DVOReport{
 		OrgID:           "1",
-		NamespaceID:     namespaceID,
-		NamespaceName:   "namespace-name-A",
-		ClusterID:       "193a2099-1234-5678-916a-d570c9aac158",
+		NamespaceID:     namespaceBID,
+		NamespaceName:   "namespace-name-B",
+		ClusterID:       string(testdata.ClusterName),
 		Recommendations: 1,
 		Report:          currentDvoReportFromDB,
 		Objects:         1,
@@ -58,8 +96,8 @@ func TestProcessSingleDVONamespace_MustProcessEscapedString(t *testing.T) {
 
 	assert.Equal(t, 1, len(processedWorkload.Recommendations))
 	assert.Equal(t, 1, len(processedWorkload.Recommendations[0].Objects))
-	assert.Equal(t, objectUID, processedWorkload.Recommendations[0].Objects[0].UID)
-	assert.Equal(t, namespaceID, processedWorkload.Namespace.UUID)
+	assert.Equal(t, objectBUID, processedWorkload.Recommendations[0].Objects[0].UID)
+	assert.Equal(t, namespaceBID, processedWorkload.Namespace.UUID)
 	assert.Equal(t, 1, processedWorkload.Metadata.Objects)
 	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
 
@@ -78,8 +116,8 @@ func TestProcessSingleDVONamespace_MustProcessCorrectString(t *testing.T) {
 
 	dvoReport := types.DVOReport{
 		OrgID:           "1",
-		NamespaceID:     namespaceID,
-		NamespaceName:   "namespace-name-A",
+		NamespaceID:     namespaceBID,
+		NamespaceName:   "namespace-name-B",
 		ClusterID:       "193a2099-1234-5678-916a-d570c9aac158",
 		Recommendations: 1,
 		Report:          fixedDvoReportFromDB,
@@ -92,9 +130,58 @@ func TestProcessSingleDVONamespace_MustProcessCorrectString(t *testing.T) {
 
 	assert.Equal(t, 1, len(processedWorkload.Recommendations))
 	assert.Equal(t, 1, len(processedWorkload.Recommendations[0].Objects))
-	assert.Equal(t, objectUID, processedWorkload.Recommendations[0].Objects[0].UID)
-	assert.Equal(t, namespaceID, processedWorkload.Namespace.UUID)
+	assert.Equal(t, objectBUID, processedWorkload.Recommendations[0].Objects[0].UID)
+	assert.Equal(t, namespaceBID, processedWorkload.Namespace.UUID)
 	assert.Equal(t, 1, processedWorkload.Metadata.Objects)
+	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
+
+	samples, err := json.Marshal(processedWorkload.Recommendations[0].TemplateData["samples"])
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(string(samples)), 1)
+}
+
+// TestProcessSingleDVONamespace_MustFilterZeroObjects_CCXDEV_12589_Reproducer
+// tests the behavior of the ProcessSingleDVONamespace
+// to filter out recommendations that have 0 objects/workloads for that particular namespace.
+// Since we process the report every time, we need to filter out objects+namespaces that don't match
+// the requested one. And since we can end up with 0 objects for that rule_ID + namespace after the filtering,
+// we mustn't show this recommendation in the API, as it has no rule hits in reality.
+func TestProcessSingleDVONamespace_MustFilterZeroObjects_CCXDEV_12589_Reproducer(t *testing.T) {
+	testServer := server.New(helpers.DefaultServerConfig, nil, nil)
+
+	now := types.Timestamp(time.Now().UTC().Format(time.RFC3339))
+
+	dvoReport := types.DVOReport{
+		OrgID:           "1",
+		NamespaceID:     namespaceAID,
+		NamespaceName:   "namespace-name-A",
+		ClusterID:       string(testdata.ClusterName),
+		Recommendations: 1,
+		Report:          fixedDvoReportFromDB,
+		Objects:         2,
+		ReportedAt:      now,
+		LastCheckedAt:   now,
+	}
+
+	processedWorkload := testServer.ProcessSingleDVONamespace(dvoReport)
+
+	assert.Equal(t, 1, len(processedWorkload.Recommendations)) // <-- this would be 2 without CCXDEV-12589 fix
+	assert.Equal(t, 2, len(processedWorkload.Recommendations[0].Objects))
+	expectedObjects := []server.DVOObject{
+		{
+			UID:  "193a2099-0000-1111-916a-d570c9aac158",
+			Kind: "Pod",
+		},
+		{
+			UID:  "193a2099-1234-5678-916a-d570c9aac158",
+			Kind: "DaemonSet",
+		},
+	}
+	assert.ElementsMatch(t, expectedObjects, processedWorkload.Recommendations[0].Objects)
+	assert.Equal(t, namespaceAID, processedWorkload.Namespace.UUID)
+
+	// check correct metadata as well
+	assert.Equal(t, 2, processedWorkload.Metadata.Objects)
 	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
 
 	samples, err := json.Marshal(processedWorkload.Recommendations[0].TemplateData["samples"])


### PR DESCRIPTION
# Description
because the whole report contains a list of recommendations and each recommendation contains a list of objects + namespaces instead of the other thing around, it can happen that upon filtering the objects to get rid of namespaces that weren't requested, we can end up with 0 hitting objects in that namespace.

- fix
- extending test data
- adding a reproducer UT 


Fixes https://issues.redhat.com/browse/CCXDEV-12589

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
