### PR TITLE
[CCXDEV-15031] Handling errors in finish transaction

### DIFF
--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -291,7 +291,7 @@ func (storage DVORecommendationsDBStorage) WriteReportForCluster(
 		return nil
 	}(tx)
 
-	finishTransaction(tx, err)
+	err = finishTransaction(tx, err)
 
 	return err
 }

--- a/storage/info_rules.go
+++ b/storage/info_rules.go
@@ -56,7 +56,7 @@ func (storage OCPRecommendationsDBStorage) WriteReportInfoForCluster(
 
 	err = storage.updateInfoReport(tx, orgID, clusterName, info)
 
-	finishTransaction(tx, err)
+	err = finishTransaction(tx, err)
 	return err
 }
 

--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -1308,15 +1308,19 @@ func commitTransaction(tx *sql.Tx) error {
 		return commitError
 	}
 	return nil
-
 }
 
 // finishTransaction finishes the transaction depending on err. err == nil -> commit, err != nil -> rollback
 func finishTransaction(tx *sql.Tx, err error) error {
 	if err != nil {
-		return rollbackTransaction(tx)
+		rollbackErr := rollbackTransaction(tx)
+		if rollbackErr != nil {
+			return rollbackErr
+		}
+		return err
 	} else {
-		return commitTransaction(tx)
+		err = commitTransaction(tx)
+		return err
 	}
 }
 

--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -1300,7 +1300,7 @@ func rollbackTransaction(tx *sql.Tx) error {
 	return nil
 }
 
-// commitTransaction attempts to commit the transaction, when error is detecter it attempts rollback.
+// commitTransaction attempts to commit the transaction, when error is detected it attempts rollback.
 func commitTransaction(tx *sql.Tx) error {
 	commitError := tx.Commit()
 	if commitError != nil {

--- a/storage/ocp_recommendations_storage_test.go
+++ b/storage/ocp_recommendations_storage_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -298,6 +299,34 @@ func TestDBStorageWriteReportForClusterUnsupportedDriverError(t *testing.T) {
 		testdata.RequestID1,
 	)
 	assert.EqualError(t, err, "writing report with DB -1 is not supported")
+}
+
+// TestDBStorageWriteReportForClusterCommitFailure checks that if the database COMMIT operation
+// fails during an attempt to write a report, a ROLLBACK is subsequently performed and
+// the original commit error is returned by WriteReportForCluster.
+func TestDBStorageWriteReportForClusterCommitFailure(t *testing.T) {
+	mockStorage, mockSQL := ira_helpers.MustGetMockStorageWithExpectsForDriver(t, types.DBDriverPostgres)
+	mockSQL.ExpectBegin()
+	mockSQL.ExpectQuery(`SELECT last_checked_at FROM report`).
+		WillReturnRows(sqlmock.NewRows([]string{"last_checked_at"}))
+	mockSQL.ExpectQuery(`SELECT rule_fqdn, error_key, created_at FROM rule_hit`).
+		WillReturnRows(sqlmock.NewRows([]string{"rule_fqdn", "error_key", "created_at"}))
+	mockSQL.ExpectExec(`DELETE FROM rule_hit`).
+		WillReturnResult(driver.ResultNoRows)
+	mockSQL.ExpectExec(`INSERT INTO report`).
+		WillReturnResult(driver.ResultNoRows)
+	dbCommitErr := errors.New("simulated DB commit failure")
+	mockSQL.ExpectCommit().WillReturnError(dbCommitErr)
+	mockSQL.ExpectRollback()
+	expectedReturnedError := dbCommitErr
+	err := mockStorage.WriteReportForCluster(
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
+		testdata.ReportEmptyRulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(),
+		testdata.RequestID1)
+	assert.Error(t, err)
+	if err != nil {
+		assert.Equal(t, expectedReturnedError.Error(), err.Error())
+	}
 }
 
 // TestDBStorageWriteReportForClusterMoreRecentInDB checks that older report

--- a/storage/ocp_recommendations_storage_test.go
+++ b/storage/ocp_recommendations_storage_test.go
@@ -324,9 +324,31 @@ func TestDBStorageWriteReportForClusterCommitFailure(t *testing.T) {
 		testdata.ReportEmptyRulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(),
 		testdata.RequestID1)
 	assert.Error(t, err)
-	if err != nil {
-		assert.Equal(t, expectedReturnedError.Error(), err.Error())
-	}
+	assert.Equal(t, expectedReturnedError.Error(), err.Error())
+}
+
+// TestDBStorageWriteReportForClusterRollBackFailure checks that if an error occurs within the report writing transaction
+// (triggering a rollback attempt), and the subsequent ROLLBACK operation itself also fails,
+// WriteReportForCluster returns the error from the failed ROLLBACK.
+func TestDBStorageWriteReportForClusterRollBackFailure(t *testing.T) {
+	simulatedLogicError := errors.New("simulated failure during DELETE FROM rule_hit")
+	simulatedRollbackFailureError := errors.New("simulated DB rollback failure")
+	mockStorage, mockSQL := ira_helpers.MustGetMockStorageWithExpectsForDriver(t, types.DBDriverPostgres)
+	mockSQL.ExpectBegin()
+	mockSQL.ExpectQuery(`SELECT last_checked_at FROM report`).
+		WillReturnRows(sqlmock.NewRows([]string{"last_checked_at"}))
+	mockSQL.ExpectQuery(`SELECT rule_fqdn, error_key, created_at FROM rule_hit`).
+		WillReturnRows(sqlmock.NewRows([]string{"rule_fqdn", "error_key", "created_at"}))
+	mockSQL.ExpectExec(`DELETE FROM rule_hit`).
+		WillReturnError(simulatedLogicError)
+	mockSQL.ExpectRollback().WillReturnError(simulatedRollbackFailureError)
+	expectedReturnedError := simulatedRollbackFailureError
+	err := mockStorage.WriteReportForCluster(
+		testdata.OrgID, testdata.ClusterName, testdata.Report3Rules,
+		testdata.ReportEmptyRulesParsed, testdata.LastCheckedAt, time.Now(), time.Now(),
+		testdata.RequestID1)
+	assert.Error(t, err)
+	assert.Equal(t, expectedReturnedError.Error(), err.Error())
 }
 
 // TestDBStorageWriteReportForClusterMoreRecentInDB checks that older report


### PR DESCRIPTION
# Description

There is currently cluster under iqe-account that does not have any reports in database but recomendations were generated. This might have been caused by finishTransaction function not returning error when there was error with commiting the transaction -> the reports were not added to the table but recomendations were. This PR is fixing this issue and hopefully the core cause of CCXDEV-15031

Fixes # CCXDEV-15031

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

I have created one unit test and also i tried to deploy the aggregator to ephemeral and ran iqe tests aginst it 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
