### PR TITLE
[CCXDEV-14564] DVO writer write heartbeats

### DIFF
--- a/storage/noop_dvo_recommendations_storage.go
+++ b/storage/noop_dvo_recommendations_storage.go
@@ -104,3 +104,11 @@ func (*NoopDVOStorage) WriteHeartbeat(
 ) error {
 	return nil
 }
+
+// WriteHeartbeas noop
+func (*NoopDVOStorage) WriteHeartbeats(
+	[]string,
+	time.Time,
+) error {
+	return nil
+}


### PR DESCRIPTION
Once a runtimes report is received, the heartbeats table should be populated with instances seen there.