### PR TITLE
fix: add goconst exclusion for tests/ and extract repeated storage column name constants

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
       - path: tests/
         linters:
           - gosec
+          - goconst
       - path: migration/ocpmigrations/mig_(.+)\.go
         linters:
           - revive

--- a/storage/consts.go
+++ b/storage/consts.go
@@ -37,4 +37,8 @@ const (
 	closeStatementError = "Unable to close statement"
 	// inClauseError when constructing IN clause fails
 	inClauseError = "error constructing WHERE IN clause"
+	// clusterIDKey column name for cluster ID
+	clusterIDKey = "cluster_id"
+	// recommendationKey table/type name for recommendations
+	recommendationKey = "recommendation"
 )

--- a/storage/dvo_recommendations_storage.go
+++ b/storage/dvo_recommendations_storage.go
@@ -324,7 +324,7 @@ func (storage DVORecommendationsDBStorage) updateOrgIDForClusterInTx(
 ) error {
 	// Define relevant tables
 	tables := []TableInfo{
-		{"dvo.dvo_report", "cluster_id"},
+		{"dvo.dvo_report", clusterIDKey},
 	}
 
 	// Check if there are existing records and get current org_id

--- a/storage/ocp_recommendations_storage.go
+++ b/storage/ocp_recommendations_storage.go
@@ -922,7 +922,7 @@ func (storage OCPRecommendationsDBStorage) getRuleKeyCreatedAtMapForTable(table 
 		RuleKeyCreatedAt, err = storage.getRuleKeyCreatedAtMap(
 			selectRuleCreatedAtQuery, orgID, clusterName,
 		)
-	case "recommendation":
+	case recommendationKey:
 		RuleKeyCreatedAt, err = storage.getRuleKeyCreatedAtMap(
 			selectRuleImpactedSinceQuery, orgID, clusterName,
 		)
@@ -1179,8 +1179,8 @@ func (storage OCPRecommendationsDBStorage) updateOrgIDForClusterInTx(
 	// Define tables to check for existing org_id (in priority order)
 	tablesToCheck := []TableInfo{
 		{"report", "cluster"},
-		{"recommendation", "cluster_id"},
-		{"report_info", "cluster_id"},
+		{recommendationKey, clusterIDKey},
+		{"report_info", clusterIDKey},
 	}
 
 	// Check if there are existing records and get current org_id
@@ -1206,12 +1206,12 @@ func (storage OCPRecommendationsDBStorage) updateOrgIDForClusterInTx(
 	// Define all tables that need org_id update
 	tablesToUpdate := []TableInfo{
 		{"report", "cluster"},
-		{"recommendation", "cluster_id"},
-		{"report_info", "cluster_id"},
-		{"rule_hit", "cluster_id"},
-		{"cluster_rule_toggle", "cluster_id"},
-		{"cluster_rule_user_feedback", "cluster_id"},
-		{"cluster_user_rule_disable_feedback", "cluster_id"},
+		{recommendationKey, clusterIDKey},
+		{"report_info", clusterIDKey},
+		{"rule_hit", clusterIDKey},
+		{"cluster_rule_toggle", clusterIDKey},
+		{"cluster_rule_user_feedback", clusterIDKey},
+		{"cluster_user_rule_disable_feedback", clusterIDKey},
 	}
 
 	return updateOrgIDInTables(tx, newOrgID, clusterName, tablesToUpdate)
@@ -1304,7 +1304,7 @@ func (storage OCPRecommendationsDBStorage) WriteRecommendationsForCluster(
 		if _, ok := storage.clustersLastChecked[clusterName]; ok {
 			// Get impacted_since if present
 			impactedSinceMap, err = storage.getRuleKeyCreatedAtMapForTable(
-				"recommendation", orgID, clusterName)
+				recommendationKey, orgID, clusterName)
 			if err != nil {
 				log.Error().Err(err).Msg("Unable to get recommendation impacted_since")
 			}


### PR DESCRIPTION
## What broke and why

golangci-lint v2.12.0 flagged additional goconst violations not caught in the previous fix:

- `storage/dvo_recommendations_storage.go` and `storage/ocp_recommendations_storage.go`: `"cluster_id"` (18 total occurrences) and `"recommendation"` (3 occurrences) repeated as column/table name strings
- `tests/data/dvo_data.go`: test data strings flagged because the `tests/` path exclusion only covered `gosec`, not `goconst`

## Why this fix

- Production storage files: extracting `clusterIDKey` and `recommendationKey` to `consts.go` follows the existing pattern in that file and makes column names change-proof
- `tests/` path: test data files use intentionally repeated fixture strings — excluding goconst there is correct, same rationale as `_test.go`

## Unblocks

Allows https://github.com/RedHatInsights/insights-results-aggregator/pull/2474 to pass CI and merge.