### PR TITLE
active cluster list filtering in `DVOWorkloadRecommendations` endpoint

### DIFF
--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -113,7 +113,13 @@ func (server *HTTPServer) getWorkloads(writer http.ResponseWriter, request *http
 	}
 	log.Debug().Int(orgIDStr, int(orgID)).Msg("getWorkloads")
 
-	workloads, err := server.StorageDvo.ReadWorkloadsForOrganization(orgID)
+	// try to read map of cluster IDs from request body
+	clusterMap, successful := ReadClusterMapFromBody(writer, request)
+	if !successful {
+		// wrong state has been handled already
+		return
+	}
+	workloads, err := server.StorageDvo.ReadWorkloadsForOrganization(orgID, clusterMap)
 	if err != nil {
 		log.Error().Err(err).Msg("Errors retrieving DVO workload recommendations from storage")
 		handleServerError(writer, err)

--- a/server/dvo_handlers_test.go
+++ b/server/dvo_handlers_test.go
@@ -256,10 +256,10 @@ func TestGetWorkloadsOK(t *testing.T) {
 	}
 
 	ira_helpers.AssertAPIRequestDVO(t, mockStorage, nil, &helpers.APIRequest{
-		Method:       http.MethodGet,
+		Method:       http.MethodPost,
 		Endpoint:     server.DVOWorkloadRecommendations,
 		EndpointArgs: []interface{}{testdata.OrgID},
-		Body:         fmt.Sprintf(`{[%v]}`, testdata.ClusterName),
+		Body:         fmt.Sprintf(`["%v"]`, testdata.ClusterName),
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       `{"status":"ok","workloads":` + helpers.ToJSONString([]types.WorkloadsForNamespace{workload}) + `}`,
@@ -276,6 +276,72 @@ func TestGetWorkloads_NoData(t *testing.T) {
 		EndpointArgs: []interface{}{testdata.OrgID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
+	})
+}
+
+func TestGetWorkloadsOK_TwoNamespacesGet(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
+	defer closer()
+
+	err := mockStorage.WriteReportForCluster(
+		testdata.OrgID,
+		testdata.ClusterName,
+		types.ClusterReport(ira_data.ValidReport),
+		ira_data.TwoNamespacesRecommendation,
+		now,
+		now,
+		now,
+		testdata.RequestID1,
+	)
+	helpers.FailOnError(t, err)
+
+	workloads := []types.WorkloadsForNamespace{
+		{
+			Cluster: types.Cluster{
+				UUID: string(testdata.ClusterName),
+			},
+			Namespace: types.Namespace{
+				UUID: ira_data.NamespaceAUID,
+				Name: "namespace-name-A",
+			},
+			Metadata: types.DVOMetadata{
+				Recommendations: 1,
+				Objects:         1,
+				ReportedAt:      now.UTC().Format(time.RFC3339),
+				LastCheckedAt:   now.UTC().Format(time.RFC3339),
+			},
+			RecommendationsHitCount: types.RuleHitsCount{
+				"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1,
+			},
+		},
+		{
+			Cluster: types.Cluster{
+				UUID: string(testdata.ClusterName),
+			},
+			Namespace: types.Namespace{
+				UUID: ira_data.NamespaceBUID,
+				Name: "namespace-name-B",
+			},
+			Metadata: types.DVOMetadata{
+				Recommendations: 1,
+				Objects:         1,
+				ReportedAt:      now.UTC().Format(time.RFC3339),
+				LastCheckedAt:   now.UTC().Format(time.RFC3339),
+			},
+			RecommendationsHitCount: types.RuleHitsCount{
+				"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1,
+			},
+		},
+	}
+
+	ira_helpers.AssertAPIRequestDVO(t, mockStorage, nil, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     server.DVOWorkloadRecommendations,
+		EndpointArgs: []interface{}{testdata.OrgID},
+	}, &helpers.APIResponse{
+		StatusCode:  http.StatusOK,
+		Body:        `{"status":"ok","workloads":` + helpers.ToJSONString(workloads) + `}`,
+		BodyChecker: workloadInResponseChecker,
 	})
 }
 
@@ -335,10 +401,10 @@ func TestGetWorkloadsOK_TwoNamespaces(t *testing.T) {
 	}
 
 	ira_helpers.AssertAPIRequestDVO(t, mockStorage, nil, &helpers.APIRequest{
-		Method:       http.MethodGet,
+		Method:       http.MethodPost,
 		Endpoint:     server.DVOWorkloadRecommendations,
 		EndpointArgs: []interface{}{testdata.OrgID},
-		Body:         fmt.Sprintf(`{[%v]}`, testdata.ClusterName),
+		Body:         fmt.Sprintf(`["%v"]`, testdata.ClusterName),
 	}, &helpers.APIResponse{
 		StatusCode:  http.StatusOK,
 		Body:        `{"status":"ok","workloads":` + helpers.ToJSONString(workloads) + `}`,
@@ -346,6 +412,8 @@ func TestGetWorkloadsOK_TwoNamespaces(t *testing.T) {
 	})
 }
 
+// TestGetWorkloadsOK_ActiveClusterFilter tests scenario where cluster list filtering is enabled by making
+// a POST request, but no clusters are provided. Therefore, all clusters/results must be filtered out.
 func TestGetWorkloadsOK_ActiveClusterFilter(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
@@ -363,13 +431,13 @@ func TestGetWorkloadsOK_ActiveClusterFilter(t *testing.T) {
 	helpers.FailOnError(t, err)
 
 	ira_helpers.AssertAPIRequestDVO(t, mockStorage, nil, &helpers.APIRequest{
-		Method:       http.MethodGet,
+		Method:       http.MethodPost,
 		Endpoint:     server.DVOWorkloadRecommendations,
 		EndpointArgs: []interface{}{testdata.OrgID},
-		Body:         `{}`, // <-- no cluster list
+		Body:         `[]`, // <-- no cluster list
 	}, &helpers.APIResponse{
 		StatusCode:  http.StatusOK,
-		Body:        `{"status":"ok","workloads":""}`, // <-- cluster filtered
+		Body:        `{"status":"ok","workloads":[]}`, // <-- cluster filtered
 		BodyChecker: workloadInResponseChecker,
 	})
 }

--- a/server/dvo_handlers_test.go
+++ b/server/dvo_handlers_test.go
@@ -334,6 +334,7 @@ func TestGetWorkloadsOK_TwoNamespacesGet(t *testing.T) {
 		},
 	}
 
+	// testing that GET functionality is kept (no filtering)
 	ira_helpers.AssertAPIRequestDVO(t, mockStorage, nil, &helpers.APIRequest{
 		Method:       http.MethodGet,
 		Endpoint:     server.DVOWorkloadRecommendations,

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -187,6 +187,6 @@ func (server *HTTPServer) addInsightsAdvisorEndpointsToRouter(router *mux.Router
 	router.HandleFunc(apiPrefix+RecommendationsListEndpoint, server.getRecommendations).Methods(http.MethodPost, http.MethodOptions)
 	router.HandleFunc(apiPrefix+ClustersRecommendationsListEndpoint, server.getClustersRecommendationsList).Methods(http.MethodPost, http.MethodOptions)
 
-	router.HandleFunc(apiPrefix+DVOWorkloadRecommendations, server.getWorkloads).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+DVOWorkloadRecommendations, server.getWorkloads).Methods(http.MethodGet, http.MethodPost)
 	router.HandleFunc(apiPrefix+DVOWorkloadRecommendationsSingleNamespace, server.getWorkloadsForNamespace).Methods(http.MethodGet)
 }

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -221,7 +221,7 @@ func ReadClusterMapFromBody(writer http.ResponseWriter, request *http.Request) (
 		return
 	}
 
-	// decode from body
+	// decode cluster list from body
 	var clustersInRequest []types.ClusterName
 	err := json.NewDecoder(request.Body).Decode(&clustersInRequest)
 	if err != nil {
@@ -230,10 +230,9 @@ func ReadClusterMapFromBody(writer http.ResponseWriter, request *http.Request) (
 	}
 
 	clusterMap = make(map[types.ClusterName]struct{}, len(clustersInRequest))
-
-	// more efficient to unmarshall a JSON list and iterate over it to create a map
-	for _, cid := range clustersInRequest {
-		clusterMap[cid] = struct{}{}
+	// more efficient to unmarshall a JSON list and iterate over it to create a map than marshaling a map
+	for i := range clustersInRequest {
+		clusterMap[clustersInRequest[i]] = struct{}{}
 	}
 
 	return clusterMap, true

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -206,3 +206,35 @@ func getRuleAndErrorKeyFromRuleID(ruleIDWithErrorKey string) (
 	errorKey = types.ErrorKey(splitedRuleID[1])
 	return
 }
+
+// ReadClusterMapFromBody retrieves a list of clusters from the request body and
+// generates a map of empty structs for fast access. If it's not possible,
+// it writes an http error to the writer and returns false
+func ReadClusterMapFromBody(writer http.ResponseWriter, request *http.Request) (
+	clusterMap map[types.ClusterName]struct{},
+	successful bool,
+) {
+	// check if there's any body provided in the request sent by client
+	if request.ContentLength <= 0 {
+		err := &NoBodyError{}
+		handleServerError(writer, err)
+		return
+	}
+
+	// decode from body
+	var clustersInRequest []types.ClusterName
+	err := json.NewDecoder(request.Body).Decode(&clustersInRequest)
+	if err != nil {
+		handleServerError(writer, err)
+		return
+	}
+
+	clusterMap = make(map[types.ClusterName]struct{}, len(clustersInRequest))
+
+	// more efficient to unmarshall a JSON list and iterate over it to create a map
+	for _, cid := range clustersInRequest {
+		clusterMap[cid] = struct{}{}
+	}
+
+	return clusterMap, true
+}

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -371,6 +371,9 @@ func TestDVOStorageReadWorkloadsForOrganization(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
 
+	activeClusterMap := make(map[types.ClusterName]struct{})
+	activeClusterMap[testdata.ClusterName] = struct{}{}
+
 	err := mockStorage.WriteReportForCluster(
 		testdata.OrgID,
 		testdata.ClusterName,
@@ -396,7 +399,7 @@ func TestDVOStorageReadWorkloadsForOrganization(t *testing.T) {
 	)
 	helpers.FailOnError(t, err)
 
-	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID)
+	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID, activeClusterMap)
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, testdata.ClusterName, types.ClusterName(workloads[0].Cluster.UUID))
@@ -514,6 +517,9 @@ func TestDVOStorageWriteReport_TwoNamespacesTwoRecommendations(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
 
+	activeClusterMap := make(map[types.ClusterName]struct{})
+	activeClusterMap[testdata.ClusterName] = struct{}{}
+
 	nowTstmp := types.Timestamp(now.UTC().Format(time.RFC3339))
 
 	err := mockStorage.WriteReportForCluster(
@@ -568,7 +574,7 @@ func TestDVOStorageWriteReport_TwoNamespacesTwoRecommendations(t *testing.T) {
 		},
 	}
 
-	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID)
+	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID, activeClusterMap)
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, 2, len(workloads))
@@ -588,6 +594,9 @@ func TestDVOStorageWriteReport_TwoNamespacesTwoRecommendations(t *testing.T) {
 func TestDVOStorageWriteReport_FilterOutDuplicateObjects_CCXDEV_12608_Reproducer(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()
+
+	activeClusterMap := make(map[types.ClusterName]struct{})
+	activeClusterMap[testdata.ClusterName] = struct{}{}
 
 	nowTstmp := types.Timestamp(now.UTC().Format(time.RFC3339))
 
@@ -650,7 +659,7 @@ func TestDVOStorageWriteReport_FilterOutDuplicateObjects_CCXDEV_12608_Reproducer
 		},
 	}
 
-	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID)
+	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID, activeClusterMap)
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, 2, len(workloads))
@@ -662,6 +671,123 @@ func TestDVOStorageWriteReport_FilterOutDuplicateObjects_CCXDEV_12608_Reproducer
 	assert.Equal(t, testdata.ClusterName, types.ClusterName(report.ClusterID))
 	assert.Equal(t, ira_data.NamespaceAUID, report.NamespaceID)
 	assert.Equal(t, uint(3), report.Recommendations)
+	assert.Equal(t, uint(2), report.Objects)
+	assert.Equal(t, nowTstmp, report.ReportedAt)
+	assert.Equal(t, nowTstmp, report.LastCheckedAt)
+}
+
+// TestDVOStorageWriteReport_ActiveClusterListFiltering tests the behavior when providing the active
+// cluster list in POST body
+func TestDVOStorageWriteReport_ActiveClusterListFiltering(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
+	defer closer()
+
+	// only contains one cluster
+	activeClusterMap := make(map[types.ClusterName]struct{})
+	activeClusterMap[testdata.ClusterName] = struct{}{}
+
+	nowTstmp := types.Timestamp(now.UTC().Format(time.RFC3339))
+
+	err := mockStorage.WriteReportForCluster(
+		testdata.OrgID,
+		testdata.ClusterName,
+		types.ClusterReport(ira_data.ValidReport2Rules2Namespaces),
+		[]types.WorkloadRecommendation{ira_data.Recommendation1TwoNamespaces, ira_data.Recommendation2OneNamespace},
+		now,
+		now,
+		now,
+		testdata.RequestID1,
+	)
+	helpers.FailOnError(t, err)
+
+	expectedWorkloads := []types.WorkloadsForNamespace{
+		{
+			Cluster: types.Cluster{
+				UUID: string(testdata.ClusterName),
+			},
+			Namespace: types.Namespace{
+				UUID: ira_data.NamespaceAUID,
+				Name: ira_data.NamespaceAWorkload.Namespace,
+			},
+			Metadata: types.DVOMetadata{
+				Recommendations: 2,
+				Objects:         2,
+				ReportedAt:      now.UTC().Format(time.RFC3339),
+				LastCheckedAt:   now.UTC().Format(time.RFC3339),
+			},
+			RecommendationsHitCount: types.RuleHitsCount{
+				"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE":                 1,
+				"ccx_rules_ocp.external.dvo.unset_requirements|DVO_UNSET_REQUIREMENTS": 2,
+			},
+		},
+		{
+			Cluster: types.Cluster{
+				UUID: string(testdata.ClusterName),
+			},
+			Namespace: types.Namespace{
+				UUID: ira_data.NamespaceBUID,
+				Name: ira_data.NamespaceBWorkload.Namespace,
+			},
+			Metadata: types.DVOMetadata{
+				Recommendations: 1, // <-- must contain only 1 rule, the other rule wasn't hitting this ns
+				Objects:         1,
+				ReportedAt:      now.UTC().Format(time.RFC3339),
+				LastCheckedAt:   now.UTC().Format(time.RFC3339),
+			},
+			RecommendationsHitCount: types.RuleHitsCount{
+				"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1,
+			},
+		},
+		{
+			Cluster: types.Cluster{
+				UUID: string(testdata.GetRandomClusterID()), // <-- not in active cluster list
+			},
+			Namespace: types.Namespace{
+				UUID: ira_data.NamespaceBUID,
+				Name: ira_data.NamespaceBWorkload.Namespace,
+			},
+			Metadata: types.DVOMetadata{
+				Recommendations: 1,
+				Objects:         1,
+				ReportedAt:      now.UTC().Format(time.RFC3339),
+				LastCheckedAt:   now.UTC().Format(time.RFC3339),
+			},
+			RecommendationsHitCount: types.RuleHitsCount{
+				"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1,
+			},
+		},
+		{
+			Cluster: types.Cluster{
+				UUID: string(testdata.GetRandomClusterID()), // <-- not in active cluster list
+			},
+			Namespace: types.Namespace{
+				UUID: ira_data.NamespaceAUID,
+				Name: ira_data.NamespaceAWorkload.Namespace,
+			},
+			Metadata: types.DVOMetadata{
+				Recommendations: 1,
+				Objects:         1,
+				ReportedAt:      now.UTC().Format(time.RFC3339),
+				LastCheckedAt:   now.UTC().Format(time.RFC3339),
+			},
+			RecommendationsHitCount: types.RuleHitsCount{
+				"ccx_rules_ocp.external.dvo.an_issue_pod|DVO_AN_ISSUE": 1,
+			},
+		},
+	}
+
+	workloads, err := mockStorage.ReadWorkloadsForOrganization(testdata.OrgID, activeClusterMap)
+	helpers.FailOnError(t, err)
+
+	assert.Equal(t, 2, len(workloads))
+	assert.ElementsMatch(t, expectedWorkloads, workloads)
+
+	report, err := mockStorage.ReadWorkloadsForClusterAndNamespace(testdata.OrgID, testdata.ClusterName, ira_data.NamespaceAUID)
+	helpers.FailOnError(t, err)
+
+	assert.Equal(t, testdata.ClusterName, types.ClusterName(report.ClusterID))
+	assert.Equal(t, ira_data.NamespaceAUID, report.NamespaceID)
+	assert.Equal(t, uint(2), report.Recommendations)
 	assert.Equal(t, uint(2), report.Objects)
 	assert.Equal(t, nowTstmp, report.ReportedAt)
 	assert.Equal(t, nowTstmp, report.LastCheckedAt)

--- a/storage/noop_dvo_recommendations_storage.go
+++ b/storage/noop_dvo_recommendations_storage.go
@@ -79,7 +79,7 @@ func (*NoopDVOStorage) WriteReportForCluster(
 }
 
 // ReadWorkloadsForOrganization noop
-func (*NoopDVOStorage) ReadWorkloadsForOrganization(types.OrgID, map[types.ClusterName]struct{}) ([]types.WorkloadsForNamespace, error) {
+func (*NoopDVOStorage) ReadWorkloadsForOrganization(types.OrgID, map[types.ClusterName]struct{}, bool) ([]types.WorkloadsForNamespace, error) {
 	return nil, nil
 }
 

--- a/storage/noop_dvo_recommendations_storage.go
+++ b/storage/noop_dvo_recommendations_storage.go
@@ -79,7 +79,7 @@ func (*NoopDVOStorage) WriteReportForCluster(
 }
 
 // ReadWorkloadsForOrganization noop
-func (*NoopDVOStorage) ReadWorkloadsForOrganization(types.OrgID) ([]types.WorkloadsForNamespace, error) {
+func (*NoopDVOStorage) ReadWorkloadsForOrganization(types.OrgID, map[types.ClusterName]struct{}) ([]types.WorkloadsForNamespace, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
# Description
This PR implements a cluster filtering mechanism in the DVO `DVOWorkloadRecommendations` endpoint. Based on [benchmarks](https://gist.github.com/Bee-lee/1ef7ea86db29b41ef81443964015679e), the absolute fastest way is to pass the cluster list as a JSON-encoded array, even though we need to have them as a map in the end, it's much faster than marshaling a map of equal size. Iterating over maps takes longer than iterating over slices, but more importantly `json` takes much longer to marshal/unmarshal a map than a slice (5-10x longer at worst).

- `organization/{org_id}/workloads` now accepts a `POST` method. If a `POST` request is made, the handler expects a JSON-encoded cluster UUID list in the request body. Failure to provide the body results in a `400 Bad Request`. 
- by making a `POST` request, the cluster filtering is enabled, meaning that if a valid empty list is provided `{[]}`, the handler will filter every result out, returning an empty results set. 
- support for existing `GET` method is kept, cluster filtering is disabled unless a `POST` request is made
 
Fixes https://issues.redhat.com/browse/CCXDEV-12957

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Changes in REST API schema
- Unit tests (no changes in the code)
- REST API tests

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
