### PR TITLE
fix reported_at and last_checked_at mixed up in /dvo/namespaces

### DIFF
--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -517,8 +517,8 @@ func (storage DVORecommendationsDBStorage) ReadWorkloadsForClusterAndNamespace(
 			&dvoReport.Recommendations,
 			&dvoReport.Report,
 			&dvoReport.Objects,
-			&lastCheckedAtDB,
 			&reportedAtDB,
+			&lastCheckedAtDB,
 		)
 		if err != nil {
 			log.Error().Err(err).Msg("ReadWorkloadsForClusterAndNamespace")


### PR DESCRIPTION
# Description
same issues as in #1975 but in the 2nd DVO endpoint. Adding more UT coverage before the rest of UTs come in a separate PR. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
local

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
