### PR TITLE
[CCXDEV-15295] Making sure that empty recommendations are not added to cluster

### DIFF
--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -1430,23 +1430,17 @@ func (storage OCPRecommendationsDBStorage) ReadClusterListRecommendations(
 			log.Error().Err(err).Msg("problem reading one recommendation")
 			return clusterMap, err
 		}
-
-		if cluster, exists := clusterMap[clusterID]; exists {
-			// Only add non-empty rule IDs to recommendations
-			if ruleID != "" {
-				cluster.Recommendations = append(cluster.Recommendations, ruleID)
-				clusterMap[clusterID] = cluster
-			}
-		} else {
+		if _, exists := clusterMap[clusterID]; !exists {
 			// create entry in map for new cluster ID
-			cluster := ctypes.ClusterRecommendationList{
+			clusterMap[clusterID] = ctypes.ClusterRecommendationList{
+				// created at is the same for all rows for each cluster
 				CreatedAt:       timestamp,
 				Recommendations: []ctypes.RuleID{},
 			}
-			// Only add non-empty rule IDs to recommendations
-			if ruleID != "" {
-				cluster.Recommendations = append(cluster.Recommendations, ruleID)
-			}
+		}
+		if ruleID != "" {
+			cluster := clusterMap[clusterID]
+			cluster.Recommendations = append(clusterMap[clusterID].Recommendations, ruleID)
 			clusterMap[clusterID] = cluster
 		}
 	}


### PR DESCRIPTION
# Description
There was issue in ReadClusterListRecommendations function which caused custer to have empty string in recommendation list. This PR fixes the issue 

Fixes # (issue)
  - Added validation to prevent empty rule IDs from being added to cluster
  recommendations

## Type of change

Please delete options that are not relevant.

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

The unit test were runned locally and iqe tests as part of the PR 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
