### PR TITLE
[CCXDEV-12791] Rename insights-results-smart-proxy to ccx-smart-proxy

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -28,7 +28,7 @@ REF_ENV="insights-production"
 #       git version of clowdapp.yaml(or any other) file from the pull request.
 COMPONENT_NAME="ccx-insights-results ccx-redis dvo-writer"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/insights-results-aggregator"
-COMPONENTS="ccx-data-pipeline ccx-insights-results ccx-redis dvo-writer dvo-extractor insights-content-service insights-results-smart-proxy ccx-mock-ams" # space-separated list of components to load
+COMPONENTS="ccx-data-pipeline ccx-insights-results ccx-redis dvo-writer dvo-extractor insights-content-service ccx-smart-proxy ccx-mock-ams" # space-separated list of components to load
 COMPONENTS_W_RESOURCES=""  # component to keep
 CACHE_FROM_LATEST_IMAGE="true"
 DEPLOY_FRONTENDS="false"


### PR DESCRIPTION
# Description

This rename is needed in order to use the smart-proxy endpoint internally from other AppSRE namespaces. We used to have different app-sre component ID and clowdapp name which made it impossible.

## Type of change

- Configuration update

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
