### PR TITLE
Use latest image of go-toolset for building binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 
 COPY . .
 


### PR DESCRIPTION
# Description

As we are aiming for automatic version bumping and Konflux MRs are pilling up, this change aims to reduce the load with similar results. In addition, as Konflux might change tags with go version, e.g. 1.23 to 9.6, we are not loosing much relevenat information anyways. Finally, we expect that any imcompatibility between the code and the image used to build it is manifested in the CI.

## Type of change

- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
