### PR TITLE
fix: exclude goconst from test files in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
       - path: _test\.go
         linters:
           - gosec
+          - goconst
           - revive
       - path: tests/
         linters:


### PR DESCRIPTION
## What broke and why

golangci-lint v2.12.0 changed `goconst` behavior to also check test files, flagging intentionally repeated string literals in test setup code (e.g. `postgres`, `localhost`, `user`, env var key strings in `aggregator_test.go` and `conf/configuration_test.go`).

## Why this fix

Test fixtures legitimately repeat strings like `"postgres"` and `"localhost"` across multiple test cases — these are test data, not production constants. Extracting them to constants would make the tests harder to read without any correctness benefit. Excluding `goconst` from `_test.go` paths is the correct approach.

## Unblocks

Allows https://github.com/RedHatInsights/insights-results-aggregator/pull/2474 to pass CI and merge.