### PR TITLE
Fix wrong creation of impactedSince map

### DIFF
--- a/consumer/ocp_rules_consumer_test.go
+++ b/consumer/ocp_rules_consumer_test.go
@@ -504,7 +504,6 @@ func TestParseProperMessageWithInfoReport(t *testing.T) {
 				"links": {}
 			  }
 		]
-
 	}`
 	message := sarama.ConsumerMessage{Value: []byte(createConsumerMessage(consumerReport))}
 	parsed, err := consumer.ParseMessage(&ocpConsumer, &message)

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -85,3 +85,7 @@ func InsertRecommendations(
 	_ = tx.Commit()
 	return inserted, nil
 }
+
+func GetRuleKeyCreatedAtMap(storage *OCPRecommendationsDBStorage, query string, orgID types.OrgID, clusterName types.ClusterName) (map[string]types.Timestamp, error) {
+	return storage.getRuleKeyCreatedAtMap(query, orgID, clusterName)
+}

--- a/storage/export_test.go
+++ b/storage/export_test.go
@@ -89,3 +89,7 @@ func InsertRecommendations(
 func GetRuleKeyCreatedAtMap(storage *OCPRecommendationsDBStorage, query string, orgID types.OrgID, clusterName types.ClusterName) (map[string]types.Timestamp, error) {
 	return storage.getRuleKeyCreatedAtMap(query, orgID, clusterName)
 }
+
+func GetRuleKeyCreatedAtMapForTable(storage *OCPRecommendationsDBStorage, table string, orgID types.OrgID, clusterName types.ClusterName) (map[string]types.Timestamp, error) {
+	return storage.getRuleKeyCreatedAtMapForTable(table, orgID, clusterName)
+}

--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -234,6 +234,12 @@ const (
 
 	// ocpDBSchema uses the default public schema in all queries/migrations and all environments
 	ocpDBSchema = "public"
+
+	// Query for getting creation timestamp in rule_hit table for given Org + Cluster
+	selectRuleCreatedAtQuery = `SELECT rule_fqdn, error_key, created_at FROM rule_hit WHERE org_id = $1 AND cluster_id = $2;`
+
+	// Query for getting creation timestamp in recommendation table for impacted_since Org + Cluster
+	selectRuleImpactedSinceQuery = `SELECT rule_fqdn, error_key, impacted_since FROM recommendation WHERE org_id = $1 AND cluster_id = $2;`
 )
 
 // OCPRecommendationsDBStorage is an implementation of Storage interface that use selected SQL like database
@@ -912,6 +918,31 @@ func (storage OCPRecommendationsDBStorage) GetRuleHitInsertStatement(rules []typ
 	return fmt.Sprintf(ruleInsertStatement, strings.Join(placeholders, ","))
 }
 
+func (storage OCPRecommendationsDBStorage) getRuleKeyCreatedAtMapForTable(table string, orgID types.OrgID, clusterName types.ClusterName) (
+	RuleKeyCreatedAt map[string]types.Timestamp,
+	err error) {
+	// Switch case to select the appropriate query based on the table name
+	switch table {
+	case "rule_hit":
+		RuleKeyCreatedAt, err = storage.getRuleKeyCreatedAtMap(
+			selectRuleCreatedAtQuery, orgID, clusterName,
+		)
+	case "recommendation":
+		RuleKeyCreatedAt, err = storage.getRuleKeyCreatedAtMap(
+			selectRuleImpactedSinceQuery, orgID, clusterName,
+		)
+	default:
+		log.Error().Err(err).Str("tableName", table).Msg("Unexpected table to get ruleCreatedAtMap")
+		return
+	}
+
+	if err != nil {
+		log.Error().Err(err).Str("tableName", table).Msg("Unable to generate ruleCreatedAtMap")
+		return
+	}
+	return
+}
+
 // valuesForRuleHitsInsert function prepares values to insert rules into
 // rule_hit table.
 func valuesForRuleHitsInsert(
@@ -955,9 +986,8 @@ func (storage OCPRecommendationsDBStorage) updateReport(
 	reportUpsertQuery := storage.getReportUpsertQuery()
 
 	// Get created_at if present before deletion
-	query := "SELECT rule_fqdn, error_key, created_at FROM rule_hit WHERE org_id = $1 AND cluster_id = $2;"
-	RuleKeyCreatedAt, err := storage.getRuleKeyCreatedAtMap(
-		query, orgID, clusterName,
+	RuleKeyCreatedAt, err := storage.getRuleKeyCreatedAtMapForTable(
+		"rule_hit", orgID, clusterName,
 	)
 	if err != nil {
 		log.Error().Err(err).Msgf("Unable to get recommendation impacted_since")
@@ -1208,9 +1238,8 @@ func (storage OCPRecommendationsDBStorage) WriteRecommendationsForCluster(
 		// Delete current recommendations for the cluster if some report has been previously stored for this cluster
 		if _, ok := storage.clustersLastChecked[clusterName]; ok {
 			// Get impacted_since if present
-			query := "SELECT rule_fqdn, error_key, impacted_since FROM recommendation WHERE org_id = $1 AND cluster_id = $2;"
-			impactedSinceMap, err = storage.getRuleKeyCreatedAtMap(
-				query, orgID, clusterName)
+			impactedSinceMap, err = storage.getRuleKeyCreatedAtMapForTable(
+				"recommendation", orgID, clusterName)
 			if err != nil {
 				log.Error().Err(err).Msgf("Unable to get recommendation impacted_since")
 			}

--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -1208,13 +1208,12 @@ func (storage OCPRecommendationsDBStorage) WriteRecommendationsForCluster(
 		// Delete current recommendations for the cluster if some report has been previously stored for this cluster
 		if _, ok := storage.clustersLastChecked[clusterName]; ok {
 			// Get impacted_since if present
-			query := "SELECT rule_fqdn, error_key, impacted_since FROM recommendation WHERE org_id = $1 AND cluster_id = $2 LIMIT 1;"
+			query := "SELECT rule_fqdn, error_key, impacted_since FROM recommendation WHERE org_id = $1 AND cluster_id = $2;"
 			impactedSinceMap, err = storage.getRuleKeyCreatedAtMap(
 				query, orgID, clusterName)
 			if err != nil {
 				log.Error().Err(err).Msgf("Unable to get recommendation impacted_since")
 			}
-
 			// it is needed to use `org_id = $1` condition there
 			// because it allows DB to use proper btree indexing
 			// and not slow sequential scan

--- a/storage/ocp_recommendations_storage_test.go
+++ b/storage/ocp_recommendations_storage_test.go
@@ -1207,17 +1207,17 @@ func Test_CCXDEV_10244_DBStorageGetImpactedSinceMap(t *testing.T) {
 	}
 	assert.Equal(t, expectResp, res)
 
-	//We have 3 recommendations with different rule FQDN for this Org ID + Clustername
+	// We have 3 recommendations with different rule FQDN for this Org ID + Clustername
+	// Therefore, we expect 3 entries in the RuleKeyCreatedAtMap
 
-	//query used before fix.
+	// query used before fix.
 	query := "SELECT rule_fqdn, error_key, created_at FROM recommendation WHERE org_id = $1 AND cluster_id = $2 LIMIT 1;"
 	rkcMap, err := storage.GetRuleKeyCreatedAtMap(mockStorage.(*storage.OCPRecommendationsDBStorage), query, testdata.OrgID, testdata.ClusterName)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, len(rkcMap), 1)
 
 	//query used after fix, without limiting number of rows retrieved from the DB
-	query = "SELECT rule_fqdn, error_key, created_at FROM recommendation WHERE org_id = $1 AND cluster_id = $2;"
-	rkcMap, err = storage.GetRuleKeyCreatedAtMap(mockStorage.(*storage.OCPRecommendationsDBStorage), query, testdata.OrgID, testdata.ClusterName)
+	rkcMap, err = storage.GetRuleKeyCreatedAtMapForTable(mockStorage.(*storage.OCPRecommendationsDBStorage), "recommendation", testdata.OrgID, testdata.ClusterName)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, len(rkcMap), 3)
 }


### PR DESCRIPTION
# Description

Remove the `LIMIT 1` from the select query. I think what was intended is to select only distinct results, which is not needed neither as the rows have a unique combination `org ID` + `cluster ID` + `rule FQDN` + `error key`.

With this fix, the `impactedSince` map contains an entry for all the rows that exist in the `recommendation `table for a given `org ID + cluster ID`, which ensures the timestamp is conserved for a previously hitting rule.

Fixes CCXDEV-10244

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
