### PR TITLE
Use Redis sets instead of strings

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -471,7 +471,8 @@ func setMigrationVersion(db storage.Storage, dbConn *sql.DB, versStr string) int
 	if versStrLower := strings.ToLower(versStr); versStrLower == "latest" || versStrLower == "max" {
 		targetVersion = db.GetMaxVersion()
 	} else {
-		vers, err := strconv.Atoi(versStr)
+		vers, err := strconv.ParseUint(versStr, 10, 64)
+
 		if err != nil {
 			log.Error().Err(err).Msg("Unable to parse target migration version")
 			return ExitStatusMigrationError

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/RedHatInsights/insights-operator-utils/logger"
+	typeutils "github.com/RedHatInsights/insights-operator-utils/types"
 	mapset "github.com/deckarep/golang-set"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/rs/zerolog/log"
@@ -277,7 +278,7 @@ func loadAllowlistFromCSV(r io.Reader) (mapset.Set, error) {
 			continue // skip header
 		}
 
-		orgID, err := strconv.ParseUint(line[0], 10, 64)
+		val, err := strconv.ParseUint(line[0], 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"organization ID on line %v in allowlist CSV is not numerical. Found value: %v",
@@ -285,6 +286,10 @@ func loadAllowlistFromCSV(r io.Reader) (mapset.Set, error) {
 			)
 		}
 
+		orgID, err := typeutils.Uint64ToUint32(val)
+		if err != nil {
+			return nil, err
+		}
 		allowlist.Add(types.OrgID(orgID))
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/RedHatInsights/insights-operator-utils v1.25.10
+	github.com/RedHatInsights/insights-operator-utils v1.25.11
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.9
 	github.com/RedHatInsights/insights-results-types v1.23.4
 	github.com/Shopify/sarama v1.27.1
@@ -42,7 +42,7 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getkin/kin-openapi v0.22.1 // indirect
-	github.com/getsentry/sentry-go v0.24.1 // indirect
+	github.com/getsentry/sentry-go v0.28.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -54,7 +54,7 @@ require (
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mozillazg/request v0.8.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
 github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
 github.com/RedHatInsights/insights-operator-utils v1.24.5/go.mod h1:7qR/8rlMdiqoXAkZyQ5JhVrVNCa6SBwNUt4KMq/17j4=
-github.com/RedHatInsights/insights-operator-utils v1.25.10 h1:UITYPaTX95SQTlUsrvQ+EUMeaDeymTbOTuzB7ihivl4=
-github.com/RedHatInsights/insights-operator-utils v1.25.10/go.mod h1:doiPhD3B4h4MWoUutqn1tBK2eD0yNplgfYroKXgTEj8=
+github.com/RedHatInsights/insights-operator-utils v1.25.11 h1:BcD9ISCkzDFnhor3d4So6nmjVjILQATS8GJhoRVqOak=
+github.com/RedHatInsights/insights-operator-utils v1.25.11/go.mod h1:zC4Wok6rNTMSQU8ey8ulPby2IB1wcujgFteB866vo1A=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
@@ -198,8 +198,8 @@ github.com/getkin/kin-openapi v0.20.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s
 github.com/getkin/kin-openapi v0.22.1 h1:ODA1olTp175o//NfHko/uCAAhwUSfm5P4+K52XvTg4w=
 github.com/getkin/kin-openapi v0.22.1/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/getsentry/sentry-go v0.6.1/go.mod h1:0yZBuzSvbZwBnvaF9VwZIMen3kXscY8/uasKtAX1qG8=
-github.com/getsentry/sentry-go v0.24.1 h1:W6/0GyTy8J6ge6lVCc94WB6Gx2ZuLrgopnn9w8Hiwuk=
-github.com/getsentry/sentry-go v0.24.1/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.28.1 h1:zzaSm/vHmGllRM6Tpx1492r0YDzauArdBfkJRtY6P5k=
+github.com/getsentry/sentry-go v0.28.1/go.mod h1:1fQZ+7l7eeJ3wYi82q5Hg8GqAPgefRq+FP/QhafYVgg=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
@@ -429,8 +429,9 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
@@ -478,7 +479,7 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/goerrcheck.sh
+++ b/goerrcheck.sh
@@ -17,7 +17,7 @@
 if ! [ -x "$(command -v errcheck)" ]
 then
     echo -e "${BLUE}Installing errcheck ${NC}"
-    GO111MODULE=off go get github.com/kisielk/errcheck
+        GO111MODULE=on go install github.com/kisielk/errcheck@latest
 fi
 
 errcheck ./...

--- a/ineffassign.sh
+++ b/ineffassign.sh
@@ -24,7 +24,7 @@ echo -e "${BLUE}Detecting ineffectual assignments in Go code${NC}"
 if ! [ -x "$(command -v ineffassign)" ]
 then
     echo -e "${BLUE}Installing ineffassign${NC}"
-    GO111MODULE=off go get github.com/gordonklaus/ineffassign
+    GO111MODULE=on go install github.com/gordonklaus/ineffassign@latest
 fi
 
 if ! ineffassign ./...

--- a/server.go
+++ b/server.go
@@ -88,7 +88,7 @@ func setDBVersion(s *server.HTTPServer, storageConf storage.Configuration, stora
 		log.Error().Err(err).Msg(msg)
 		serverInstance.InfoParams[key] = msg
 	} else {
-		serverInstance.InfoParams[key] = strconv.Itoa(int(currentVersion))
+		serverInstance.InfoParams[key] = strconv.FormatUint(uint64(currentVersion), 10)
 	}
 }
 

--- a/server/dvo_handlers.go
+++ b/server/dvo_handlers.go
@@ -214,8 +214,8 @@ func (server *HTTPServer) ProcessSingleDVONamespace(workload types.DVOReport) (
 			Name: workload.NamespaceName,
 		},
 		Metadata: types.DVOMetadata{
-			Recommendations: int(workload.Recommendations),
-			Objects:         int(workload.Objects),
+			Recommendations: workload.Recommendations,
+			Objects:         workload.Objects,
 			ReportedAt:      string(workload.ReportedAt),
 			LastCheckedAt:   string(workload.LastCheckedAt),
 		},

--- a/server/dvo_handlers_test.go
+++ b/server/dvo_handlers_test.go
@@ -127,8 +127,8 @@ func TestProcessSingleDVONamespace_MustProcessEscapedString(t *testing.T) {
 	assert.Equal(t, 1, len(processedWorkload.Recommendations[0].Objects))
 	assert.Equal(t, objectBUID, processedWorkload.Recommendations[0].Objects[0].UID)
 	assert.Equal(t, ira_data.NamespaceBUID, processedWorkload.Namespace.UUID)
-	assert.Equal(t, 1, processedWorkload.Metadata.Objects)
-	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
+	assert.Equal(t, uint(1), processedWorkload.Metadata.Objects)
+	assert.Equal(t, uint(1), processedWorkload.Metadata.Recommendations)
 
 	samples, err := json.Marshal(processedWorkload.Recommendations[0].TemplateData["samples"])
 	assert.NoError(t, err)
@@ -161,8 +161,8 @@ func TestProcessSingleDVONamespace_MustProcessCorrectString(t *testing.T) {
 	assert.Equal(t, 1, len(processedWorkload.Recommendations[0].Objects))
 	assert.Equal(t, objectBUID, processedWorkload.Recommendations[0].Objects[0].UID)
 	assert.Equal(t, ira_data.NamespaceBUID, processedWorkload.Namespace.UUID)
-	assert.Equal(t, 1, processedWorkload.Metadata.Objects)
-	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
+	assert.Equal(t, uint(1), processedWorkload.Metadata.Objects)
+	assert.Equal(t, uint(1), processedWorkload.Metadata.Recommendations)
 
 	samples, err := json.Marshal(processedWorkload.Recommendations[0].TemplateData["samples"])
 	assert.NoError(t, err)
@@ -212,8 +212,8 @@ func TestProcessSingleDVONamespace_MustFilterZeroObjects_CCXDEV_12589_Reproducer
 	assert.Equal(t, ira_data.NamespaceAUID, processedWorkload.Namespace.UUID)
 
 	// check correct metadata as well
-	assert.Equal(t, 2, processedWorkload.Metadata.Objects)
-	assert.Equal(t, 1, processedWorkload.Metadata.Recommendations)
+	assert.Equal(t, uint(2), processedWorkload.Metadata.Objects)
+	assert.Equal(t, uint(1), processedWorkload.Metadata.Recommendations)
 
 	samples, err := json.Marshal(processedWorkload.Recommendations[0].TemplateData["samples"])
 	assert.NoError(t, err)

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	httputils "github.com/RedHatInsights/insights-operator-utils/http"
+	typeutils "github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-results-aggregator/types"
@@ -63,7 +64,13 @@ func readUserID(writer http.ResponseWriter, request *http.Request) (types.UserID
 // readOrgID retrieves org_id from request
 // if it's not possible, it writes http error to the writer and returns false
 func readOrgID(writer http.ResponseWriter, request *http.Request) (types.OrgID, bool) {
-	orgID, err := getRouterPositiveIntParam(request, "org_id")
+	val, err := getRouterPositiveIntParam(request, "org_id")
+	if err != nil {
+		handleServerError(writer, err)
+		return 0, false
+	}
+
+	orgID, err := typeutils.Uint64ToUint32(val)
 	if err != nil {
 		handleServerError(writer, err)
 		return 0, false

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1260,6 +1260,26 @@ func TestHTTPServer_RecommendationsListEndpoint_3Recs2Clusters(t *testing.T) {
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       respBody,
+		BodyChecker: func(t testing.TB, expected, got []byte) {
+			var expectedMap, gotMap map[string]interface{}
+			err := json.Unmarshal(expected, &expectedMap)
+			assert.NoError(t, err)
+			err = json.Unmarshal(got, &gotMap)
+			assert.NoError(t, err)
+
+			assert.Equal(t, expectedMap["status"], gotMap["status"])
+
+			expectedRecs := expectedMap["recommendations"].(map[string]interface{})
+			gotRecs := gotMap["recommendations"].(map[string]interface{})
+
+			assert.Equal(t, len(expectedRecs), len(gotRecs))
+
+			for rule, expectedClusters := range expectedRecs {
+				gotClusters, exists := gotRecs[rule]
+				assert.True(t, exists)
+				assert.ElementsMatch(t, expectedClusters, gotClusters)
+			}
+		},
 	})
 }
 

--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -582,7 +582,7 @@ func (storage OCPRecommendationsDBStorage) ListOfClustersForOrgSpecificRule(
 func (storage OCPRecommendationsDBStorage) GetOrgIDByClusterID(cluster types.ClusterName) (types.OrgID, error) {
 	row := storage.connection.QueryRow("SELECT org_id FROM report WHERE cluster = $1 ORDER BY org_id;", cluster)
 
-	var orgID uint64
+	var orgID uint32
 	err := row.Scan(&orgID)
 	if err != nil {
 		log.Error().Err(err).Msg("GetOrgIDByClusterID")

--- a/storage/ocp_recommendations_storage_test.go
+++ b/storage/ocp_recommendations_storage_test.go
@@ -239,7 +239,7 @@ func TestDBStorageGetOrgIDByClusterID_Error(t *testing.T) {
 		t,
 		err,
 		`sql: Scan error on column index 0, name "org_id": `+
-			`converting driver.Value type string ("not-int") to a uint64: invalid syntax`,
+			`converting driver.Value type string ("not-int") to a uint32: invalid syntax`,
 	)
 }
 
@@ -1285,7 +1285,13 @@ func TestDBStorageReadRecommendationsForClustersMoreClusters(t *testing.T) {
 	res, err := mockStorage.ReadRecommendationsForClusters(clusterList, testdata.OrgID)
 	helpers.FailOnError(t, err)
 
-	assert.Equal(t, expect, res)
+	// Compare the results
+	assert.Equal(t, len(expect), len(res), "Number of rules should match")
+	for ruleID, expectedClusters := range expect {
+		actualClusters, exists := res[ruleID]
+		assert.True(t, exists, "Rule %s should exist in the result", ruleID)
+		assert.ElementsMatch(t, expectedClusters, actualClusters, "Clusters for rule %s should match", ruleID)
+	}
 }
 
 // TestDBStorageReadRecommendationsForClustersNoRecommendations checks that when no recommendations

--- a/types/errors.go
+++ b/types/errors.go
@@ -127,7 +127,7 @@ func regexGetNthMatch(regexStr string, nMatch uint, str string) (string, error) 
 	}
 
 	matches := regex.FindStringSubmatch(str)
-	if len(matches) < int(nMatch+1) {
+	if uint(len(matches)) < nMatch+1 {
 		return "", errors.New("regexGetNthMatch unable to find match")
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -224,8 +224,8 @@ type Namespace struct {
 
 // DVOMetadata structure contains basic information about workload metadata
 type DVOMetadata struct {
-	Recommendations int         `json:"recommendations"`
-	Objects         int         `json:"objects"`
+	Recommendations uint        `json:"recommendations"`
+	Objects         uint        `json:"objects"`
 	ReportedAt      string      `json:"reported_at"`
 	LastCheckedAt   string      `json:"last_checked_at"`
 	HighestSeverity int         `json:"highest_severity"`


### PR DESCRIPTION
# Description

Using Redis strings gets real slow when the number of entries starts growing. We have around 750000 values in the cache on any given day, which is not a lot, but retrieving values from there takes up to 30 seconds sometimes, depending on what's happening in the Redis server. Not viable. This PR replaces the Reds strings with Sets, which is way more efficient in this case.

Fixes CCXDEV-13117

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
