### PR TITLE
add DVO migration 0004 adding `rule_hits_count` (jsonb) column

### DIFF
--- a/migration/dvomigrations/actual_migrations_test.go
+++ b/migration/dvomigrations/actual_migrations_test.go
@@ -15,12 +15,33 @@
 package dvomigrations_test
 
 import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
 	"testing"
+
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/RedHatInsights/insights-results-aggregator/migration"
 	"github.com/RedHatInsights/insights-results-aggregator/migration/dvomigrations"
 	"github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
 )
+
+type ruleHitsCount map[string]int
+
+func (in ruleHitsCount) Value() (driver.Value, error) {
+	return json.Marshal(in)
+}
+
+func (in *ruleHitsCount) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("not byte array")
+	}
+
+	return json.Unmarshal(b, &in)
+}
 
 func TestAllMigrations(t *testing.T) {
 	db, closer := helpers.PrepareDBDVO(t)
@@ -38,4 +59,70 @@ func TestAllMigrations(t *testing.T) {
 	// downgrade back to 0
 	err = migration.SetDBVersion(dbConn, db.GetDBDriverType(), dbSchema, migration.Version(0), dvomigrations.UsableDVOMigrations)
 	helpers.FailOnError(t, err)
+}
+
+func Test0004RuleHitsCount(t *testing.T) {
+	db, closer := helpers.PrepareDBDVO(t)
+	defer closer()
+
+	dbConn := db.GetConnection()
+	dbSchema := db.GetDBSchema()
+
+	err := migration.SetDBVersion(dbConn, db.GetDBDriverType(), dbSchema, migration.Version(3), dvomigrations.UsableDVOMigrations)
+	helpers.FailOnError(t, err)
+
+	// insert before mig 0004 to test that default values are parsable
+	_, err = dbConn.Exec(`
+	INSERT INTO dvo.dvo_report (org_id, cluster_id, namespace_id, recommendations, objects) VALUES ($1, $2, $3, $4, $5);
+	`,
+		testdata.OrgID,
+		testdata.ClusterName,
+		"namespace",
+		1,
+		2,
+	)
+	helpers.FailOnError(t, err)
+
+	err = migration.SetDBVersion(dbConn, db.GetDBDriverType(), dbSchema, migration.Version(4), dvomigrations.UsableDVOMigrations)
+	helpers.FailOnError(t, err)
+
+	var ruleHits ruleHitsCount
+	err = dbConn.QueryRow(`
+		SELECT rule_hits_count FROM dvo.dvo_report WHERE cluster_id = $1;`,
+		testdata.ClusterName,
+	).Scan(
+		&ruleHits,
+	)
+
+	helpers.FailOnError(t, err)
+	// must be valid parsable json for existing rows
+	assert.Equal(t, "{}", helpers.ToJSONString(ruleHits))
+
+	cID := testdata.GetRandomClusterID()
+
+	ruleHitsInput := ruleHitsCount{
+		string(testdata.Rule1CompositeID): 1,
+	}
+	// insert a struct directly, implemented Value() method will take care of marshalling, validation, ..
+	_, err = dbConn.Exec(`
+	INSERT INTO dvo.dvo_report (org_id, cluster_id, namespace_id, recommendations, objects, rule_hits_count) VALUES ($1, $2, $3, $4, $5, $6);
+	`,
+		testdata.OrgID,
+		cID,
+		"namespace",
+		1,
+		2,
+		ruleHitsInput,
+	)
+	helpers.FailOnError(t, err)
+
+	err = dbConn.QueryRow(`
+	SELECT rule_hits_count FROM dvo.dvo_report WHERE cluster_id = $1;`,
+		cID,
+	).Scan(
+		&ruleHits,
+	)
+
+	helpers.FailOnError(t, err)
+	assert.Equal(t, ruleHitsInput, ruleHits)
 }

--- a/migration/dvomigrations/dvo_migrations.go
+++ b/migration/dvomigrations/dvo_migrations.go
@@ -7,4 +7,5 @@ var UsableDVOMigrations = []migration.Migration{
 	mig0001CreateDVOReport,
 	mig0002CreateDVOReportIndexes,
 	mig0003CCXDEV12602DeleteBuggyRecords,
+	mig0004AddRuleHitsCount,
 }

--- a/migration/dvomigrations/mig_0004_rule_hits_count_column.go
+++ b/migration/dvomigrations/mig_0004_rule_hits_count_column.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dvomigrations
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/migration"
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+var mig0004AddRuleHitsCount = migration.Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		_, err := tx.Exec(`
+			ALTER TABLE dvo.dvo_report ADD COLUMN rule_hits_count JSONB DEFAULT '{}';
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec(`
+			COMMENT ON COLUMN dvo.dvo_report.rule_hits_count IS 'JSON containing rule IDs and the number of hits for each rule';
+		`)
+
+		return err
+	},
+	StepDown: func(tx *sql.Tx, _ types.DBDriver) error {
+		_, err := tx.Exec(`ALTER TABLE dvo.dvo_report DROP COLUMN IF EXISTS rule_hits_count;`)
+		return err
+	},
+}


### PR DESCRIPTION
# Description
New DB column needed to satisfy new columns in Advisor UI (Hits by severity, Highest severity).

Uses [jsonb type](https://www.postgresql.org/docs/current/datatype-json.html), which is nice to work with using `sql.DB` by implementing `Value()` and `Scan()` or other [methods on a type](https://github.com/RedHatInsights/insights-results-aggregator/compare/master...Bee-lee:insights-results-aggregator:dbily-3oifn?expand=1#diff-c1e517c8a52d72648a957142c21262350eff214ace43c20d78ccdc1d591bf90dR33). This ensures we only have valid/expected values in this JSON column.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
locally with imported data

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
