### PR TITLE
[CCXDEV-12524] Fix key used in rule hits count map

### DIFF
--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -34,8 +34,6 @@ import (
 
 const (
 	namespaceIDParam = "namespace"
-	// RecommendationSuffix is used to strip a suffix from rule ID
-	RecommendationSuffix = ".recommendation"
 )
 
 // Cluster structure contains cluster UUID and cluster name
@@ -302,7 +300,7 @@ func (server *HTTPServer) ProcessSingleDVONamespace(workload types.DVOReport) (
 		// recommendation.ResponseID doesn't contain the full rule ID, so smart-proxy was unable to retrieve content, we need to build it
 		compositeRuleID, err := generators.GenerateCompositeRuleID(
 			// for some unknown reason, there's a `.recommendation` suffix for each rule hit instead of the usual .report
-			types.RuleFQDN(strings.TrimSuffix(recommendation.Component, RecommendationSuffix)),
+			types.RuleFQDN(strings.TrimSuffix(recommendation.Component, types.WorkloadRecommendationSuffix)),
 			types.ErrorKey(recommendation.Key),
 		)
 		if err != nil {

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -374,6 +374,30 @@ func (storage DVORecommendationsDBStorage) updateReport(
 	return nil
 }
 
+// updateRuleHitsCountsForNamespace updates the rule hits for given namespace based on the given recommendation
+func updateRuleHitsCountsForNamespace(ruleHitsCounts map[string]types.RuleHitsCount, namespaceUID string, recommendation types.WorkloadRecommendation) {
+	if _, ok := ruleHitsCounts[namespaceUID]; !ok {
+		ruleHitsCounts[namespaceUID] = make(types.RuleHitsCount)
+	}
+
+	// define key in rule hits counts map as concatenation of rule component and key
+	compositeRuleID, err := generators.GenerateCompositeRuleID(
+		// for some unknown reason, there's a `.recommendation` suffix for each rule hit instead of the usual .report
+		types.RuleFQDN(strings.TrimSuffix(recommendation.Component, types.WorkloadRecommendationSuffix)),
+		types.ErrorKey(recommendation.Key),
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("error generating composite rule ID for rule")
+		return
+	}
+
+	compositeRuleIDString := string(compositeRuleID)
+	if _, ok := ruleHitsCounts[namespaceUID][compositeRuleIDString]; !ok {
+		ruleHitsCounts[namespaceUID][compositeRuleIDString] = 0
+	}
+	ruleHitsCounts[namespaceUID][compositeRuleIDString]++
+}
+
 // mapWorkloadRecommendations filters out the data which is grouped by recommendations and aggregates
 // them by namespace.
 // Essentially we need to "invert" data from:
@@ -408,26 +432,7 @@ func mapWorkloadRecommendations(recommendations *[]types.WorkloadRecommendation)
 			// per single recommendation within namespace
 			objectsPerRecommendation[workload.NamespaceUID]++
 
-			if _, ok := ruleHitsCounts[workload.NamespaceUID]; !ok {
-				ruleHitsCounts[workload.NamespaceUID] = make(types.RuleHitsCount)
-			}
-
-			// define key in rule hits counts map as concatenation of rule component and key
-			compositeRuleID, err := generators.GenerateCompositeRuleID(
-				// for some unknown reason, there's a `.recommendation` suffix for each rule hit instead of the usual .report
-				types.RuleFQDN(strings.TrimSuffix(recommendation.Component, types.WorkloadRecommendationSuffix)),
-				types.ErrorKey(recommendation.Key),
-			)
-			if err != nil {
-				log.Error().Err(err).Msg("error generating composite rule ID for rule")
-				continue
-			}
-
-			compositeRuleIDString := string(compositeRuleID)
-			if _, ok := ruleHitsCounts[workload.NamespaceUID][compositeRuleIDString]; !ok {
-				ruleHitsCounts[workload.NamespaceUID][compositeRuleIDString] = 0
-			}
-			ruleHitsCounts[workload.NamespaceUID][compositeRuleIDString]++
+			updateRuleHitsCountsForNamespace(ruleHitsCounts, workload.NamespaceUID, recommendation)
 
 			// per whole namespace; just workload IDs with empty structs to filter out duplicate objects
 			if _, ok := objectsPerNamespace[workload.NamespaceUID]; !ok {

--- a/types/types.go
+++ b/types/types.go
@@ -56,6 +56,8 @@ const (
 	UserVoteNone = types.UserVoteNone
 	// UserVoteLike shows user's like
 	UserVoteLike = types.UserVoteLike
+	// WorkloadRecommendationSuffix is used to strip a suffix from rule ID (Component attribute) in WorkloadRecommendation
+	WorkloadRecommendationSuffix = ".recommendation"
 )
 
 type (


### PR DESCRIPTION
# Description

Key used in rule hits counts should not be response ID, but concatenation of rule component and key. Key is thus now in format `ccx_rules_ocp.external.dvo.rule|RULE_KEY`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Changes were manually tested locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
