### PR TITLE
Set correct image during PR checks

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,11 +27,17 @@ REF_ENV="insights-production"
 #       Using multiple components name in COMPONENT_NAME forces bonfire to use the
 #       git version of clowdapp.yaml(or any other) file from the pull request.
 COMPONENT_NAME="ccx-insights-results ccx-redis dvo-writer"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-IMAGE="quay.io/cloudservices/insights-results-aggregator"
+IMAGE="quay.io/redhat-services-prod/obsint-processing-tenant/aggregator/aggregator"
 COMPONENTS="ccx-data-pipeline ccx-insights-results ccx-redis dvo-writer dvo-extractor insights-content-service ccx-smart-proxy ccx-mock-ams" # space-separated list of components to load
 COMPONENTS_W_RESOURCES=""  # component to keep
 CACHE_FROM_LATEST_IMAGE="true"
 DEPLOY_FRONTENDS="false"
+
+# Set the correct images
+EXTRA_DEPLOY_ARGS="\
+    --set-parameter ${APP_NAME}/IMAGE=quay.io/cloudservices/insights-results-aggregator \
+    --set-parameter ccx-smart-proxy/IMAGE=quay.io/redhat-services-prod/obsint-processing-tenant/smart-proxy/smart-proxy \
+"
 
 export IQE_PLUGINS="ccx"
 # Run all pipeline tests

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,7 +27,7 @@ REF_ENV="insights-production"
 #       Using multiple components name in COMPONENT_NAME forces bonfire to use the
 #       git version of clowdapp.yaml(or any other) file from the pull request.
 COMPONENT_NAME="ccx-insights-results ccx-redis dvo-writer"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-IMAGE="quay.io/redhat-services-prod/obsint-processing-tenant/aggregator/aggregator"
+IMAGE="quay.io/cloudservices/insights-results-aggregator"
 COMPONENTS="ccx-data-pipeline ccx-insights-results ccx-redis dvo-writer dvo-extractor insights-content-service ccx-smart-proxy ccx-mock-ams" # space-separated list of components to load
 COMPONENTS_W_RESOURCES=""  # component to keep
 CACHE_FROM_LATEST_IMAGE="true"


### PR DESCRIPTION
# Description

The app-interface config defines the image as `quay.io/redhat-services-prod`, so the `IMAGE` must first match that value in order to later override it in the extra options.

For components, it looks like `bonfire` uses the `IMAGE` value from each component repository, not the `IMAGE` value in the app-interface `deploy.yml`.

Since the image for `ccx-smart-proxy` as defined in the git repository is `quay.io/cloudservices`, it is trying to find an image in `quay.io/cloudservices` that matches the commit hash of the default branch on the repository. Build jobs for that repository were disabled, so there are no recent images there.

That's the reason for setting the `ccx-smart-proxy` image to `quay.io/redhat-services-prod`.

Updating the default value for `IMAGE` an all the component repositories should remove the need for that second override.

## Type of change

- Unit tests (no changes in the code)
