### PR TITLE
fix wrong count in the `objects` column in `dvo.dvo_report`

### DIFF
--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -42,6 +42,7 @@ var (
 
 	namespaceAUID = "NAMESPACE-UID-A"
 	namespaceBUID = "NAMESPACE-UID-B"
+	namespaceCUID = "NAMESPACE-UID-C"
 
 	namespaceAWorkload = types.DVOWorkload{
 		Namespace:    "namespace-name-A",
@@ -63,6 +64,13 @@ var (
 		Kind:         "NotDaemonSet",
 		Name:         "test-name-1199",
 		UID:          "UID-1199",
+	}
+	namespaceCWorkload = types.DVOWorkload{
+		Namespace:    "namespace-name-C",
+		NamespaceUID: namespaceCUID,
+		Kind:         "Pod",
+		Name:         "test-name-8899",
+		UID:          "UID-8899",
 	}
 	validDVORecommendation = []types.WorkloadRecommendation{
 		{
@@ -120,37 +128,52 @@ var (
 		},
 	}
 
-	twoNamespaces2Recommendations = []types.WorkloadRecommendation{
-		{
-			ResponseID: "an_issue|DVO_AN_ISSUE",
-			Component:  "ccx_rules_ocp.external.dvo.an_issue_pod.recommendation",
-			Key:        "DVO_AN_ISSUE",
-			Links: types.DVOLinks{
-				Jira:                 []string{"https://issues.redhat.com/browse/AN_ISSUE"},
-				ProductDocumentation: []string{},
-			},
-			Details: map[string]interface{}{
-				"check_name": "",
-				"check_url":  "",
-			},
-			Tags:      []string{},
-			Workloads: []types.DVOWorkload{namespaceAWorkload, namespaceBWorkload},
+	recommendation1TwoNamespaces = types.WorkloadRecommendation{
+		ResponseID: "an_issue|DVO_AN_ISSUE",
+		Component:  "ccx_rules_ocp.external.dvo.an_issue_pod.recommendation",
+		Key:        "DVO_AN_ISSUE",
+		Links: types.DVOLinks{
+			Jira:                 []string{"https://issues.redhat.com/browse/AN_ISSUE"},
+			ProductDocumentation: []string{},
 		},
-		{
-			ResponseID: "unset_requirements|DVO_UNSET_REQUIREMENTS",
-			Component:  "ccx_rules_ocp.external.dvo.unset_requirements.recommendation",
-			Key:        "DVO_UNSET_REQUIREMENTS",
-			Links: types.DVOLinks{
-				Jira:                 []string{"https://issues.redhat.com/browse/AN_ISSUE"},
-				ProductDocumentation: []string{},
-			},
-			Details: map[string]interface{}{
-				"check_name": "",
-				"check_url":  "",
-			},
-			Tags:      []string{},
-			Workloads: []types.DVOWorkload{namespaceAWorkload2},
+		Details: map[string]interface{}{
+			"check_name": "",
+			"check_url":  "",
 		},
+		Tags:      []string{},
+		Workloads: []types.DVOWorkload{namespaceAWorkload, namespaceBWorkload},
+	}
+
+	recommendation2OneNamespace = types.WorkloadRecommendation{
+		ResponseID: "unset_requirements|DVO_UNSET_REQUIREMENTS",
+		Component:  "ccx_rules_ocp.external.dvo.unset_requirements.recommendation",
+		Key:        "DVO_UNSET_REQUIREMENTS",
+		Links: types.DVOLinks{
+			Jira:                 []string{"https://issues.redhat.com/browse/AN_ISSUE"},
+			ProductDocumentation: []string{},
+		},
+		Details: map[string]interface{}{
+			"check_name": "",
+			"check_url":  "",
+		},
+		Tags:      []string{},
+		Workloads: []types.DVOWorkload{namespaceAWorkload, namespaceAWorkload2},
+	}
+
+	recommendation3OneNamespace = types.WorkloadRecommendation{
+		ResponseID: "bad_requirements|BAD_REQUIREMENTS",
+		Component:  "ccx_rules_ocp.external.dvo.bad_requirements.recommendation",
+		Key:        "BAD_REQUIREMENTS",
+		Links: types.DVOLinks{
+			Jira:                 []string{"https://issues.redhat.com/browse/AN_ISSUE"},
+			ProductDocumentation: []string{},
+		},
+		Details: map[string]interface{}{
+			"check_name": "",
+			"check_url":  "",
+		},
+		Tags:      []string{},
+		Workloads: []types.DVOWorkload{namespaceAWorkload, namespaceAWorkload2},
 	}
 )
 
@@ -626,7 +649,7 @@ func TestDVOStorageWriteReport_TwoNamespacesTwoRecommendations(t *testing.T) {
 		testdata.OrgID,
 		testdata.ClusterName,
 		types.ClusterReport(validReport2Rules2Namespaces),
-		twoNamespaces2Recommendations,
+		[]types.WorkloadRecommendation{recommendation1TwoNamespaces, recommendation2OneNamespace},
 		now,
 		now,
 		now,
@@ -640,7 +663,7 @@ func TestDVOStorageWriteReport_TwoNamespacesTwoRecommendations(t *testing.T) {
 			NamespaceName:   namespaceAWorkload.Namespace,
 			ClusterID:       string(testdata.ClusterName),
 			Recommendations: uint(2),
-			Objects:         uint(2),
+			Objects:         uint(2), // <-- must be 2, because one workload is hitting more recommendations, but counts as 1
 			ReportedAt:      nowTstmp,
 			LastCheckedAt:   nowTstmp,
 		},
@@ -667,6 +690,68 @@ func TestDVOStorageWriteReport_TwoNamespacesTwoRecommendations(t *testing.T) {
 	assert.Equal(t, testdata.ClusterName, types.ClusterName(report.ClusterID))
 	assert.Equal(t, namespaceAUID, report.NamespaceID)
 	assert.Equal(t, uint(2), report.Recommendations)
+	assert.Equal(t, uint(2), report.Objects)
+	assert.Equal(t, nowTstmp, report.ReportedAt)
+	assert.Equal(t, nowTstmp, report.LastCheckedAt)
+}
+
+func TestDVOStorageWriteReport_FilterOutDuplicateObjects_CCXDEV_12608_Reproducer(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
+	defer closer()
+
+	nowTstmp := types.Timestamp(now.UTC().Format(time.RFC3339))
+
+	// writing 3 recommendations, but objects/workloads are hitting multiple recommendations
+	// and need to be filtered out
+	err := mockStorage.WriteReportForCluster(
+		testdata.OrgID,
+		testdata.ClusterName,
+		types.ClusterReport(validReport2Rules2Namespaces),
+		[]types.WorkloadRecommendation{
+			recommendation1TwoNamespaces,
+			recommendation2OneNamespace,
+			recommendation3OneNamespace,
+		},
+		now,
+		now,
+		now,
+		testdata.RequestID1,
+	)
+	helpers.FailOnError(t, err)
+
+	expectedWorkloads := []types.DVOReport{
+		{
+			NamespaceID:     namespaceAUID,
+			NamespaceName:   namespaceAWorkload.Namespace,
+			ClusterID:       string(testdata.ClusterName),
+			Recommendations: uint(3),
+			Objects:         uint(2), // <-- must be 2, because workloadA and workloadB are hitting more rules, but count as 1 within a namespace
+			ReportedAt:      nowTstmp,
+			LastCheckedAt:   nowTstmp,
+		},
+		{
+			NamespaceID:     namespaceBUID,
+			NamespaceName:   namespaceBWorkload.Namespace,
+			ClusterID:       string(testdata.ClusterName),
+			Recommendations: uint(1), // <-- must contain only 1 rule, the other rules weren't affecting this namespace
+			Objects:         uint(1), // <-- same as ^
+			ReportedAt:      nowTstmp,
+			LastCheckedAt:   nowTstmp,
+		},
+	}
+
+	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID)
+	helpers.FailOnError(t, err)
+
+	assert.Equal(t, 2, len(workloads))
+	assert.ElementsMatch(t, expectedWorkloads, workloads)
+
+	report, err := mockStorage.ReadWorkloadsForClusterAndNamespace(testdata.OrgID, testdata.ClusterName, namespaceAUID)
+	helpers.FailOnError(t, err)
+
+	assert.Equal(t, testdata.ClusterName, types.ClusterName(report.ClusterID))
+	assert.Equal(t, namespaceAUID, report.NamespaceID)
+	assert.Equal(t, uint(3), report.Recommendations)
 	assert.Equal(t, uint(2), report.Objects)
 	assert.Equal(t, nowTstmp, report.ReportedAt)
 	assert.Equal(t, nowTstmp, report.LastCheckedAt)


### PR DESCRIPTION
# Description
- fix wrong count in the `objects` column in `dvo.dvo_report`, it must contain the number of unique objects affected by DVO rules within a namespace. Previously, it was counting duplicate objects as well.
- improve the for loop of `recommendation.Workloads`, we're only reading the IDs, so we can safely access the list by index instead of copying it. The `Workloads` list can contain 10s-100s of thousands of items, so it might improve things a bit.
- simplifies access to map (`objectsPerRecommendation[workload.NamespaceUID]++` is fine)
- adds reproducer UT for the unique objects 

Fixes [CCXDEV-12608](https://issues.redhat.com/browse/CCXDEV-12608)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Changes in REST API schema
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
UTs should now provide enough coverage

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
