### PR TITLE
[CCXDEV-12458][dvo-writer] Fix wrong deployment name in the HPA

### DIFF
--- a/deploy/dvo-writer.yaml
+++ b/deploy/dvo-writer.yaml
@@ -31,7 +31,7 @@ objects:
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment
-      name: dvo-writer
+      name: dvo-writer-instance
     targetCPUUtilizationPercentage: 80
 
 - apiVersion: cloud.redhat.com/v1alpha1


### PR DESCRIPTION
# Description

In our deployment pipelines to stage I've seen

```
[2024-04-29 06:34:10] [ERROR] [openshift_base.py:apply_action:864] - [crcs02ue1/ccx-data-pipeline-stage] [https://api.crcs02ue1.urby.p1.openshiftapps.com:6443/]: The HorizontalPodAutoscaler "dvo-writer" is invalid: 
* spec.minReplicas: Invalid value: 0: must be greater than or equal to 1
* spec.maxReplicas: Invalid value: 0: must be greater than 0
* spec.metrics: Forbidden: must specify at least one Object or External metric to support scaling to zero replicas
 (error details: https://github.com/RedHatInsights/insights-results-aggregator/blob/master/deploy/dvo-writer.yaml)
```

This is not new. I already reported this some time ago in [CCXDEV-12458](https://issues.redhat.com/browse/CCXDEV-12458).

The root cause is simple: the HPA looks for the `dvo-writer` deployment but it doesn't exist. It's called `dvo-writer-instance`. The confusion is normal: the way deployments are called is `clowdapp_name + deployment name`, which can be misleading.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
