### PR TITLE
[CCXDEV-12602] Add migration to delete buggy rows

### DIFF
--- a/migration/dvomigrations/dvo_migrations.go
+++ b/migration/dvomigrations/dvo_migrations.go
@@ -6,4 +6,5 @@ import "github.com/RedHatInsights/insights-results-aggregator/migration"
 var UsableDVOMigrations = []migration.Migration{
 	mig0001CreateDVOReport,
 	mig0002CreateDVOReportIndexes,
+	mig0003CCXDEV12602DeleteBuggyRecords,
 }

--- a/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
+++ b/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
@@ -30,5 +30,5 @@ var mig0003CCXDEV12602DeleteBuggyRecords = migration.Migration{
 		`)
 		return err
 	},
-	StepDown: func(tx *sql.Tx, _ types.DBDriver) error { return nil },
+	StepDown: func(_ *sql.Tx, _ types.DBDriver) error { return nil },
 }

--- a/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
+++ b/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
@@ -26,7 +26,7 @@ import (
 var mig0003CCXDEV12602DeleteBuggyRecords = migration.Migration{
 	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
 		_, err := tx.Exec(`
-			DELETE FROM dvo.dvo_reports WHERE last_checked_at <= DATE '2024-04-08';
+			DELETE FROM dvo.dvo_report WHERE last_checked_at <= DATE '2024-04-08';
 		`)
 		return err
 	},

--- a/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
+++ b/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
@@ -26,7 +26,7 @@ import (
 var mig0003CCXDEV12602DeleteBuggyRecords = migration.Migration{
 	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
 		_, err := tx.Exec(`
-			DELETE FROM dvo.dvo_report WHERE last_checked_at <= DATE '2024-04-08';
+			DELETE FROM dvo.dvo_report WHERE last_checked_at <= DATE '2024-03-08';
 		`)
 		return err
 	},

--- a/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
+++ b/migration/dvomigrations/mig_0003_ccxdev_12602_delete_buggy_records.go
@@ -1,0 +1,34 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dvomigrations
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/migration"
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+var mig0003CCXDEV12602DeleteBuggyRecords = migration.Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		_, err := tx.Exec(`
+			DELETE FROM dvo.dvo_reports WHERE last_checked_at <= DATE '2024-04-08';
+		`)
+		return err
+	},
+	StepDown: func(tx *sql.Tx, _ types.DBDriver) error { return nil },
+}


### PR DESCRIPTION
# Description

We had a bug ([CCXDEV-12601](https://issues.redhat.com/browse/CCXDEV-12601)) in the [insights-results-aggregator](https://github.com/RedHatInsights/insights-results-aggregator) service that generated lots of events in the production DB. Now that [the bug is fixed](https://github.com/RedHatInsights/insights-results-aggregator/pull/1983), we need to delete the buggy rows. As this feature is just on preview, we can safely delete the rows.

## Type of change

- New migration

## Testing steps

CI:

```
Clowder is enabled
...
{"level":"debug","type":"SQL","time":"2024-03-12T09:48:15Z","message":"query `\n\t\t\tDELETE FROM dvo.dvo_report WHERE last_checked_at <= DATE '2024-04-08';\n\t\t` with params `[]`\n"}
{"level":"debug","type":"SQL","time":"2024-03-12T09:48:15Z","message":"query `\n\t\t\tDELETE FROM dvo.dvo_report WHERE last_checked_at <= DATE '2024-04-08';\n\t\t` with params `[]` took 453.05Âµs\n"}
{"level":"debug","type":"SQL","time":"2024-03-12T09:48:15Z","message":"query `UPDATE dvo.migration_info SET version=$1;` with params `[3]`\n"}
{"level":"debug","type":"SQL","time":"2024-03-12T09:48:15Z","message":"query `UPDATE dvo.migration_info SET version=$1;` with params `[3]` took 506.594Âµs\n"}
{"level":"info","time":"2024-03-12T09:48:15Z","message":"Database version is now 3"}
{"level":"info","time":"2024-03-12T09:48:15Z","message":"Closing connection to data storage"}
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
