### PR TITLE
Print the entire content of the report received from dvo extractor for debug

### DIFF
--- a/consumer/dvo_processing.go
+++ b/consumer/dvo_processing.go
@@ -107,7 +107,14 @@ func parseDVOContent(message *incomingMessage) error {
 	log.Info().Msg("Received DVO metrics (workload truncated if > 140 chars)")
 	for key, value := range *message.DvoMetrics {
 		if len(*value) >= 140 {
-			log.Info().Msgf("%s: %s", key, (*value)[:140])
+			log.Info().Msgf("%s", key)
+			for i := 0; i < len(*value); i += 140 {
+				end := i + 140
+				if end > len(*value) {
+					end = len(*value)
+				}
+				log.Info().Msgf("%s", (*value)[i:end])
+			}
 		} else {
 			log.Info().Msgf("%s: %s", key, *value)
 		}


### PR DESCRIPTION


# Description

The first 140 characters are not enough, so let's print it all in chunks. Now what we print looks like this:

> === RUN   TestParseDVOMessageWithProperMetrics
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"Received DVO metrics (workload truncated if > 140 chars)"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"fingerprints: []"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"version: 1"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"analysis_metadata: {}"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"workload_recommendations"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"[{\"response_id\":\"an_issue|DVO_AN_ISSUE\",\"component\":\"ccx_rules_ocp.external.dvo.an_issue_pod.recommendation\",\"key\":\"DVO_AN_ISSUE\",\"details\":"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"{\"check_name\":\"\",\"check_url\":\"\",\"samples\":[{\"namespace_uid\":\"NAMESPACE-UID-A\",\"kind\":\"DaemonSet\",\"uid\":\"193a2099-1234-5678-916a-d570c9aac158"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"\"}]},\"tags\":[],\"links\":{\"jira\":[\"https://issues.redhat.com/browse/AN_ISSUE\"],\"product_documentation\":[]},\"workloads\":[{\"namespace\":\"namespac"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"e-name-A\",\"namespace_uid\":\"NAMESPACE-UID-A\",\"kind\":\"DaemonSet\",\"name\":\"test-name-0099\",\"uid\":\"193a2099-1234-5678-916a-d570c9aac158\"}]}]"}
{"level":"info","time":"2024-03-06T07:57:59+01:00","message":"system: {\"metadata\":{},\"hostname\":null}"}
--- PASS: TestParseDVOMessageWithProperMetrics (0.00s)

## Type of change

- DEBUG LOGS

## Testing steps

- Modified UTs locally to check behavior
- CI should pass

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
