### PR TITLE
Support for `docker compose` plugin

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,7 +57,7 @@ By default all logs from the application aren't shown, if you want to see them, 
 
 To make a coverage report you need to start `./make-coverage.sh` tool with one of these arguments:
 
-1. `unit-posgres` unit tests with postgres database(don't forget to start `docker-compose up` with the DB)
+1. `unit-postgres` unit tests with postgres database(don't forget to start `docker-compose up` with the DB)
 1. `rest` REST API tests from `test.sh` file
 1. `integration` Any external tests, for example from iqe-ccx-plugin.
 Only this option requires you to run tests manually and stop the script by `Ctrl+C` when they are done

--- a/make-coverage.sh
+++ b/make-coverage.sh
@@ -21,9 +21,6 @@ rm coverage.out 2>/dev/null
 
 case $1 in
 "unit-postgres")
-    export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB="postgres"
-    export INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS="admin"
-
     echo "Running unit tests with postgres..."
     go test -timeout $TIMEOUT -coverprofile=coverage.out ./... 1>&2
     ;;

--- a/tests/helpers/mock_storage.go
+++ b/tests/helpers/mock_storage.go
@@ -17,7 +17,6 @@ package helpers
 import (
 	"database/sql"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -116,8 +115,6 @@ func MustCloseMockDBWithExpects(
 
 // MustGetPostgresStorage creates test postgres storage with credentials from config-devel
 func MustGetPostgresStorage(tb testing.TB, init bool) (storage.OCPRecommendationsStorage, func()) {
-	dbAdminPassword := os.Getenv("INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS")
-
 	err := conf.LoadConfiguration("../config-devel")
 	helpers.FailOnError(tb, err)
 
@@ -125,7 +122,6 @@ func MustGetPostgresStorage(tb testing.TB, init bool) (storage.OCPRecommendation
 	storageConf := &conf.Config.OCPRecommendationsStorage
 	storageConf.Driver = postgres
 	storageConf.PGDBName += "_test_db_" + strings.ReplaceAll(uuid.New().String(), "-", "_")
-	storageConf.PGPassword = dbAdminPassword
 
 	connString := fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s sslmode=disable",
@@ -161,8 +157,6 @@ func MustGetPostgresStorage(tb testing.TB, init bool) (storage.OCPRecommendation
 
 // MustGetPostgresStorageDVO creates test postgres storage with credentials from config-devel for DVO storage
 func MustGetPostgresStorageDVO(tb testing.TB, init bool) (storage.DVORecommendationsStorage, func()) {
-	dbAdminPassword := os.Getenv("INSIGHTS_RESULTS_AGGREGATOR__TESTS_DB_ADMIN_PASS")
-
 	err := conf.LoadConfiguration("../config-devel")
 	helpers.FailOnError(tb, err)
 
@@ -170,7 +164,6 @@ func MustGetPostgresStorageDVO(tb testing.TB, init bool) (storage.DVORecommendat
 	storageConf := &conf.Config.DVORecommendationsStorage
 	storageConf.Driver = postgres
 	storageConf.PGDBName += "_test_db_" + strings.ReplaceAll(uuid.New().String(), "-", "_")
-	storageConf.PGPassword = dbAdminPassword
 
 	connString := fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s sslmode=disable",


### PR DESCRIPTION
# Description

Adding support for `docker compose` plugin instead of `docker-compose` or `podman-compose` commands if available.

Removing some unneeded env vars that makes it more difficult to run the tests from IDEs

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

To be tested by CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
