### PR TITLE
[CCXDEV-14562] New table for runtimes heartbeats

### DIFF
--- a/migration/dvomigrations/actual_migrations_test.go
+++ b/migration/dvomigrations/actual_migrations_test.go
@@ -127,8 +127,6 @@ func Test0004RuleHitsCount(t *testing.T) {
 	assert.Equal(t, ruleHitsInput, ruleHits)
 }
 
-
-
 func TestMigration5_TableRuntimesHeartbeatsAlreadyExists(t *testing.T) {
 	db, closer := helpers.PrepareDBDVO(t)
 	defer closer()

--- a/migration/dvomigrations/actual_migrations_test.go
+++ b/migration/dvomigrations/actual_migrations_test.go
@@ -133,7 +133,10 @@ func TestMigration5_TableRuntimesHeartbeatsAlreadyExists(t *testing.T) {
 
 	dbConn := db.GetConnection()
 
-	_, err := dbConn.Exec(`CREATE TABLE dvo.runtimes_heartbeats(c INTEGER);`)
+	err := migration.SetDBVersion(dbConn, db.GetDBDriverType(), db.GetDBSchema(), 4, dvomigrations.UsableDVOMigrations)
+	helpers.FailOnError(t, err)
+
+	_, err = dbConn.Exec(`CREATE TABLE dvo.runtimes_heartbeats(c INTEGER);`)
 	helpers.FailOnError(t, err)
 
 	err = migration.SetDBVersion(dbConn, db.GetDBDriverType(), db.GetDBSchema(), db.GetMaxVersion(), dvomigrations.UsableDVOMigrations)
@@ -149,7 +152,7 @@ func TestMigration5_TableRuntimesHeartbeatsDoesNotExist(t *testing.T) {
 	err := migration.SetDBVersion(dbConn, db.GetDBDriverType(), db.GetDBSchema(), 5, dvomigrations.UsableDVOMigrations)
 	helpers.FailOnError(t, err)
 
-	_, err = dbConn.Exec(`DROP TABLE runtimes_heartbeats;`)
+	_, err = dbConn.Exec(`DROP TABLE dvo.runtimes_heartbeats;`)
 	helpers.FailOnError(t, err)
 
 	// try to set to the first version

--- a/migration/dvomigrations/actual_migrations_test.go
+++ b/migration/dvomigrations/actual_migrations_test.go
@@ -126,3 +126,35 @@ func Test0004RuleHitsCount(t *testing.T) {
 	helpers.FailOnError(t, err)
 	assert.Equal(t, ruleHitsInput, ruleHits)
 }
+
+
+
+func TestMigration5_TableRuntimesHeartbeatsAlreadyExists(t *testing.T) {
+	db, closer := helpers.PrepareDBDVO(t)
+	defer closer()
+
+	dbConn := db.GetConnection()
+
+	_, err := dbConn.Exec(`CREATE TABLE dvo.runtimes_heartbeats(c INTEGER);`)
+	helpers.FailOnError(t, err)
+
+	err = migration.SetDBVersion(dbConn, db.GetDBDriverType(), db.GetDBSchema(), db.GetMaxVersion(), dvomigrations.UsableDVOMigrations)
+	assert.EqualError(t, err, "table runtimes_heartbeats already exists")
+}
+
+func TestMigration5_TableRuntimesHeartbeatsDoesNotExist(t *testing.T) {
+	db, closer := helpers.PrepareDBDVO(t)
+	defer closer()
+
+	dbConn := db.GetConnection()
+
+	err := migration.SetDBVersion(dbConn, db.GetDBDriverType(), db.GetDBSchema(), 5, dvomigrations.UsableDVOMigrations)
+	helpers.FailOnError(t, err)
+
+	_, err = dbConn.Exec(`DROP TABLE runtimes_heartbeats;`)
+	helpers.FailOnError(t, err)
+
+	// try to set to the first version
+	err = migration.SetDBVersion(dbConn, db.GetDBDriverType(), db.GetDBSchema(), 4, dvomigrations.UsableDVOMigrations)
+	assert.EqualError(t, err, "no such table: runtimes_heartbeats")
+}

--- a/migration/dvomigrations/dvo_migrations.go
+++ b/migration/dvomigrations/dvo_migrations.go
@@ -8,4 +8,5 @@ var UsableDVOMigrations = []migration.Migration{
 	mig0002CreateDVOReportIndexes,
 	mig0003CCXDEV12602DeleteBuggyRecords,
 	mig0004AddRuleHitsCount,
+	mig0005CreateRuntimesHeartbeats,
 }

--- a/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
+++ b/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
@@ -10,7 +10,7 @@ import (
 var mig0005CreateRuntimesHeartbeats = migration.Migration{
 	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
 		_, err := tx.Exec(`
-			CREATE TABLE runtimes.heartbeats (
+			CREATE TABLE dvo.runtimes_heartbeats (
 				instance_id     VARCHAR NOT NULL,
 				last_checked_at TIMESTAMP,
 				PRIMARY KEY(instance_id)
@@ -21,15 +21,15 @@ var mig0005CreateRuntimesHeartbeats = migration.Migration{
 		}
 
 		_, err = tx.Exec(`
-			COMMENT ON TABLE runtimes.heartbeats IS 'This table is used to store information of when the hearbeats was last received.';
-			COMMENT ON COLUMN runtimes.heartbeats.instance_id IS 'instance ID';
-			COMMENT ON COLUMN runtimes.heartbeats.last_checked_at IS 'timestamp of the received heartbeat';
+			COMMENT ON TABLE dvo.runtimes_heartbeats IS 'This table is used to store information of when the hearbeats was last received.';
+			COMMENT ON COLUMN dvo.runtimes_heartbeats.instance_id IS 'instance ID';
+			COMMENT ON COLUMN dvo.runtimes_heartbeats.last_checked_at IS 'timestamp of the received heartbeat';
 		`)
 
 		return err
 	},
 	StepDown: func(tx *sql.Tx, _ types.DBDriver) error {
-		_, err := tx.Exec(`DROP TABLE runtimes.heartbeats;`)
+		_, err := tx.Exec(`DROP TABLE dvo.runtimes_heartbeats;`)
 		return err
 	},
 }

--- a/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
+++ b/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
@@ -1,0 +1,36 @@
+
+package dvomigrations
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/migration"
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+)
+
+var mig0005CreateRuntimesHeartbeats = migration.Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		_, err := tx.Exec(`
+			CREATE TABLE runtimes.heartbeats (
+				instance_id     VARCHAR NOT NULL
+				last_checked_at TIMESTAMP,
+				PRIMARY KEY(instance_id)
+			);
+		`)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec(`
+			COMMENT ON TABLE runtimes.heartbeats IS 'This table is used to store information of when the hearbeats was last received.';
+			COMMENT ON COLUMN runtimes.heartbeats.instance_id IS 'instance ID';
+			COMMENT ON COLUMN runtimes.heartbeats.last_checked_at IS 'timestamp of the received heartbeat';
+		`)
+
+		return err
+	},
+	StepDown: func(tx *sql.Tx, _ types.DBDriver) error {
+		_, err := tx.Exec(`DROP TABLE runtimes.heartbeats;`)
+		return err
+	},
+}

--- a/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
+++ b/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
@@ -11,7 +11,7 @@ var mig0005CreateRuntimesHeartbeats = migration.Migration{
 	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
 		_, err := tx.Exec(`
 			CREATE TABLE runtimes.heartbeats (
-				instance_id     VARCHAR NOT NULL
+				instance_id     VARCHAR NOT NULL,
 				last_checked_at TIMESTAMP,
 				PRIMARY KEY(instance_id)
 			);

--- a/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
+++ b/migration/dvomigrations/mig_0005_runtimes_heartbeats_last_check.go
@@ -1,4 +1,3 @@
-
 package dvomigrations
 
 import (


### PR DESCRIPTION
A migration included in the DVO ones (for simplicity) creates a new table to store runtimes heartbeats data (basically ID and timestamp).

Included in the DVO ones to avoid creating new migration schema and another entry point. In addition, this table will be populated by DVO-writer (a modified version of the service) and updated by a new service.