### PR TITLE
Remove info from always expected fields in report

### DIFF
--- a/consumer/ocp_processing.go
+++ b/consumer/ocp_processing.go
@@ -242,7 +242,7 @@ func isReportWithEmptyAttributes(r Report) bool {
 func checkReportStructure(r Report) error {
 	// the structure is not well-defined yet, so all we should do is to check if all keys are there
 
-	// 'skips' key is now optional, we should not expect it anymore:
+	// 'skips' and 'info' keys are now optional, we should not expect them anymore:
 	// https://github.com/RedHatInsights/insights-results-aggregator/issues/1206
 	keysNotFound := make([]string, 0, numberOfExpectedKeysInReport)
 	keysFound := 0
@@ -283,13 +283,18 @@ func parseReportContent(message *incomingMessage) error {
 		return err
 	}
 
-	// it is expected that message.ParsedInfo contains at least one item:
-	// result from special INFO rule containing cluster version that is
-	// used just in external data pipeline
+	// with support for Hypershift-enabled clusters, the info attribute became optional
+	_, infoExists := (*message.Report)[reportAttributeInfo]
+	if !infoExists {
+		log.Debug().Msgf("%s key does not exist in the JSON object", reportAttributeInfo)
+		return nil
+	}
+
 	err = json.Unmarshal(*((*message.Report)[reportAttributeInfo]), &message.ParsedInfo)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/consumer/ocp_rules_consumer_test.go
+++ b/consumer/ocp_rules_consumer_test.go
@@ -532,6 +532,35 @@ func TestParseProperMessageWithInfoReport(t *testing.T) {
 	assert.EqualValues(t, expectedInfoReport, parsed.ParsedInfo)
 }
 
+func TestParseProperMessageNoInfoAttribute(t *testing.T) {
+	data := `{
+		"OrgID": ` + fmt.Sprint(testdata.OrgID) + `,
+		"ClusterName": "` + string(testdata.ClusterName) + `",
+		"LastChecked": "` + testdata.LastCheckedAt.Format(time.RFC3339) + `",
+		"Report": {
+			"system": {
+				"metadata": {},
+				"hostname": null
+			},
+			"reports": [
+				{
+					"component": "` + string(testdata.Rule2ID) + `",
+					"key": "` + testdata.ErrorKey2 + `",
+					"user_vote": 0,
+					"disabled": ` + fmt.Sprint(testdata.Rule2Disabled) + `,
+					"details": ` + helpers.ToJSONString(testdata.Rule2ExtraData) + `
+				}
+			],
+			"fingerprints": [],
+			"skips": []
+		}
+	}`
+	message := sarama.ConsumerMessage{Value: []byte(data)}
+
+	_, err := consumer.ParseMessage(&ocpConsumer, &message)
+	helpers.FailOnError(t, err)
+}
+
 func TestProcessEmptyMessage(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorage(t, true)
 	defer closer()

--- a/consumer/ocp_rules_consumer_test.go
+++ b/consumer/ocp_rules_consumer_test.go
@@ -312,7 +312,6 @@ func TestCheckReportStructureReportWithAllAttributesPresentAndEmpty(t *testing.T
 func TestCheckReportStructureReportWithAnalysisMetadata(t *testing.T) {
 	report := consumer.Report{
 		"system":            unmarshall(`{"metadata": {}, "hostname": null}`),
-		"reports":           unmarshall("[]"),
 		"fingerprints":      unmarshall("[]"),
 		"analysis_metadata": unmarshall(`{"start": "2023-09-11T18:33:14.527845+00:00", "finish": "2023-09-11T18:33:15.632777+00:00"}`),
 	}
@@ -335,7 +334,6 @@ func TestCheckReportStructureReportWithEmptyAndMissingAttributes(t *testing.T) {
 func TestCheckReportStructureReportWithItems(t *testing.T) {
 	report := consumer.Report{
 		"fingerprints": unmarshall("[]"),
-		"info":         unmarshall("[]"),
 		"reports":      unmarshall(string(testdata.Report2Rules)),
 		"skips":        unmarshall("[]"),
 		"system":       unmarshall(`{"metadata": {},"hostname": null}`),

--- a/consumer/processing.go
+++ b/consumer/processing.go
@@ -39,12 +39,12 @@ const (
 	reportAttributeInfo          = "info"
 	reportAttributeFingerprints  = "fingerprints"
 	reportAttributeMetadata      = "analysis_metadata"
-	numberOfExpectedKeysInReport = 4
+	numberOfExpectedKeysInReport = 3 // Number of items in expectedKeysInReport
 )
 
 var (
 	expectedKeysInReport = []string{
-		reportAttributeFingerprints, reportAttributeInfo, reportAttributeReports, reportAttributeSystem,
+		reportAttributeFingerprints, reportAttributeReports, reportAttributeSystem,
 	}
 )
 


### PR DESCRIPTION
# Description

- Remove the `info` attribute from the expected attributes of the report.
  - The attribute will still be present for legacy archives
  - The attribute will not be present for reports for hypershift-enabled cluster
 

Fixes CCXDEV-12709

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Unit tests (no changes in the code)

## Testing steps

CI (UTs + PR check)

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
