### PR TITLE
Allow conflicts on writing heartbeats for second time

### DIFF
--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -722,7 +722,8 @@ func (storage DVORecommendationsDBStorage) WriteHeartbeats(
 	//trim the last ,
 	sqlStr = sqlStr[0 : len(sqlStr)-1]
 
-	sqlStr += ";"
+	sqlStr += "ON CONFLICT (instance_id) DO UPDATE SET last_checked_at = $" + fmt.Sprint(itemIndex) + ";"
+	vals = append(vals, timestamp)
 
 	log.Debug().Msgf("About to write heartbeats with %s and args %v", sqlStr, vals)
 

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -722,8 +722,7 @@ func (storage DVORecommendationsDBStorage) WriteHeartbeats(
 	//trim the last ,
 	sqlStr = sqlStr[0 : len(sqlStr)-1]
 
-	sqlStr += "ON CONFLICT (instance_id) DO UPDATE SET last_checked_at = $" + fmt.Sprint(itemIndex) + ";"
-	vals = append(vals, timestamp)
+	sqlStr += " ON CONFLICT (instance_id) DO NOTHING;"
 
 	log.Debug().Msgf("About to write heartbeats with %s and args %v", sqlStr, vals)
 

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -934,6 +934,52 @@ func TestWriteHeartbeats(t *testing.T) {
 	assert.Equal(t, data, instances)
 }
 
+func TestWriteHeartbeatsWithConfict(t *testing.T) {
+	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
+	defer closer()
+
+	data := []string{"x"}
+
+	err := mockStorage.WriteHeartbeats(
+		data, now.Add(-1*time.Hour).UTC(),
+	)
+	helpers.FailOnError(t, err)
+
+	err = mockStorage.WriteHeartbeats(
+		data, now,
+	)
+	helpers.FailOnError(t, err)
+
+	connection := storage.GetConnectionDVO(mockStorage.(*storage.DVORecommendationsDBStorage))
+
+	query := `
+		SELECT *
+		FROM dvo.runtimes_heartbeats
+	`
+
+	rows, err := connection.Query(query)
+	helpers.FailOnError(t, err)
+
+	defer func() { _ = rows.Close() }()
+
+	var instances []string
+
+	for rows.Next() {
+		var (
+			instanceID string
+			timestamp  time.Time
+		)
+		err = rows.Scan(
+			&instanceID, &timestamp,
+		)
+		helpers.FailOnError(t, err)
+
+		assert.Equal(t, now.UTC().Format(time.RFC3339), timestamp.UTC().Format(time.RFC3339))
+		instances = append(instances, instanceID)
+	}
+	assert.Equal(t, data, instances)
+}
+
 func TestUpdateHeartbeat(t *testing.T) {
 	mockStorage, closer := ira_helpers.MustGetPostgresStorageDVO(t, true)
 	defer closer()

--- a/storage/dvo_recommendations_storage_test.go
+++ b/storage/dvo_recommendations_storage_test.go
@@ -974,7 +974,7 @@ func TestWriteHeartbeatsWithConfict(t *testing.T) {
 		)
 		helpers.FailOnError(t, err)
 
-		assert.Equal(t, now.UTC().Format(time.RFC3339), timestamp.UTC().Format(time.RFC3339))
+		assert.Equal(t, now.Add(-1*time.Hour).UTC().Format(time.RFC3339), timestamp.UTC().Format(time.RFC3339))
 		instances = append(instances, instanceID)
 	}
 	assert.Equal(t, data, instances)


### PR DESCRIPTION
Implementing the solution to append new archives to existing ones is too costly, so we are going for using archives to do that. In such case, there can be duplicates on the heartbeat DB and we want to avoid SQL errors in such cases.