### PR TITLE
[CCXDEV-14924] Remove old Redis from aggregator Clowdapp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -288,15 +288,8 @@ objects:
               value: ${LOG_LEVEL}
             - name: INSIGHTS_RESULTS_AGGREGATOR__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED
               value: ${CLOUDWATCH_ENABLED}
-            - name: INSIGHTS_RESULTS_AGGREGATOR__REDIS__ENDPOINT
-              value: ${INSIGHTS_REDIS_URL}
             - name: INSIGHTS_RESULTS_AGGREGATOR__REDIS__DATABASE
               value: ${INSIGHTS_REDIS_DATABASE}
-            - name: INSIGHTS_RESULTS_AGGREGATOR__REDIS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: cache-writer-redis-credentials
-                  key: password
             - name: INSIGHTS_RESULTS_AGGREGATOR__REDIS__TIMEOUT_SECONDS
               value: ${INSIGHTS_REDIS_TIMEOUT_SECONDS}
             - name: INSIGHTS_RESULTS_AGGREGATOR__CLOUDWATCH__DEBUG
@@ -511,8 +504,6 @@ parameters:
   required: true
 - name: CREATE_STREAM_IF_NOT_EXISTS
   value: "true"
-- name: INSIGHTS_REDIS_URL
-  value: "ccx-redis:6379"
 - name: INSIGHTS_REDIS_DATABASE
   value: "0"
 - name: INSIGHTS_REDIS_TIMEOUT_SECONDS


### PR DESCRIPTION
# Description

Aggregator Clowdapp was using references to old Redis password and hostname.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

NA

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
