### PR TITLE
Remove info from always expected fields in report

### DIFF
--- a/consumer/ocp_rules_consumer_test.go
+++ b/consumer/ocp_rules_consumer_test.go
@@ -312,7 +312,6 @@ func TestCheckReportStructureReportWithAllAttributesPresentAndEmpty(t *testing.T
 func TestCheckReportStructureReportWithAnalysisMetadata(t *testing.T) {
 	report := consumer.Report{
 		"system":            unmarshall(`{"metadata": {}, "hostname": null}`),
-		"reports":           unmarshall("[]"),
 		"fingerprints":      unmarshall("[]"),
 		"analysis_metadata": unmarshall(`{"start": "2023-09-11T18:33:14.527845+00:00", "finish": "2023-09-11T18:33:15.632777+00:00"}`),
 	}
@@ -335,7 +334,6 @@ func TestCheckReportStructureReportWithEmptyAndMissingAttributes(t *testing.T) {
 func TestCheckReportStructureReportWithItems(t *testing.T) {
 	report := consumer.Report{
 		"fingerprints": unmarshall("[]"),
-		"info":         unmarshall("[]"),
 		"reports":      unmarshall(string(testdata.Report2Rules)),
 		"skips":        unmarshall("[]"),
 		"system":       unmarshall(`{"metadata": {},"hostname": null}`),

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -39,12 +39,12 @@ const (
 	reportAttributeInfo          = "info"
 	reportAttributeFingerprints  = "fingerprints"
 	reportAttributeMetadata      = "analysis_metadata"
-	numberOfExpectedKeysInReport = 4
+	numberOfExpectedKeysInReport = 3 // Number of items in expectedKeysInReport
 )
 
 var (
 	expectedKeysInReport = []string{
-		reportAttributeFingerprints, reportAttributeInfo, reportAttributeReports, reportAttributeSystem,
+		reportAttributeFingerprints, reportAttributeReports, reportAttributeSystem,
 	}
 )
 


### PR DESCRIPTION
# Description

Relax the check of the report's expected fields.

Since no info rule is triggered for HyperShift-enabled clusters archives, the `info` field in the report is now optional.

Fixes CCXDEV-12709

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Unit tests (no changes in the code)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary -> TODO (follow up issue will be created)
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change  -> TODO (follow up issue will be created)
