### PR TITLE
Use go1.20

### DIFF
--- a/.github/workflows/bdd.yaml
+++ b/.github/workflows/bdd.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
+          - "1.20"
     name: BDD for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.20'
       - name: Generate docgo and literate
         run: make godoc
       - name: Build with Jekyll

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -11,7 +11,6 @@ jobs:
         go-version:
           - "1.20"
           - "1.21"
-          - "1.22"
     name: Tests for Go ${{ matrix.go-version}}
     services:
       postgres:

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -9,10 +9,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
-          - "1.19"
           - "1.20"
           - "1.21"
+          - "1.22"
     name: Tests for Go ${{ matrix.go-version}}
     services:
       postgres:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -11,7 +11,6 @@ jobs:
         go-version:
           - "1.20"
           - "1.21"
-          - "1.22"
     name: Linters for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -9,10 +9,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
-          - "1.19"
           - "1.20"
           - "1.21"
+          - "1.22"
     name: Linters for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ COPY . .
 USER 0
 
 # build the aggregator
-RUN umask 0022 && \
-    make build && \
-    chmod a+x insights-results-aggregator
+RUN umask 0022
+RUN make build
+RUN chmod a+x insights-results-aggregator
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.20 AS builder
 
 COPY . .
 
@@ -20,6 +20,7 @@ USER 0
 
 # build the aggregator
 RUN umask 0022
+ENV GOFLAGS="-buildvcs=false"
 RUN make build
 RUN chmod a+x insights-results-aggregator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi9/go-toolset:1.18.10 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
 
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/insights-results-aggregator
 
-go 1.18
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
# Description

There is an ongoing issue with our linters installation on go1.18 (https://github.com/RedHatInsights/insights-results-aggregator/pull/1990). We've been thinking on updating to go1.20 for some time, so we will use this opportunity for it.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Configuration update

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
