### PR TITLE
`ReadWorkloadsForOrganization()` returns needed type directly instead of copying

### DIFF
--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -119,17 +119,10 @@ func (server *HTTPServer) getWorkloads(writer http.ResponseWriter, request *http
 		return
 	}
 
-	copyStart := time.Now()
-	log.Debug().Msg("processing database workloads into response")
-	processedWorkloads := server.processDVOWorkloads(workloads)
-
-	log.Debug().Uint32(orgIDStr, uint32(orgID)).Msgf(
-		"processDVOWorkloads took %s", time.Since(copyStart),
-	)
 	log.Debug().Uint32(orgIDStr, uint32(orgID)).Msgf(
 		"getWorkloads took %s", time.Since(tStart),
 	)
-	err = responses.SendOK(writer, responses.BuildOkResponseWithData("workloads", processedWorkloads))
+	err = responses.SendOK(writer, responses.BuildOkResponseWithData("workloads", workloads))
 	if err != nil {
 		log.Error().Err(err).Msg(responseDataError)
 	}

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -36,42 +36,12 @@ const (
 	namespaceIDParam = "namespace"
 )
 
-// Cluster structure contains cluster UUID and cluster name
-type Cluster struct {
-	UUID        string `json:"uuid"`
-	DisplayName string `json:"display_name"`
-}
-
-// Namespace structure contains basic information about namespace
-type Namespace struct {
-	UUID string `json:"uuid"`
-	Name string `json:"name"`
-}
-
-// Metadata structure contains basic information about workload metadata
-type Metadata struct {
-	Recommendations int         `json:"recommendations"`
-	Objects         int         `json:"objects"`
-	ReportedAt      string      `json:"reported_at"`
-	LastCheckedAt   string      `json:"last_checked_at"`
-	HighestSeverity int         `json:"highest_severity"`
-	HitsBySeverity  map[int]int `json:"hits_by_severity"`
-}
-
-// WorkloadsForNamespace structure represents a single entry of the namespace list with some aggregations
-type WorkloadsForNamespace struct {
-	Cluster                 Cluster             `json:"cluster"`
-	Namespace               Namespace           `json:"namespace"`
-	Metadata                Metadata            `json:"metadata"`
-	RecommendationsHitCount types.RuleHitsCount `json:"recommendations_hit_count"`
-}
-
 // WorkloadsForCluster structure represents workload for one selected cluster
 type WorkloadsForCluster struct {
 	Status          string              `json:"status"`
-	Cluster         Cluster             `json:"cluster"`
-	Namespace       Namespace           `json:"namespace"`
-	Metadata        Metadata            `json:"metadata"`
+	Cluster         types.Cluster       `json:"cluster"`
+	Namespace       types.Namespace     `json:"namespace"`
+	Metadata        types.DVOMetadata   `json:"metadata"`
 	Recommendations []DVORecommendation `json:"recommendations"`
 }
 
@@ -166,7 +136,7 @@ func (server *HTTPServer) getWorkloads(writer http.ResponseWriter, request *http
 }
 
 func (server *HTTPServer) processDVOWorkloads(workloads []types.DVOReport) (
-	processedWorkloads []WorkloadsForNamespace,
+	processedWorkloads []types.WorkloadsForNamespace,
 ) {
 	log.Debug().Int("workloadsLen", len(workloads)).Msg("Length of the workloads to process")
 	for _, workload := range workloads {
@@ -174,15 +144,15 @@ func (server *HTTPServer) processDVOWorkloads(workloads []types.DVOReport) (
 			Str("ClusterID", workload.ClusterID).Str("Namespace", workload.NamespaceID).
 			Msg("Length of the workloads to process")
 
-		processedWorkloads = append(processedWorkloads, WorkloadsForNamespace{
-			Cluster: Cluster{
+		processedWorkloads = append(processedWorkloads, types.WorkloadsForNamespace{
+			Cluster: types.Cluster{
 				UUID: workload.ClusterID,
 			},
-			Namespace: Namespace{
+			Namespace: types.Namespace{
 				UUID: workload.NamespaceID,
 				Name: workload.NamespaceName,
 			},
-			Metadata: Metadata{
+			Metadata: types.DVOMetadata{
 				Recommendations: int(workload.Recommendations),
 				Objects:         int(workload.Objects),
 				ReportedAt:      string(workload.ReportedAt),
@@ -241,14 +211,14 @@ func (server *HTTPServer) ProcessSingleDVONamespace(workload types.DVOReport) (
 	processedWorkloads WorkloadsForCluster,
 ) {
 	processedWorkloads = WorkloadsForCluster{
-		Cluster: Cluster{
+		Cluster: types.Cluster{
 			UUID: workload.ClusterID,
 		},
-		Namespace: Namespace{
+		Namespace: types.Namespace{
 			UUID: workload.NamespaceID,
 			Name: workload.NamespaceName,
 		},
-		Metadata: Metadata{
+		Metadata: types.DVOMetadata{
 			Recommendations: int(workload.Recommendations),
 			Objects:         int(workload.Objects),
 			ReportedAt:      string(workload.ReportedAt),

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -128,36 +128,6 @@ func (server *HTTPServer) getWorkloads(writer http.ResponseWriter, request *http
 	}
 }
 
-func (server *HTTPServer) processDVOWorkloads(workloads []types.DVOReport) (
-	processedWorkloads []types.WorkloadsForNamespace,
-) {
-	log.Debug().Int("workloadsLen", len(workloads)).Msg("Length of the workloads to process")
-	for _, workload := range workloads {
-		log.Debug().Int("hitCount", len(workload.RuleHitsCount)).
-			Str("ClusterID", workload.ClusterID).Str("Namespace", workload.NamespaceID).
-			Msg("Length of the workloads to process")
-
-		processedWorkloads = append(processedWorkloads, types.WorkloadsForNamespace{
-			Cluster: types.Cluster{
-				UUID: workload.ClusterID,
-			},
-			Namespace: types.Namespace{
-				UUID: workload.NamespaceID,
-				Name: workload.NamespaceName,
-			},
-			Metadata: types.DVOMetadata{
-				Recommendations: int(workload.Recommendations),
-				Objects:         int(workload.Objects),
-				ReportedAt:      string(workload.ReportedAt),
-				LastCheckedAt:   string(workload.LastCheckedAt),
-			},
-			RecommendationsHitCount: workload.RuleHitsCount,
-		})
-	}
-
-	return
-}
-
 // getWorkloadsForNamespace retrieves data about a single namespace within a cluster
 func (server *HTTPServer) getWorkloadsForNamespace(writer http.ResponseWriter, request *http.Request) {
 	tStart := time.Now()

--- a/server/dvo_handlers_test.go
+++ b/server/dvo_handlers_test.go
@@ -83,7 +83,7 @@ var (
 func workloadInResponseChecker(t testing.TB, expected, got []byte) {
 	type Response struct {
 		Status    string `json:"string"`
-		Workloads []server.WorkloadsForNamespace
+		Workloads []types.WorkloadsForNamespace
 	}
 
 	var expectedResp Response
@@ -234,15 +234,15 @@ func TestGetWorkloadsOK(t *testing.T) {
 	)
 	helpers.FailOnError(t, err)
 
-	workload := server.WorkloadsForNamespace{
-		Cluster: server.Cluster{
+	workload := types.WorkloadsForNamespace{
+		Cluster: types.Cluster{
 			UUID: string(testdata.ClusterName),
 		},
-		Namespace: server.Namespace{
+		Namespace: types.Namespace{
 			UUID: ira_data.NamespaceAUID,
 			Name: "namespace-name-A",
 		},
-		Metadata: server.Metadata{
+		Metadata: types.DVOMetadata{
 			Recommendations: 1,
 			Objects:         1,
 			ReportedAt:      now.UTC().Format(time.RFC3339),
@@ -259,7 +259,7 @@ func TestGetWorkloadsOK(t *testing.T) {
 		EndpointArgs: []interface{}{testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
-		Body:       `{"status":"ok","workloads":` + helpers.ToJSONString([]server.WorkloadsForNamespace{workload}) + `}`,
+		Body:       `{"status":"ok","workloads":` + helpers.ToJSONString([]types.WorkloadsForNamespace{workload}) + `}`,
 	})
 }
 
@@ -292,16 +292,16 @@ func TestGetWorkloadsOK_TwoNamespaces(t *testing.T) {
 	)
 	helpers.FailOnError(t, err)
 
-	workloads := []server.WorkloadsForNamespace{
+	workloads := []types.WorkloadsForNamespace{
 		{
-			Cluster: server.Cluster{
+			Cluster: types.Cluster{
 				UUID: string(testdata.ClusterName),
 			},
-			Namespace: server.Namespace{
+			Namespace: types.Namespace{
 				UUID: ira_data.NamespaceAUID,
 				Name: "namespace-name-A",
 			},
-			Metadata: server.Metadata{
+			Metadata: types.DVOMetadata{
 				Recommendations: 1,
 				Objects:         1,
 				ReportedAt:      now.UTC().Format(time.RFC3339),
@@ -312,14 +312,14 @@ func TestGetWorkloadsOK_TwoNamespaces(t *testing.T) {
 			},
 		},
 		{
-			Cluster: server.Cluster{
+			Cluster: types.Cluster{
 				UUID: string(testdata.ClusterName),
 			},
-			Namespace: server.Namespace{
+			Namespace: types.Namespace{
 				UUID: ira_data.NamespaceBUID,
 				Name: "namespace-name-B",
 			},
-			Metadata: server.Metadata{
+			Metadata: types.DVOMetadata{
 				Recommendations: 1,
 				Objects:         1,
 				ReportedAt:      now.UTC().Format(time.RFC3339),

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -399,14 +399,14 @@ func TestDVOStorageReadWorkloadsForOrganization(t *testing.T) {
 	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID)
 	helpers.FailOnError(t, err)
 
-	assert.Equal(t, testdata.ClusterName, types.ClusterName(workloads[0].ClusterID))
-	assert.Equal(t, testdata.ClusterName, types.ClusterName(workloads[1].ClusterID))
-	assert.Equal(t, types.Timestamp(nowAfterOneHour.UTC().Format(time.RFC3339)), workloads[0].LastCheckedAt)
-	assert.Equal(t, types.Timestamp(nowAfterOneHour.UTC().Format(time.RFC3339)), workloads[1].LastCheckedAt)
-	assert.Equal(t, types.Timestamp(now.UTC().Format(time.RFC3339)), workloads[0].ReportedAt)
-	assert.Equal(t, types.Timestamp(now.UTC().Format(time.RFC3339)), workloads[1].ReportedAt)
-	assert.Equal(t, types.RuleHitsCount{"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1}, workloads[0].RuleHitsCount)
-	assert.Equal(t, types.RuleHitsCount{"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1}, workloads[1].RuleHitsCount)
+	assert.Equal(t, testdata.ClusterName, types.ClusterName(workloads[0].Cluster.UUID))
+	assert.Equal(t, testdata.ClusterName, types.ClusterName(workloads[1].Cluster.UUID))
+	assert.Equal(t, types.Timestamp(nowAfterOneHour.UTC().Format(time.RFC3339)), workloads[0].Metadata.LastCheckedAt)
+	assert.Equal(t, types.Timestamp(nowAfterOneHour.UTC().Format(time.RFC3339)), workloads[1].Metadata.LastCheckedAt)
+	assert.Equal(t, types.Timestamp(now.UTC().Format(time.RFC3339)), workloads[0].Metadata.ReportedAt)
+	assert.Equal(t, types.Timestamp(now.UTC().Format(time.RFC3339)), workloads[1].Metadata.ReportedAt)
+	assert.Equal(t, types.RuleHitsCount{"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1}, workloads[0].RecommendationsHitCount)
+	assert.Equal(t, types.RuleHitsCount{"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1}, workloads[1].RecommendationsHitCount)
 }
 
 // TestDVOStorageReadWorkloadsForNamespace tests timestamps being kept correctly

--- a/storage/noop_dvo_recommendations_storage.go
+++ b/storage/noop_dvo_recommendations_storage.go
@@ -79,7 +79,7 @@ func (*NoopDVOStorage) WriteReportForCluster(
 }
 
 // ReadWorkloadsForOrganization noop
-func (*NoopDVOStorage) ReadWorkloadsForOrganization(types.OrgID) ([]types.DVOReport, error) {
+func (*NoopDVOStorage) ReadWorkloadsForOrganization(types.OrgID) ([]types.WorkloadsForNamespace, error) {
 	return nil, nil
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -210,6 +210,36 @@ type DVOReport struct {
 	RuleHitsCount   RuleHitsCount   `json:"rule_hits_count"`
 }
 
+// Cluster structure contains cluster UUID and cluster name
+type Cluster struct {
+	UUID        string `json:"uuid"`
+	DisplayName string `json:"display_name"`
+}
+
+// Namespace structure contains basic information about namespace
+type Namespace struct {
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+}
+
+// DVOMetadata structure contains basic information about workload metadata
+type DVOMetadata struct {
+	Recommendations int         `json:"recommendations"`
+	Objects         int         `json:"objects"`
+	ReportedAt      string      `json:"reported_at"`
+	LastCheckedAt   string      `json:"last_checked_at"`
+	HighestSeverity int         `json:"highest_severity"`
+	HitsBySeverity  map[int]int `json:"hits_by_severity"`
+}
+
+// WorkloadsForNamespace structure represents a single entry of the namespace list with some aggregations
+type WorkloadsForNamespace struct {
+	Cluster                 Cluster       `json:"cluster"`
+	Namespace               Namespace     `json:"namespace"`
+	Metadata                DVOMetadata   `json:"metadata"`
+	RecommendationsHitCount RuleHitsCount `json:"recommendations_hit_count"`
+}
+
 // ClusterReports is a data structure containing list of clusters, list of
 // errors and dictionary with results per cluster.
 type ClusterReports = types.ClusterReports


### PR DESCRIPTION
# Description
The `ReadWorkloadsForOrganization()` storage function is not used anywhere else, so we can use the structs needed in the `server` part directly, instead of copying the whole results set.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
