### PR TITLE
[CCXDEV-15434] Old tutorial entries causing a log error report

### DIFF
--- a/migration/ocpmigrations/actual_migrations_test.go
+++ b/migration/ocpmigrations/actual_migrations_test.go
@@ -17,6 +17,7 @@ package ocpmigrations_test
 import (
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -1196,4 +1197,241 @@ func TestMigration31(t *testing.T) {
 
 	// default value on stepdown
 	assert.Equal(t, userID, types.UserID("-1"))
+}
+
+func TestMigration32(t *testing.T) {
+	dbConn, dbDriver, dbSchema, closer := ira_helpers.PrepareDBAndInfo(t)
+	defer closer()
+
+	err := migration.SetDBVersion(dbConn, dbDriver, dbSchema, 31, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	const insertToggleQuery = `
+		INSERT INTO cluster_rule_toggle
+		(cluster_id, rule_id, error_key, org_id, disabled, updated_at)
+		VALUES
+		($1, $2, $3, $4, $5, $6)
+	`
+
+	// rows with empty error_key should be deleted
+	for i := 0; i < 2; i++ {
+		_, err = dbConn.Exec(
+			insertToggleQuery,
+			testdata.GetRandomClusterID(),
+			testdata.Rule1ID,
+			"",
+			testdata.OrgID,
+			storage.RuleToggleDisable,
+			time.Now(),
+		)
+		helpers.FailOnError(t, err)
+	}
+
+	// rows with non-empty error_key should remain
+	for i := 0; i < 2; i++ {
+		_, err = dbConn.Exec(
+			insertToggleQuery,
+			testdata.GetRandomClusterID(),
+			testdata.Rule1ID,
+			testdata.ErrorKey1,
+			testdata.OrgID,
+			storage.RuleToggleDisable,
+			time.Now(),
+		)
+		helpers.FailOnError(t, err)
+	}
+
+	err = migration.SetDBVersion(dbConn, dbDriver, dbSchema, 32, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	var remainingCount int
+	err = dbConn.QueryRow(`SELECT count(*) FROM cluster_rule_toggle`).Scan(&remainingCount)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 2, remainingCount)
+
+	var emptyErrorKeyCount int
+	err = dbConn.QueryRow(`SELECT count(*) FROM cluster_rule_toggle WHERE error_key = ''`).Scan(&emptyErrorKeyCount)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 0, emptyErrorKeyCount)
+
+	version, err := migration.GetDBVersion(dbConn, dbSchema)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, migration.Version(32), version)
+
+	// StepDown is a one-way operation: it must succeed but not restore deleted rows.
+	err = migration.SetDBVersion(dbConn, dbDriver, dbSchema, 31, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	version, err = migration.GetDBVersion(dbConn, dbSchema)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, migration.Version(31), version)
+
+	err = dbConn.QueryRow(`SELECT count(*) FROM cluster_rule_toggle`).Scan(&remainingCount)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 2, remainingCount)
+
+	err = dbConn.QueryRow(`SELECT count(*) FROM cluster_rule_toggle WHERE error_key = ''`).Scan(&emptyErrorKeyCount)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 0, emptyErrorKeyCount)
+}
+
+func TestMigration32_StepUpNoEmptyErrorKeyRows(t *testing.T) {
+	dbConn, dbDriver, dbSchema, closer := ira_helpers.PrepareDBAndInfo(t)
+	defer closer()
+
+	err := migration.SetDBVersion(dbConn, dbDriver, dbSchema, 31, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	const insertToggleQuery = `
+		INSERT INTO cluster_rule_toggle
+		(cluster_id, rule_id, error_key, org_id, disabled, updated_at)
+		VALUES
+		($1, $2, $3, $4, $5, $6)
+	`
+
+	for i := 0; i < 3; i++ {
+		_, err = dbConn.Exec(
+			insertToggleQuery,
+			testdata.GetRandomClusterID(),
+			testdata.Rule1ID,
+			testdata.ErrorKey1,
+			testdata.OrgID,
+			storage.RuleToggleDisable,
+			time.Now(),
+		)
+		helpers.FailOnError(t, err)
+	}
+
+	err = migration.SetDBVersion(dbConn, dbDriver, dbSchema, 32, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	var remainingCount int
+	err = dbConn.QueryRow(`SELECT count(*) FROM cluster_rule_toggle`).Scan(&remainingCount)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 3, remainingCount)
+}
+
+func TestMigration32_StepDownDoesNotRestoreDeletedRows(t *testing.T) {
+	dbConn, dbDriver, dbSchema, closer := ira_helpers.PrepareDBAndInfo(t)
+	defer closer()
+
+	err := migration.SetDBVersion(dbConn, dbDriver, dbSchema, 31, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	const insertToggleQuery = `
+		INSERT INTO cluster_rule_toggle
+		(cluster_id, rule_id, error_key, org_id, disabled, updated_at)
+		VALUES
+		($1, $2, $3, $4, $5, $6)
+	`
+
+	malformedClusterID := testdata.GetRandomClusterID()
+	validClusterID := testdata.GetRandomClusterID()
+
+	_, err = dbConn.Exec(
+		insertToggleQuery,
+		malformedClusterID,
+		testdata.Rule1ID,
+		"",
+		testdata.OrgID,
+		storage.RuleToggleDisable,
+		time.Now(),
+	)
+	helpers.FailOnError(t, err)
+
+	_, err = dbConn.Exec(
+		insertToggleQuery,
+		validClusterID,
+		testdata.Rule2ID,
+		testdata.ErrorKey2,
+		testdata.OrgID,
+		storage.RuleToggleDisable,
+		time.Now(),
+	)
+	helpers.FailOnError(t, err)
+
+	err = migration.SetDBVersion(dbConn, dbDriver, dbSchema, 32, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	var clusterID types.ClusterName
+	var ruleID types.RuleID
+	var errorKey string
+	err = dbConn.QueryRow(`
+		SELECT cluster_id, rule_id, error_key
+		FROM cluster_rule_toggle
+	`).Scan(&clusterID, &ruleID, &errorKey)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, validClusterID, clusterID)
+	assert.Equal(t, testdata.Rule2ID, ruleID)
+	assert.Equal(t, testdata.ErrorKey2, errorKey)
+
+	err = migration.SetDBVersion(dbConn, dbDriver, dbSchema, 31, ocpmigrations.UsableOCPMigrations)
+	helpers.FailOnError(t, err)
+
+	var remainingCount int
+	err = dbConn.QueryRow(`SELECT count(*) FROM cluster_rule_toggle`).Scan(&remainingCount)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 1, remainingCount)
+
+	err = dbConn.QueryRow(`
+		SELECT count(*)
+		FROM cluster_rule_toggle
+		WHERE cluster_id = $1 AND error_key = ''
+	`, malformedClusterID).Scan(&remainingCount)
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 0, remainingCount)
+}
+
+func TestMigration32_StepUpDeleteError(t *testing.T) {
+	const errStr = "delete error"
+	mig32 := ocpmigrations.Mig0032CleanupClusterRuleToggleEmptyErrorKey
+
+	tx, db, expects := GetTxForMigration(t)
+	defer ira_helpers.MustCloseMockDBWithExpects(t, db, expects)
+
+	expects.ExpectExec("DELETE FROM cluster_rule_toggle").
+		WillReturnError(errors.New(errStr))
+
+	err := mig32.StepUp(tx, types.DBDriverGeneral)
+	assert.EqualError(t, err, errStr)
+}
+
+func TestMigration32_StepUpRowsAffectedError(t *testing.T) {
+	const errStr = "rows affected error"
+	mig32 := ocpmigrations.Mig0032CleanupClusterRuleToggleEmptyErrorKey
+
+	tx, db, expects := GetTxForMigration(t)
+	defer ira_helpers.MustCloseMockDBWithExpects(t, db, expects)
+
+	expects.ExpectExec("DELETE FROM cluster_rule_toggle").
+		WillReturnResult(sqlmock.NewErrorResult(errors.New(errStr)))
+
+	err := mig32.StepUp(tx, types.DBDriverGeneral)
+	assert.EqualError(t, err, errStr)
+}
+
+func TestMigration32_StepUpSuccess(t *testing.T) {
+	mig32 := ocpmigrations.Mig0032CleanupClusterRuleToggleEmptyErrorKey
+
+	tx, db, expects := GetTxForMigration(t)
+	defer ira_helpers.MustCloseMockDBWithExpects(t, db, expects)
+
+	expects.ExpectExec("DELETE FROM cluster_rule_toggle").
+		WillReturnResult(sqlmock.NewResult(0, 3))
+
+	err := mig32.StepUp(tx, types.DBDriverGeneral)
+	helpers.FailOnError(t, err)
+}
+
+func TestMigration32_StepDownNoOp(t *testing.T) {
+	mig32 := ocpmigrations.Mig0032CleanupClusterRuleToggleEmptyErrorKey
+
+	tx, db, expects := GetTxForMigration(t)
+	defer ira_helpers.MustCloseMockDBWithExpects(t, db, expects)
+
+	err := mig32.StepDown(tx, types.DBDriverPostgres)
+	helpers.FailOnError(t, err)
+
+	err = mig32.StepDown(tx, types.DBDriverGeneral)
+	helpers.FailOnError(t, err)
 }

--- a/migration/ocpmigrations/export_test.go
+++ b/migration/ocpmigrations/export_test.go
@@ -10,5 +10,6 @@ package ocpmigrations
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd
 // to see why this trick is needed.
 var (
-	Mig0004ModifyClusterRuleUserFeedback = mig0004ModifyClusterRuleUserFeedback
+	Mig0004ModifyClusterRuleUserFeedback         = mig0004ModifyClusterRuleUserFeedback
+	Mig0032CleanupClusterRuleToggleEmptyErrorKey = mig0032CleanupClusterRuleToggleEmptyErrorKey
 )

--- a/migration/ocpmigrations/mig_0032_cleanup_cluster_rule_toggle_empty_error_key.go
+++ b/migration/ocpmigrations/mig_0032_cleanup_cluster_rule_toggle_empty_error_key.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This migration removes invalid rows from cluster_rule_toggle where error_key
+// is empty. Such rows were created before error_key was added to the primary key
+// and populated for existing rules.
+
+package ocpmigrations
+
+import (
+	"database/sql"
+
+	"github.com/RedHatInsights/insights-results-aggregator/migration"
+	"github.com/RedHatInsights/insights-results-aggregator/types"
+	"github.com/rs/zerolog/log"
+)
+
+var mig0032CleanupClusterRuleToggleEmptyErrorKey = migration.Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		res, err := tx.Exec(`
+			DELETE FROM cluster_rule_toggle WHERE error_key = ''
+		`)
+		if err != nil {
+			return err
+		}
+
+		deletedRows, err := res.RowsAffected()
+		if err != nil {
+			log.Error().Err(err).Msg("unable to retrieve number of deleted rows")
+			return err
+		}
+
+		log.Info().Msgf("deleted %d rows from table cluster_rule_toggle with empty error_key", deletedRows)
+
+		return nil
+	},
+	StepDown: func(tx *sql.Tx, driver types.DBDriver) error {
+		log.Info().Msg("Mig0032 is a one-way ticket. Nothing to be done for StepDown.")
+		return nil
+	},
+}

--- a/migration/ocpmigrations/ocp_migrations.go
+++ b/migration/ocpmigrations/ocp_migrations.go
@@ -48,4 +48,5 @@ var UsableOCPMigrations = []migration.Migration{
 	mig0029DropClusterRuleToggleUserIDColumn,
 	mig0030DropRuleDisableUserIDColumn,
 	mig0031AlterConstraintDropUserAdvisorRatings,
+	mig0032CleanupClusterRuleToggleEmptyErrorKey,
 }

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -14,6 +14,8 @@
 
 package server
 
+import "github.com/RedHatInsights/insights-results-aggregator/types"
+
 // Export for testing
 //
 // This source file contains name aliases of all package-private functions
@@ -36,3 +38,12 @@ var (
 	ConstructClusterNames     = constructClusterNames
 	FillInGeneratedReports    = fillInGeneratedReports
 )
+
+// GetRuleToggleMapForCluster exports getRuleToggleMapForCluster for unit tests.
+func GetRuleToggleMapForCluster(
+	s *HTTPServer,
+	clusterName types.ClusterName,
+	orgID types.OrgID,
+) (map[types.RuleID]bool, error) {
+	return s.getRuleToggleMapForCluster(clusterName, orgID)
+}

--- a/server/rules.go
+++ b/server/rules.go
@@ -227,7 +227,7 @@ func (server HTTPServer) getRuleToggleMapForCluster(
 		compositeRuleID, err := generators.GenerateCompositeRuleID(types.RuleFQDN(rule.RuleID), rule.ErrorKey)
 		if err != nil {
 			ruleSpecificErr := fmt.Errorf("error generating composite rule ID for rule %s: %s", rule.RuleID, err.Error())
-			log.Error().Err(ruleSpecificErr).
+			log.Warn().Err(ruleSpecificErr).
 				Str("rule_id", string(rule.RuleID)).
 				Str("cluster_id", string(rule.ClusterID)).
 				Str("error_key", string(rule.ErrorKey)).

--- a/server/rules_test.go
+++ b/server/rules_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RedHatInsights/insights-results-aggregator/server"
+	"github.com/RedHatInsights/insights-results-aggregator/storage"
+	"github.com/RedHatInsights/insights-results-aggregator/tests/helpers"
+)
+
+func TestGetRuleToggleMapForCluster_SkipsMalformedDisabledRule(t *testing.T) {
+	mockStorage, expects := helpers.MustGetMockStorageWithExpects(t)
+	defer helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
+
+	now := time.Now()
+	expects.ExpectQuery("SELECT").
+		WithArgs(testdata.OrgID, storage.RuleToggleDisable).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"cluster_id", "rule_id", "error_key", "disabled_at", "updated_at", "disabled",
+		}).
+			AddRow(testdata.ClusterName, testdata.Rule1ID, "", now, now, storage.RuleToggleDisable).
+			AddRow(testdata.ClusterName, testdata.Rule2ID, testdata.ErrorKey2, now, now, storage.RuleToggleDisable).
+			AddRow(testdata.GetRandomClusterID(), testdata.Rule1ID, testdata.ErrorKey1, now, now, storage.RuleToggleDisable))
+
+	testServer := server.New(helpers.DefaultServerConfig, mockStorage, nil)
+
+	toggleMap, err := server.GetRuleToggleMapForCluster(testServer, testdata.ClusterName, testdata.OrgID)
+	helpers.FailOnError(t, err)
+
+	assert.Len(t, toggleMap, 1)
+	assert.True(t, toggleMap[testdata.Rule2CompositeID])
+}
+
+func TestGetRuleToggleMapForCluster_ListOfDisabledRulesDBError(t *testing.T) {
+	const errStr = "database error"
+
+	mockStorage, expects := helpers.MustGetMockStorageWithExpects(t)
+	defer helpers.MustCloseMockStorageWithExpects(t, mockStorage, expects)
+
+	expects.ExpectQuery("SELECT").
+		WithArgs(testdata.OrgID, storage.RuleToggleDisable).
+		WillReturnError(errors.New(errStr))
+
+	testServer := server.New(helpers.DefaultServerConfig, mockStorage, nil)
+
+	toggleMap, err := server.GetRuleToggleMapForCluster(testServer, testdata.ClusterName, testdata.OrgID)
+	assert.EqualError(t, err, errStr)
+	assert.Empty(t, toggleMap)
+}


### PR DESCRIPTION
Set lower message level for non-error when a disabled rule is not well formed
Cleanup of cluster_rule_togger database, removing entries without error_key.

# Description

Some old rules like the tutorial one, when disabled by an user, they didn't contain an error key. Now, this is causing that every time a report is generated, if a rule without error key is disabled in the database, a log error message is printed and captured by Glitchtip.

This fix attack the problem from 3 fronts:

1. Make the log level warning instead of error, as it is not causing a malfunctioning of the endpoint.
2. Create a new migration in order to perform a clean up of the table, removing all the entries without error key from the database.

Fixes #[CCXDEV-15434](https://redhat.atlassian.net/browse/CCXDEV-15434)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Created unit tests

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change


[CCXDEV-15434]: https://redhat.atlassian.net/browse/CCXDEV-15434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ